### PR TITLE
Add Green Man Gaming

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2702,6 +2702,16 @@
     },
 
     {
+        "name": "Green Man Gaming",
+        "url": "https://corporate.greenmangaming.com/privacy-policy",
+        "difficulty": "hard",
+        "email": "dataprotection@greenmangaming.com",
+        "domains": [
+            "greenmangaming.com"
+        ]
+    },
+
+    {
         "name": "Grindr",
         "url": "https://help.grindr.com/hc/en-us/requests/new?ticket_form_id=24054",
         "difficulty": "hard",


### PR DESCRIPTION
Wasn't sure whether the URL should be this page instead:

https://greenmangaming.zendesk.com/hc/en-us/articles/360006712732-Account-Deletion-Deactivation-FAQ

It dosn't actually explain *how* to delete your account, whereas the privacy policy does have that information quite clearly under "Data Handling and Your Choices".