### PR TITLE
Auto-focus search field on page load

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -148,4 +148,7 @@ $(function(){
         e.preventDefault();
         $("body,html").scrollTo(".about");
     });
+
+    // Auto-focus search field on load
+    $("#search").focus();
 });


### PR DESCRIPTION
For whatever reason, adding the `autofocus` attribute to the search field's HTML tag didn't do the trick. Thankfully, it's a one-line Javascript fix to get that to work properly.

Closes jdm-contrib/jdm#276