### PR TITLE
Add more specific link for EasyJet account deletion request

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1983,9 +1983,9 @@
 
     {
         "name": "easyJet",
-        "url": "http://www.easyjet.com/en/help/contact",
+        "url": "https://www.easyjet.com/en/policy/privacy-promise/request-data-form",
         "difficulty": "hard",
-        "notes": "You have to mail the customer support and request for account deletion.",
+        "notes": "You have to fill out the Data protection request form on their website, providing your identification.",
         "domains": [
             "easyjet.com"
         ]


### PR DESCRIPTION
This PR updates the EasyJet contact link to be a more specific link for requesting account deletion. 
https://www.easyjet.com/en/policy/privacy-promise/request-data-form

This saves people an extra hop of finding that link, which I received after starting a live chat.