### PR TITLE
Account deletion at Stratum.hk and 000Webhost.com

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1294,11 +1294,28 @@
 
     {
         "name": "Coinbase",
-        "url": "https://www.coinbase.com/settings/security_settings",
-        "difficulty": "easy",
-        "notes": "Sign in then visit <a href=\"https://www.coinbase.com/settings/security_settings\">https://www.coinbase.com/settings/security_settings</a> and scroll to the bottom to find a button to close you account.",
+        "url": "http://coinbase.com/close_account",
+        "difficulty": "medium",
+        "notes": "Sign in then visit <a href=\"http://coinbase.com/close_account\">http://coinbase.com/close_account</a> and scroll to the bottom to find a button to close you account. In order to be deleted, your account can not have pending transactions.",
+        "notes_pt_br": "Faça login e acesse <a href=\"http://coinbase.com/close_account\">http://coinbase.com/close_account</a>. Role até o final da página para encontrar o botão para fechar sua conta. Para que possa ser excluída, sua conta não deve haver nenhum tipo de transação pendente.",
         "domains": [
             "coinbase.com"
+        ]
+    },
+
+    {
+        "name": "CoinBR/Stratum",
+        "url": "http://stratum.hk/support",
+        "difficulty": "hard",
+        "notes": "Contact the customer support via email and request the deletion of your account. In order for them to identify your account, make the request through the same email address that you have used to create your CoinBR/Stratum account.",
+        "notes_pt_br": "Entre em contato com o suporte via e-mail e solicite que sua conta seja excluída. Para que eles possam identificar sua conta, faça a requisição a partir da mesma conta de e-mail que você usou para criar sua conta CoinBR/Stratum.",
+        "email": "support@stratum.hk",
+        "email_subject": "[ Permanently Account Deletion Request ]",
+        "email_body": "I have no further interest in using the services provided by Stratum, so I would like my account to be permanently deleted.",
+        "domains": [
+            "stratum.hk",
+            "coinbr.net",
+            "coinbr.io"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3160,6 +3160,17 @@
     },
 
     {
+        "name": "Happy Scribe",
+        "url": "http://happyscribe.co/users/edit",
+        "difficulty": "easy",
+        "notes": "Go to \"Settings > Delete Account > Delete my account\".",
+        "notes_pt_br": "Vá para \"Settings > Delete Account > Delete my account\".",
+        "domains": [
+            "happyscribe.co"
+        ]
+    },
+
+    {
         "name": "HelloFax",
         "url": "https://www.hellofax.com/home/myAccount",
         "difficulty": "easy",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -690,12 +690,14 @@
 
     {
         "name": "Bitly",
-        "url": "https://bitly.com/a/deactivate_account",
+        "url": "http://app.bitly.com/bitlinks/?actions=deactivate",
         "difficulty": "easy",
-        "notes": "Select why you are deleting your account. Your account will be deleted but all your shortlinks will remain.",
+        "notes": "Go to \" Profile > Delete Account\" and select why you are deleting your account. Your account will be deleted but all your shortlinks will remain.",
         "notes_pl": "Wybierz, dlaczego chcesz usunąć konto. Twoje konto zostanie usunięte, ale wszystkie twoje skrócone linki zostaną na serwerze.",
+        "notes_pt_br": "Vá para \" Profile > Delete Account\" e selecione uma razão pela qual você está excluindo sua conta. Sua conta será excluída, mais os seus links encurtados permanecerão ativos.",
         "domains": [
-            "bitly.com"
+            "bitly.com",
+            "bit.ly"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1,5 +1,17 @@
 [
     {
+        "name": "000Webhost",
+        "url": "http://000webhost.com/members/profile",
+        "difficulty": "easy",
+        "notes": "Go to \"Profile > Delete My Account\" and select why you are deleting your account.",
+        "notes_pt_br": "Vá para \"Profile > Delete My Account\" e selecione um motivo pelo qual você está excluindo sua conta.",
+        "domains": [
+            "000webhost.com",
+            "000webhostapp.com"
+        ]
+    },
+
+    {
         "name": "1Password",
         "url": "https://my.1password.com/profile",
         "difficulty": "easy",


### PR DESCRIPTION
_Changes_

* Updated: `url`, `difficulty`, `notes` and `notes_pt_br` from Coinbase account deletion info.
* Updated: `url`, `notes`, `notes_pt_br` and `domains` from Bitly account deletion info.
* Added: 000Webhost account deletion info.
* Added: CoinBR/Stratum account deletion info.
* Added: Happy Scribe account deletion info.

_Additional information_

"**CoinBR**" is now called as "**Stratum**". `coinbr.io`, `coinbr.net` and `stratum.hk` are domains owned by the same company. They also are related to the same type of account.

I have modified the level of difficulty of the **Coinbase** account deletion from `easy` to `medium` because Coinbase only allows an account to be permanently deleted if there is no pending transaction or some limitation applied to them, In this case, it may be necessary for the user to complete these additional steps before he can permanently delete the account.