### PR TITLE
Upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.3.3
+- 2.6.4
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "ffi", ">= 1.9.24"
-gem "jekyll", ">= 3.7.4"
+gem "ffi", ">= 1.11.1"
+gem "jekyll", "= 3.8.6"
 gem "html-proofer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.5)
+    jekyll (3.8.6)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -47,10 +47,10 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-watch (2.1.2)
+    jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (1.17.0)
-    liquid (4.0.1)
+    liquid (4.0.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -68,12 +68,12 @@ GEM
     public_suffix (3.1.1)
     rainbow (3.0.0)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
-    rouge (3.3.0)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rouge (3.10.0)
     ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
-    sass (3.6.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -91,9 +91,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  ffi (>= 1.9.24)
+  ffi (>= 1.11.1)
   html-proofer
-  jekyll (>= 3.7.4)
+  jekyll (= 3.8.6)
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ validated using a mixture of Ruby and Node.js packages and scripts.
 
 **Dependencies:**
 
-- [Ruby](https://www.ruby-lang.org) (>=2.3.3)
+- [Ruby](https://www.ruby-lang.org) (>=2.6.4)
 - [Node.js](https://nodejs.org)
 
 **Installation**


### PR DESCRIPTION
Just upgrading dependencies to newer versions.

Not upgrading to Jekyll 4.0 because it fails. Issue already reported here:
https://github.com/jekyll/jekyll-sass-converter/issues/93