### PR TITLE
Add 20 Sites, Fix Overleaf & Feedly

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5071,6 +5071,17 @@
             "osu.ppy.sh"
         ]
     },
+    
+    {
+        "name": "Outdooractive",
+        "url": "https://support.outdooractive.com/hc/en-us/articles/201186213-How-can-I-delete-my-community-account-",
+        "difficulty": "hard",
+        "notes": "Contact Support via the online form and request your account to be deleted.",
+        "notes_de": "Kontaktiere den Support über das Online-Formular und fordere eine Löschung des Accounts an.",
+        "domains": [
+            "outdooractive.com"
+        ]
+    },
 
     {
         "name": "Outlook",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3106,6 +3106,19 @@
             "grubhub.com"
         ]
     },
+    
+    {
+        "name": "Guild Wars",
+        "url": "https://help.guildwars2.com/hc/de/requests/new?ticket_form_id=38933",
+        "difficulty": "hard",
+        "notes": "You need create a support ticket and request for them to delete your account. Before your account gets deleted you need to answer why you want the account to be deleted.",
+        "notes_de": "Über ein Support-Ticket kann eine Löschung des Accounts beantragt werden. Bevor der Account gelöscht wird, muss zuerst angegeben werden, warum der Account gelöscht werden soll.",
+        "domains": [
+            "arena.net",
+            "guildwars2.com",
+            "help.guildwars2.com"
+        ]
+    },
 
     {
         "name": "Gumroad",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5144,6 +5144,18 @@
             "parkmobile.zendesk.com"
         ]
     },
+    
+    {
+        "name": "Passdock",
+        "url": "https://api.passdock.com/users/edit",
+        "difficulty": "easy",
+        "notes": "Select 'Delete account' at the bottom of your account info page.",
+        "notes_de": "Klicke 'Account löschen' unten auf der Account-Info-Seite.",
+        "domains": [
+            "passdock.com",
+            "api.passdock.com"
+        ]
+    },
 
     {
         "name": "Pastebin",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5398,6 +5398,15 @@
             "pixlr.com"
         ]
     },
+    
+    {
+        "name": "Pixum",
+        "url": "https://int.pixum.com/service/delete-account",
+        "difficulty": "hard",
+        "notes": "Contact support via email and request your account to be deleted.",
+        "notes_de": "Schreibe dem Support per E-Mail und bitte um eine Löschung des Accounts",
+        "email": "service@pixum.com"
+    },
 
     {
         "name": "Player FM",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3117,7 +3117,7 @@
         "name": "Guild Wars",
         "url": "https://help.guildwars2.com/hc/de/requests/new?ticket_form_id=38933",
         "difficulty": "hard",
-        "notes": "You need create a support ticket and request for them to delete your account. Before your account gets deleted you need to answer why you want the account to be deleted.",
+        "notes": "You need to create a support ticket and request for them to delete your account. Before your account gets deleted you need to answer why you want the account to be deleted.",
         "notes_de": "Über ein Support-Ticket kann eine Löschung des Accounts beantragt werden. Bevor der Account gelöscht wird, muss zuerst angegeben werden, warum der Account gelöscht werden soll.",
         "domains": [
             "arena.net",
@@ -4186,6 +4186,8 @@
     {
         "name": "MacTrade",
         "url": "https://www.mactrade.de/goodahead_customer/account/delete/",
+        "notes": "In your user account go to 'Delete Account' and confirm the deletion via the 'Delete account now' button.",
+        "notes_de": "Wähle 'Konto löschen' in deinem Benutzerkonto und bestätige die Löschung mit dem Button 'Benutzerkonto jetzt löschen'.",
         "difficulty": "easy",
         "domains": [
             "mactrade.de"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4154,6 +4154,16 @@
             "lumosity.com"
         ]
     },
+    
+    {
+        "name": "MacTrade",
+        "url": "https://www.mactrade.de/goodahead_customer/account/delete/",
+        "difficulty": "easy",
+        "domains": [
+            "mactrade.de"
+        ]
+    },
+    
 
     {
         "name": "Magoosh",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -112,7 +112,7 @@
             "academia.edu"
         ]
     },
-    
+
     {
         "name": "Acasa",
         "url": "https://app.helloacasa.com/register/edit",
@@ -888,7 +888,7 @@
             "boxcryptor.com"
         ]
     },
-    
+
     {
         "name": "Bring!",
         "url": "https://getbring.com/#!/contact",
@@ -1892,7 +1892,7 @@
             "docusign.com"
         ]
     },
-    
+
     {
         "name": "Doodle",
         "url": "https://doodle.com/account",
@@ -3112,7 +3112,7 @@
             "grubhub.com"
         ]
     },
-    
+
     {
         "name": "Guild Wars",
         "url": "https://help.guildwars2.com/hc/de/requests/new?ticket_form_id=38933",
@@ -3528,7 +3528,7 @@
             "innogames.com"
         ]
     },
-    
+
     {
         "name": "Inoreader",
         "url": "https://www.inoreader.com",
@@ -3633,7 +3633,7 @@
         "notes": "Closing your account will delete your profile and all of your publications. There is no going back, so don't say we didn't warn you.",
         "notes_fa": "با بستن حساب کاربریتان تمامی مجلات و اطلاعات شما حذف می‌شود. این اطلاعات غیز قابل بازگشت خواهند بود."
     },
-    
+
     {
         "name": "iStudiez",
         "url": "https://support.istudentpro.com/support/solutions/articles/3000068641-delete-cloud-sync-account",
@@ -3870,7 +3870,7 @@
             "koding.com"
         ]
     },
-    
+
     {
         "name": "Koingo Software",
         "url": "https://www.koingosw.com/account/delete.php",
@@ -4182,7 +4182,7 @@
             "lumosity.com"
         ]
     },
-    
+
     {
         "name": "MacTrade",
         "url": "https://www.mactrade.de/goodahead_customer/account/delete/",
@@ -4191,7 +4191,7 @@
             "mactrade.de"
         ]
     },
-    
+
     {
         "name": "MacUpdate",
         "url": "https://www.macupdate.com/member/account-preferences",
@@ -4262,7 +4262,7 @@
             "mapbox.com"
         ]
     },
-    
+
     {
         "name": "Mapstr",
         "url": "https://mapstr.com/faq.html",
@@ -4283,7 +4283,7 @@
             "marvelapp.com"
         ]
     },
-    
+
     {
         "name": "Massdrop",
         "url": "https://helpdesk.massdrop.com/hc/en-us/articles/360019265073-How-do-I-delete-my-account-",
@@ -4676,7 +4676,7 @@
             "myfitnesspal.com"
         ]
     },
-    
+
     {
         "name": "MyFRITZ!",
         "url": "https://sso.myfritz.net/account/#/delete",
@@ -4895,7 +4895,7 @@
             "nike.com"
         ]
     },
-    
+
     {
         "name": "Ninox",
         "url": "https://ninoxdb.de/de/support/contactus",
@@ -5077,7 +5077,7 @@
             "osu.ppy.sh"
         ]
     },
-    
+
     {
         "name": "Outdooractive",
         "url": "https://support.outdooractive.com/hc/en-us/articles/201186213-How-can-I-delete-my-community-account-",
@@ -5183,7 +5183,7 @@
             "parkmobile.zendesk.com"
         ]
     },
-    
+
     {
         "name": "Passdock",
         "url": "https://api.passdock.com/users/edit",
@@ -5323,7 +5323,7 @@
         "notes": "It is necessary to contact the support, for example through 'Mein Konto' -> 'Meinung abgeben'.",
         "notes_de": "Es ist nötig den Support zu kontaktieren oder über das Webinterface seine Meinung abzugeben unter 'Mein Konto' -> 'Meinung abgeben'"
     },
-    
+
     {
         "name": "Philips Hue",
         "url": "https://account.meethue.com/account",
@@ -5416,7 +5416,7 @@
             "pivotaltracker.com"
         ]
     },
-    
+
     {
         "name": "Pixabay",
         "url": "https://pixabay.com/de/accounts/settings/",
@@ -5437,7 +5437,7 @@
             "pixlr.com"
         ]
     },
-    
+
     {
         "name": "Pixum",
         "url": "https://int.pixum.com/service/delete-account",
@@ -6651,7 +6651,7 @@
             "tagged.com"
         ]
     },
-    
+
     {
         "name": "Taiga",
         "url": "https://tree.taiga.io/user-settings/user-profile",
@@ -6739,7 +6739,7 @@
             "telegram.org"
         ]
     },
-    
+
     {
         "name": "Things",
         "url": "https://support.culturedcode.com/customer/en/portal/articles/2803591-deleting-your-account-data",
@@ -7088,7 +7088,7 @@
             "unfuddle.io"
         ]
     },
-    
+
     {
         "name": "United Domains",
         "url": "https://www.united-domains.de/support/kontakt-formular/close//",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -112,6 +112,18 @@
             "academia.edu"
         ]
     },
+    
+    {
+        "name": "Acasa",
+        "url": "https://app.helloacasa.com/register/edit",
+        "difficulty": "easy",
+        "notes": "In your account settings choose 'Remove my account' at the bottom.",
+        "notes_de": "Wähle 'Remove my account' in den Account-Einstellungen.",
+        "domains": [
+            "splittable.co",
+            "helloacasa.com"
+        ]
+    },
 
     {
         "name": "Acorns",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4234,6 +4234,17 @@
             "mapbox.com"
         ]
     },
+    
+    {
+        "name": "Mapstr",
+        "url": "https://mapstr.com/faq.html",
+        "difficulty": "easy",
+        "notes": "Log in to your account in the app, then in the account settings choose 'Delete my account'.",
+        "notes_de": "Melde dich in der App mit deinem Account an. Wähle dann in den Konto-Einstellungen 'Mein Konto löschen'.",
+        "domains": [
+            "mapstr.com"
+        ]
+    },
 
     {
         "name": "Marvel",
@@ -4242,6 +4253,17 @@
         "notes": "Log into your account -> My Account -> click on Delete Account at the bottom of page.",
         "domains": [
             "marvelapp.com"
+        ]
+    },
+    
+    {
+        "name": "Massdrop",
+        "url": "https://helpdesk.massdrop.com/hc/en-us/articles/360019265073-How-do-I-delete-my-account-",
+        "difficulty": "hard",
+        "notes": "Contact support via the online form and ask for your account to be deleted.",
+        "notes_de": "Kontaktiere den Support über das Online-Formular und fordere eine Löschung des Accounts.",
+        "domains": [
+            "drop.com"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4164,6 +4164,16 @@
         ]
     },
     
+    {
+        "name": "MacUpdate",
+        "url": "https://www.macupdate.com/member/account-preferences",
+        "difficulty": "easy",
+        "notes": "In your account preferences select 'Delete all my personal data' in the bottom left. 14 days after your request all your data will be deleted. During the 14 days the delete request may be cancelled.",
+        "notes_de": "In den Account-Einstellungen kann der Account links unten mit 'Delete all my personal data' gelöscht werden. Die Daten werden erst nach einer 14 tägigen Frist gelöscht. Während der 14 Tage kann der Löschvorgang abgebrochen werden.",
+        "domains": [
+            "macupdate.com"
+        ]
+    },
 
     {
         "name": "Magoosh",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7029,6 +7029,18 @@
             "unfuddle.io"
         ]
     },
+    
+    {
+        "name": "United Domains",
+        "url": "https://www.united-domains.de/support/kontakt-formular/close//",
+        "difficulty": "hard",
+        "notes": "Contact Support and request to delete your account.",
+        "notes_de": "Kontaktiere den Support und fordere eine Löschung des Accounts an.",
+        "email": "support@united-domains.de",
+        "domains": [
+            "united-domains.de"
+        ]
+    },
 
     {
         "name": "Unity ID",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -6603,6 +6603,18 @@
             "tagged.com"
         ]
     },
+    
+    {
+        "name": "Taiga",
+        "url": "https://tree.taiga.io/user-settings/user-profile",
+        "difficulty": "easy",
+        "notes": "Log in to your user account, go to 'User Settings' and select 'Delete Taiga account' below the save button. Confirm and done.",
+        "notes_de": "Nach dem Einloggen im Menü zu 'User Settings' gehen und dort 'Delete Taiga account' unter dem 'Save' Button auswählen. Bestätigen, fertig.",
+        "domains": [
+            "taiga.io",
+            "tree.taiga.io"
+        ]
+    },
 
     {
         "name": "Tango",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4867,6 +4867,18 @@
             "nike.com"
         ]
     },
+    
+    {
+        "name": "Ninox",
+        "url": "https://ninoxdb.de/de/support/contactus",
+        "difficulty": "hard",
+        "notes": "Contact Support via the online contact form and request your account to be deleted. Alternatively you can use the support E-Mail address.",
+        "notes_de": "Über das Online-Kontaktformular kann der Support gebeten werden, den Account zu löschen. Alternativ lässt sich auch per E-Mail Kontakt aufnehmen.",
+        "email": "support@ninoxdb.de",
+        "domains": [
+            "ninoxdb.de"
+        ]
+    },
 
     {
         "name": "njal.la",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4648,6 +4648,18 @@
             "myfitnesspal.com"
         ]
     },
+    
+    {
+        "name": "MyFRITZ!",
+        "url": "https://sso.myfritz.net/account/#/delete",
+        "difficulty": "easy",
+        "notes": "Login and select 'Delete Account' in the sidebar in your account settings",
+        "notes_de": "Einloggen und in den Kontoeinstellungen 'Konto löschen' aus der Seitenleiste wählen.",
+        "domains": [
+            "myfritz.net",
+            "sso.myfritz.net"
+        ]
+    },
 
     {
         "name": "myJdownloader",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -888,6 +888,18 @@
             "boxcryptor.com"
         ]
     },
+    
+    {
+        "name": "Bring!",
+        "url": "https://getbring.com/#!/contact",
+        "difficulty": "hard",
+        "notes": "Contact support and ask for your account to be deleted.",
+        "notes_de": "Kontaktiere den Support und fordere eine Löschung des Accounts an.",
+        "email": "feedback@getbring.com",
+        "domains": [
+            "getbring.com"
+        ]
+    },
 
     {
         "name": "British Airways",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5070,9 +5070,9 @@
 
     {
         "name": "Overleaf",
-        "url": "https://www.overleaf.com/help/299-how-do-i-delete-my-overleaf-account",
-        "difficulty": "hard",
-        "notes": "You must contact support directly and ask them to delete your account.",
+        "url": "https://www.overleaf.com/user/settings",
+        "difficulty": "easy",
+        "notes": "Select 'Delete your account' at the bottom of the account settings page.",
         "email": "privacy@overleaf.com",
         "domains": [
             "overleaf.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3533,6 +3533,17 @@
             "innogames.com"
         ]
     },
+    
+    {
+        "name": "Inoreader",
+        "url": "https://www.inoreader.com",
+        "difficulty": "easy",
+        "notes": "Select 'Reset or cancel' under preferences and click on 'Cancel account'.",
+        "notes_de": "Gehe zu 'Zurücksetzen oder Abbrechen' in den Einstellungen und wähle 'Konto auflösen'.",
+        "domains": [
+            "inoreader.com"
+        ]
+    },
 
     {
         "name": "Instacast Cloud",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3616,6 +3616,18 @@
         "notes": "Closing your account will delete your profile and all of your publications. There is no going back, so don't say we didn't warn you.",
         "notes_fa": "با بستن حساب کاربریتان تمامی مجلات و اطلاعات شما حذف می‌شود. این اطلاعات غیز قابل بازگشت خواهند بود."
     },
+    
+    {
+        "name": "iStudiez",
+        "url": "https://support.istudentpro.com/support/solutions/articles/3000068641-delete-cloud-sync-account",
+        "difficulty": "hard",
+        "notes": "Contact support and ask for your account to be removed.",
+        "notes_de": "Kontaktiere den Support und fordere eine Löschung deines Accounts.",
+        "email": "support@istudentpro.com",
+        "domains": [
+            "istudentpro.com"
+        ]
+    },
 
     {
         "name": "iTunes / Apple ID",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3864,6 +3864,17 @@
             "koding.com"
         ]
     },
+    
+    {
+        "name": "Koingo Software",
+        "url": "https://www.koingosw.com/account/delete.php",
+        "difficulty": "medium",
+        "notes": "Enter your E-Mail in the account deletion form and confirm the deletion in the E-Mail sent to you.",
+        "notes_de": "Fülle das Online-Formular zum Löschen des Accounts mit deiner E-Mail aus und bestätige die Löschung in der gesendeten E-Mail.",
+        "domains": [
+            "koingosw.com"
+        ]
+    },
 
     {
         "name": "Kongregate",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5377,6 +5377,17 @@
             "pivotaltracker.com"
         ]
     },
+    
+    {
+        "name": "Pixabay",
+        "url": "https://pixabay.com/de/accounts/settings/",
+        "difficulty": "easy",
+        "notes": "In your account setting choose 'Delete account'.",
+        "notes_de": "Wähle 'Konto Löschen' in den Kontoeinstellungen.",
+        "domains": [
+            "pixabay.com"
+        ]
+    },
 
     {
         "name": "Pixlr",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5284,6 +5284,18 @@
         "notes": "It is necessary to contact the support, for example through 'Mein Konto' -> 'Meinung abgeben'.",
         "notes_de": "Es ist nötig den Support zu kontaktieren oder über das Webinterface seine Meinung abzugeben unter 'Mein Konto' -> 'Meinung abgeben'"
     },
+    
+    {
+        "name": "Philips Hue",
+        "url": "https://account.meethue.com/account",
+        "difficulty": "easy",
+        "notes": "Click 'Delete Account' on your account page.",
+        "notes_de": "Klicke auf 'Konto löschen' in den Kontoeinstellungen.",
+        "domains": [
+            "meethue.com",
+            "account.meethue.com"
+        ]
+    },
 
     {
         "name": "PhishTank",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1892,6 +1892,17 @@
             "docusign.com"
         ]
     },
+    
+    {
+        "name": "Doodle",
+        "url": "https://doodle.com/account",
+        "difficulty": "easy",
+        "notes": "In your Doodle account select 'Delete Doodle account' at the bottom of the page.",
+        "notes_de": "Wähle 'Doodle Konto löschen' unten in den Konto-Einstellungen.",
+        "domains": [
+            "doodle.com"
+        ]
+    },
 
     {
         "name": "Douban",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2408,13 +2408,8 @@
         "name": "Feedly",
         "url": "https://feedly.com/#erase",
         "difficulty": "easy",
-        "notes": "Email customer support to request deletion.",
-        "notes_fr": "Contactez le support pour supprimer votre compte.",
-        "notes_it": "Contatta il servizio clienti via email per richiedere la cancellazione.",
-        "notes_de": "Schreibe eine mail an den Kundensupport um die Löschung zu beantragen",
-        "notes_pt_br": "Envie um e-mail para a assistência ao cliente para pedir a remoção.",
-        "notes_cat": "Enviï un e-mail a l'assistència al client per demanar l'eliminació del compte.",
-        "notes_es": "Envía un e-mail a la asistencia al cliente para pedir la eliminación de tu cuenta.",
+        "notes": "Log in and click the 'Delete Account' button.",
+        "notes_de": "Melde dich an und klicke auf den 'Account löschen' Button.",
         "domains": [
             "feedly.com"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -6691,6 +6691,17 @@
             "telegram.org"
         ]
     },
+    
+    {
+        "name": "Things",
+        "url": "https://support.culturedcode.com/customer/en/portal/articles/2803591-deleting-your-account-data",
+        "difficulty": "easy",
+        "notes": "In the Things app go to Preferences -> Things Cloud and select Edit Account. Then select 'Delete Account'.",
+        "notes_de": "Der Account kann über die Things Einstellungen -> Things Cloud bei 'Account bearbeiten' über 'Account löschen' gelöscht werden.",
+        "domains": [
+            "culturedcode.com"
+        ]
+    },
 
     {
         "name": "Threema",


### PR DESCRIPTION
This pull request adds entries for the following services:

- Acasa (helloacasa.com)
- Bring! (getbring.com)
- Guild Wars / ArenaNet (guildwars2.com)
- iStudiez (istudentpro.com)
- MacTrade (mactrade.de)
- MacUpdate (macupdate.com)
- Mapstr (mapstr.com)
- MyFRITZ! (myfritz.net)
- Ninox (ninoxdb.de)
- Passdock (passdock.com)
- Philips Hue (meethue.com)
- Pixabay (pixabay.com)
- Taiga (taiga.io)
- United Domains (united-domains.de)
- Things (culturedcode.com)
- Pixum (pixum.com)
- Doodle (doodle.com)
- Koingo Software (koingosw.com)
- Outdooractive (outdooractive.com)
- Inoreader (inoreader.com)

It also fixes the entries for the following services:

- Overleaf (Accounts can now be deleted without contacting support)
- Feedly (Accounts can be deleted without contacting support)