### PR TITLE
Account deletion at Mercado Libre and Viva o Linux

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1,0 +1,7736 @@
+[
+    {
+        "name": "000Webhost",
+        "url": "http://000webhost.com/members/profile",
+        "difficulty": "easy",
+        "notes": "Go to \"Profile > Delete My Account\" and select why you are deleting your account.",
+        "notes_pt_br": "Vá para \"Profile > Delete My Account\" e selecione um motivo pelo qual você está excluindo sua conta.",
+        "domains": [
+            "000webhost.com",
+            "000webhostapp.com"
+        ]
+    },
+
+    {
+        "name": "1Password",
+        "url": "https://my.1password.com/profile",
+        "difficulty": "easy",
+        "notes": "Login to your account, go to profile, click 'Permanently Delete Account'. Confirm by entering 'I am sure' and click 'Delete Account'.",
+        "domains": [
+            "1password.com"
+        ]
+    },
+
+    {
+        "name": "280daily",
+        "url": "https://280daily.com/settings/delete",
+        "difficulty": "easy",
+        "notes": "Enter your account password and click on 'DELETE ACCOUNT'.",
+        "domains": [
+            "280daily.com"
+        ]
+    },
+
+    {
+        "name": "4shared",
+        "url": "http://www.4shared.com/web/account/settings#overview",
+        "difficulty": "easy",
+        "domains": [
+            "4shared.com"
+        ]
+    },
+
+    {
+        "name": "500px",
+        "url": "https://500px.com/settings",
+        "difficulty": "hard",
+        "notes": "On Account Settings, under \"Please choose your issue below\", select \"Delete Account\", fill the form and submit.",
+        "domains": [
+            "500px.com"
+        ]
+    },
+
+    {
+        "name": "7digital",
+        "url": "https://help.7digital.com/hc/en-gb/requests/new",
+        "difficulty": "hard",
+        "notes": "Email customer service using their web contact form and ask them to delete your account.",
+        "domains": [
+            "7digital.com"
+        ]
+    },
+
+    {
+        "name": "9GAG",
+        "url": "https://9gag.com/member/delete",
+        "difficulty": "easy",
+        "notes": "Login to your account, go to parameters, click Delete my account. Confirm by clicking I want to delete my account. And again by clicking Delete my 9GAG account.",
+        "notes_fr": "Connectez vous, allez dans les parametres, cilquez sur supprimer mon compte. Confirmez en cliquant sur je supprimer mon compte. Et confirmez encore avec supprimer mon compte.",
+        "notes_it": "Logga il tuo account, vai su parameters, clicca Delete my account. Conferma cliccando I want to delete my account. E ancora cliccando Delete my 9GAG account.",
+        "notes_pt_br": "Faça login em sua conta, vá em parâmetros, clique em Delete my account. Confirme clicando em I want to delete my account. E novamente em Delete my 9GAG account.",
+        "notes_cat": "Entra al teu compte, ves a paràmetres, fés clic a 'Delete my account'. Confirma clicant a 'I want to delete my account'. I novament a 'Delete my 9GAG account'.",
+        "notes_es": "Entra en tu cuenta, ve a parámetros, haz clic en 'Delete my account'. Confirma haciendo clic en 'I want to delete my account'. I de nuevo en 'Delete my 9GAG account'.",
+        "notes_pl": "Zaloguj się na swoje konto, przejdź do ustawień, kliknij Delete my account. Potwierdź klikając I want to delete my account. Następnie wprowadź swoje hasło i kliknij Delete my 9GAG account.",
+        "domains": [
+            "9gag.com"
+        ]
+    },
+
+    {
+        "name": "AbeBooks",
+        "url": "https://www.abebooks.com/customer-support/",
+        "difficulty": "hard",
+        "notes": "Select 'Something else' and then 'Close my account' and fill out the e-mail form.",
+        "domains": [
+            "abebooks.com"
+        ]
+    },
+
+    {
+        "name": "Abload",
+        "url": "http://abload.de/settings.php",
+        "difficulty": "easy",
+        "domains": [
+            "abload.de"
+        ]
+    },
+
+    {
+        "name": "About.me",
+        "url": "https://about.me/account",
+        "difficulty": "easy",
+        "domains": [
+            "about.me"
+        ]
+    },
+
+    {
+        "name": "Academia",
+        "url": "https://www.academia.edu/settings#account-removal",
+        "difficulty": "easy",
+        "domains": [
+            "academia.edu"
+        ]
+    },
+
+    {
+        "name": "Acasa",
+        "url": "https://app.helloacasa.com/register/edit",
+        "difficulty": "easy",
+        "notes": "In your account settings choose 'Remove my account' at the bottom.",
+        "notes_de": "Wähle 'Remove my account' in den Account-Einstellungen.",
+        "domains": [
+            "splittable.co",
+            "helloacasa.com"
+        ]
+    },
+
+    {
+        "name": "Acorns",
+        "url": "https://www.acorns.com/support/contact/",
+        "difficulty": "impossible",
+        "notes": "You have to contact customer support to deactivate your account. Can be reactivated again.",
+        "domains": [
+            "acorns.com"
+        ]
+    },
+
+    {
+        "name": "Adobe",
+        "url": "https://helpx.adobe.com/in/contact.html",
+        "difficulty": "hard",
+        "notes": "You have to call them in order to delete your account. Alternatively, you can send them an email.",
+        "notes_fr": "Vous devez les appeler pour supprimer votre compte. Vous pouvez aussi envoyer un email.",
+        "notes_it": "Per eliminare il tuo account dovrai contattarli via telefono. Alternativamente puoi spedire una mail",
+        "notes_pt_br": "Você deve ligar para eles para deletar sua conta. De maneira alternativa, você pode enviá-los um e-mail.",
+        "notes_cat": "S'ha de posar en cotacte amb ells. Mitjançant telèfon o e-mail.",
+        "notes_es": "Tienes que poner en contacto con ellos. Mediante teléfono o e-mail.",
+        "notes_pl": "Możesz zadzwonić lub wysłać email z prośbą o usunięcie konta.",
+        "notes_ar": "يجب عليك أن تتصل بهم لكي تحذف حسابك او أن ترسل لهم بريد الكتروني",
+        "domains": [
+            "adobe.com"
+        ]
+    },
+
+    {
+        "name": "Airbnb",
+        "url": "https://www.airbnb.com/help/article/240/how-do-i-cancel-my-account",
+        "difficulty": "hard",
+        "notes": "Your account can be deleted <a href=\"https://www.airbnb.com/help/contact_us\">by contacting support</a>, although some pertinent information may be retained as legally required.",
+        "domains": [
+            "airbnb.ae",
+            "airbnb.at",
+            "airbnb.be",
+            "airbnb.ca",
+            "airbnb.cat",
+            "airbnb.ch",
+            "airbnb.cl",
+            "airbnb.co.cr",
+            "airbnb.co.id",
+            "airbnb.co.in",
+            "airbnb.co.kr",
+            "airbnb.co.nz",
+            "airbnb.co.uk",
+            "airbnb.co.ve",
+            "airbnb.com",
+            "airbnb.com.ar",
+            "airbnb.com.au",
+            "airbnb.com.bo",
+            "airbnb.com.br",
+            "airbnb.com.bz",
+            "airbnb.com.co",
+            "airbnb.com.ec",
+            "airbnb.com.gt",
+            "airbnb.com.hk",
+            "airbnb.com.hn",
+            "airbnb.com.mt",
+            "airbnb.com.my",
+            "airbnb.com.ni",
+            "airbnb.com.pa",
+            "airbnb.com.pe",
+            "airbnb.com.py",
+            "airbnb.com.sg",
+            "airbnb.com.sv",
+            "airbnb.com.tr",
+            "airbnb.com.tw",
+            "airbnb.cz",
+            "airbnb.de",
+            "airbnb.dk",
+            "airbnb.es",
+            "airbnb.fi",
+            "airbnb.fr",
+            "airbnb.gr",
+            "airbnb.gy",
+            "airbnb.hu",
+            "airbnb.ie",
+            "airbnb.is",
+            "airbnb.it",
+            "airbnb.jp",
+            "airbnb.mx",
+            "airbnb.nl",
+            "airbnb.no",
+            "airbnb.pl",
+            "airbnb.pt",
+            "airbnb.ru",
+            "airbnb.se"
+        ]
+    },
+
+    {
+        "name": "Alibaba",
+        "url": "http://www.alibaba.com/help/contact-us.html",
+        "difficulty": "hard",
+        "notes": "Despite what it says in their FAQ there is actually no automatic way to delete your account. But they do see to be happy to do it if you ask them - you can contact them via <a href=\"http://www.alibaba.com/help/contact-us.html\">their Contact Us page</a>.",
+        "notes_fr": "Malgré la suggestion du FAQ, il n'y a pas au fait de façon automatique de supprimer votre compte. Cela dit, ils me semblent contents de le faire si vous le demandez - vous pouvez les contactez via <a href=\"http://www.alibaba.com/help/contact-us.html\">http://www.alibaba.com/help/contact-us.html</a>.",
+        "domains": [
+            "alibaba.com"
+        ]
+    },
+
+    {
+        "name": "Alvanista",
+        "url": "http://alvanista.com/profile/edit",
+        "difficulty": "easy",
+        "notes": "Follow the link to edit your profile and click cancel account at bottom.",
+        "notes_pt_br": "Use o link de editar o perfil e clique em cancelar conta no fim da página",
+        "domains": [
+            "alvanista.com"
+        ]
+    },
+
+    {
+        "name": "Amara",
+        "url": "http://www.amara.org/profiles/account/",
+        "difficulty": "easy",
+        "notes": "Just head to the account page and click the red button 'Delete your account' at the bottom left of the page.",
+        "notes_pt_br": "Apenas vá para a página de sua conta e clique no botão 'Delete your account' no canto inferior esquerdo da página.",
+        "domains": [
+            "amara.org"
+        ]
+    },
+
+    {
+        "name": "Amazon",
+        "url": "https://www.amazon.com/gp/help/customer/contact-us/ref=cu_cf_email?ie=UTF8&mode=email#a",
+        "difficulty": "hard",
+        "notes": "To close your account, contact Amazon by email (via this contact form) and request that your account be closed.",
+        "notes_fr": "Pour fermer votre compte, contactez Amazon par mail (par le formulaire de contact) et demandez la fermeture de votre compte.",
+        "notes_it": "Per chiudere il tuo account, contatta amazon via mail (utilizzando il form contattaci) richiedendo di chiudere il tuo account",
+        "notes_de": "Um deinen Account zu löschen, kontaktiere den Support über den Link und beantrage die Löschung dort.",
+        "notes_pt_br": "Para fechar sua conta, contate Amazon por e-mail (usando este modelo de contato) e requira que sua conta seja fechada.",
+        "notes_cat": "Per tancar el seu compte, contacti amb Amazon via e-mail (omplint aquest formulari de contacte) i demanant que es tanqui el seu compte.",
+        "notes_es": "Para cerrar tu cuenta, contacta con Amazon via e-mail (rellenando este formulario de contacto) y pidiendo que se cierre tu cuenta.",
+        "notes_pl": "Skontakuj się z Amazonem za pomocą formularza kontaktowego i poproś o usunięcie swojego konta.",
+        "domains": [
+            "amazon.com"
+        ]
+    },
+
+    {
+        "name": "Amazon AWS",
+        "url": "https://portal.aws.amazon.com/gp/aws/manageYourAccount?#productToCancel",
+        "difficulty": "easy",
+        "notes": "You must login before visiting the link.",
+        "notes_fr": "Il faut que vous vous connectez avant d'utiliser le lien.",
+        "notes_pl": "Musisz się zalogować przed wejściem w link.",
+        "domains": [
+            "amazon.com"
+        ]
+    },
+
+    {
+        "name": "Angelist",
+        "url": "https://angel.co/settings",
+        "difficulty": "easy",
+        "notes": "Click delete account once logged in.",
+        "domains": [
+            "angel.co"
+        ]
+    },
+
+    {
+        "name": "Animal Crossing Community",
+        "url": "http://www.animalcrossingcommunity.com/help_main.asp?HelpSectionID=5#Topic201",
+        "difficulty": "impossible",
+        "notes": "We do not 'delete' or 'terminate' accounts on ACC. If you no longer wish to use the site, you may delete all personal information from your profile and then stop logging in.",
+        "notes_fr": "ACC ne supprime pas les comptes. Cependant vous pouvez supprimer les informations qui sont dessus et arreter de vous connecter.",
+        "notes_it": "Non è possibile chiudere o terminare un account su ACC. Se non desideri più utilizzare il sito, puoi comunque eliminare tutti i dati personali dal tuo profilo e non loggarci più",
+        "notes_pt_br": "Nós não 'deletamos' ou 'terminamos' contas na ACC. Caso você não queira mais utilizar o site, você pode deletar todas as suas informações pessoas em seu perfil e então parar de logar-se.",
+        "notes_cat": "Nosaltres no 'esborrem' o 'finalitzem' comptes d'ACC. En el cas que no vulgui utilitzar més el lloc, pot esborrar totes les teves dades personals del seu perfil i evitar entrar més.",
+        "notes_es": "«Nosotros no 'borramos' o 'finalizamos' cuentas de ACC. En el supuesto que no quieras utilizar más el sitio, puede borrar toda tu información personal de tu perfil y evitar entrar más a tu cuenta.»",
+        "domains": [
+            "animalcrossingcommunity.com"
+        ]
+    },
+
+    {
+        "name": "AnkiApp",
+        "url": "https://join.ankiapp.com/",
+        "difficulty": "easy",
+        "notes": "Log in to your account and click 'Delete Account'. Confirm by entering your password and click 'OK'. You cannot delete your account via web.ankiapp.com - please visit join.ankiapp.com instead.",
+        "domains": [
+            "ankiapp.com"
+        ]
+    },
+
+    {
+        "name": "AnkiWeb",
+        "url": "https://ankiweb.net/account/remove",
+        "difficulty": "easy",
+        "notes": "Confirm by entering your e-mail address and click 'Remove'.",
+        "domains": [
+            "ankiweb.net"
+        ]
+    },
+
+    {
+        "name": "Any.do",
+        "url": "https://support.any.do/hc/en-us/articles/202759291-How-can-I-delete-my-account-",
+        "difficulty": "medium",
+        "notes": "You can only delete your account via the mobile app: install the app, log in, click Profile, click Delete Account.",
+        "domains": [
+            "any.do"
+        ]
+    },
+
+    {
+        "name": "AOL / Instant Messenger",
+        "url": "http://cancel.aol.com",
+        "difficulty": "easy",
+        "domains": [
+            "aol.com"
+        ]
+    },
+
+    {
+        "name": "AppFog",
+        "url": "https://groups.google.com/forum/#!topic/appfog-users/H9AkHjHFfZk",
+        "difficulty": "hard",
+        "notes": "Remove all applications and services from your account, then request deletion by emailing customer services.",
+        "notes_fr": "Enlevez toutes les applications et tous les services de votre compte, puis demandez la suppression de votre compte en envoyant un e-mail au service clients.",
+        "email": "support@appfog.com",
+        "domains": [
+            "appfog.com"
+        ]
+    },
+
+    {
+        "name": "Arcor.de",
+        "url": "https://www.arcor.de/register/admin_kuendigen_pw.jsp",
+        "difficulty": "easy",
+        "notes": "Only viable if you have online accounts only.",
+        "domains": [
+            "arcor.de"
+        ]
+    },
+
+    {
+        "name": "ArmorGames",
+        "url": "http://armorgames.com/settings/delete-account",
+        "difficulty": "easy",
+        "domains": [
+            "armorgames.com"
+        ]
+    },
+
+    {
+        "name": "The Artist Union",
+        "url": "https://theartistunion.com/dashboard/account",
+        "difficulty": "easy",
+        "notes": "Login to your account first. Click 'Delete Account' and confirm by clicking 'Ok'.",
+        "domains": [
+            "theartistunion.com"
+        ]
+    },
+
+    {
+        "name": "Artsy",
+        "url": "http://artsy.net/user/delete",
+        "difficulty": "easy",
+        "domains": [
+            "artsy.net"
+        ]
+    },
+
+    {
+        "name": "Asgardia.space",
+        "url": "https://asgardia.space/",
+        "difficulty": "impossible",
+        "notes": "You have to send an e-mail and request for account deletion, which might take up to 10 days. By some accounts, the site administrators will not follow up on deletion requests, leading to no follow-up.",
+        "email": "support@asgardia.space",
+        "domains": [
+            "asgardia.space"
+        ]
+    },
+
+    {
+        "name": "Ask.fm",
+        "url": "http://ask.fm/account/settings/optout",
+        "difficulty": "easy",
+        "domains": [
+            "ask.fm"
+        ]
+    },
+
+    {
+        "name": "Asos",
+        "url": "http://asos-de.custhelp.com/app/askchangedetails",
+        "difficulty": "hard",
+        "notes": "Request deletion from customer services.",
+        "notes_fr": "Demandez la suppresion du compte par le support du site.",
+        "notes_it": "Richiedi la cancellazione al servizio clienti",
+        "notes_de": "Beantrage die Löschung beim Support.",
+        "notes_pt_br": "Peça para que seja deletada pela assistência ao cliente.",
+        "notes_cat": "Demani l'eliminació del compte al servei d'atenció al client.",
+        "notes_es": "Pide la eliminación de tu cuenta al servicio de atención al cliente.",
+        "domains": [
+            "asos.de"
+        ]
+    },
+
+    {
+        "name": "Assembla",
+        "url": "https://www.assembla.com/user/edit/edit_account_settings",
+        "difficulty": "easy",
+        "domains": [
+            "assembla.com"
+        ]
+    },
+
+    {
+        "name": "Aternos",
+        "url": "https://aternos.org/close/",
+        "difficulty": "easy",
+        "domains": [
+            "aternos.org"
+        ]
+    },
+
+    {
+        "name": "Atlassian",
+        "url": "https://id.atlassian.com/manage/close-account",
+        "difficulty": "easy",
+        "domains": [
+            "atlassian.com"
+        ]
+    },
+
+    {
+        "name": "Audiomack",
+        "url": "http://www.audiomack.com/dashboard#delete-account",
+        "difficulty": "easy",
+        "notes": "Click the delete account link in the bottom left corner",
+        "domains": [
+            "audiomack.com"
+        ]
+    },
+
+    {
+        "name": "Autodesk",
+        "url": "https://knowledge.autodesk.com/contact-support/websupport/account-deletion",
+        "difficulty": "hard",
+        "notes": "Fill out the form to request for your account to be deleted.",
+        "domains": [
+            "autodesk.com"
+        ]
+    },
+
+    {
+        "name": "AutoScout24",
+        "url": "https://accounts.autoscout24.com/Delete",
+        "difficulty": "easy",
+        "domains": [
+            "autoscout24.com",
+            "autoscout24.at",
+            "autoscout24.be",
+            "autoscout24.es",
+            "autoscout24.de",
+            "autoscout24.fr",
+            "autoscout24.it",
+            "autoscout24.lu",
+            "autoscout24.nl",
+            "autoscout24.bg",
+            "autoscout24.cz",
+            "autoscout24.eu",
+            "autoscout24.hr",
+            "autoscout24.ro",
+            "autoscout24.se",
+            "autoscout24.com.tr",
+            "autoscout24.com.ua",
+            "autoscout24.net"
+        ]
+    },
+
+    {
+        "name": "Avast!",
+        "url": "https://my.avast.com",
+        "difficulty": "easy",
+        "notes": "Login, go to \"Profile Details\" tab, and simply click on the \"Delete Account\" button.",
+        "domains": [
+            "assembla.com"
+        ]
+    },
+
+    {
+        "name": "Avira",
+        "url": "https://answers.avira.com/en/question/how-do-i-delete-my-avira-account-12214?sh=true",
+        "difficulty": "hard",
+        "note": "Contact support to request deletion of your account with the email: support@avira.com",
+        "email": "support@avira.com",
+        "domains": [
+            "avira.com"
+        ]
+    },
+
+    {
+        "name": "AwardWallet",
+        "url": "https://awardwallet.com/user/delete",
+        "difficulty": "easy",
+        "notes": "You must enter your password and supply a reason for deleting your account",
+        "domains": [
+            "awardwallet.com"
+        ]
+    },
+
+    {
+        "name": "Babbel",
+        "url": "https://home.babbel.com/user-profile/settings",
+        "difficulty": "medium",
+        "notes": "Scroll down and press delete. A confirmation box will show up. You will have to go click the link in the email they send to you to permanently delete your Babbel account.",
+        "domains": [
+            "babbel.com"
+        ]
+    },
+
+    {
+        "name": "Backblaze",
+        "url": "https://secure.backblaze.com/user_account.htm",
+        "difficulty": "impossible",
+        "notes": "Accounts cannot be deleted, even when contacting customer service. User account credentials will be permanently retained by Backblaze.",
+        "domains": [
+            "backblaze.com"
+        ]
+    },
+
+    {
+        "name": "Badoo",
+        "url": "http://badoo.com/settings/",
+        "difficulty": "easy",
+        "notes": "On the top right corner click 'Settings', then on the left hand side click 'Delete'. Type your information, to delete Badoo, enter your password and in the other box, explain why you want to leave. Click on the 'Confirm' button, you will receive a message page confirming your rquest was successfully completed.",
+        "notes_ru": "Зайдите в 'Настройки', затем слева нажмите 'Удалить', укажите причину удаления и подтвердите выбор нажав кнопку 'Подтвердить'.",
+        "domains": [
+            "badoo.com"
+        ]
+    },
+
+    {
+        "name": "Bambuser",
+        "url": "https://bambuser.com/settings",
+        "difficulty": "easy",
+        "notes": "Go to your Settings page and scroll down to find 'Deactivate' account. Click on 'Close Account' button, and confirm the account deletion.",
+        "notes_fr": "Allez dans vos Parametres et allez jusqu'à Désactiver mon compte. Cliquez Fermer mon compte, et confirmez.",
+        "notes_it": "Vai sulla pagina delle impostazioni e scorri giù fino a trovare 'Deactivate account'. Clicca su il pulsante 'Close Account', e conferma la cancellazione dell'account",
+        "notes_pt_br": "Vá para a página Settings e desça até o final da página e ache 'Deactivate account'. Clique no botão 'Close Account', e confirme.",
+        "notes_cat": "Vagi a la pàgina 'Settings', baixa fins a trobar 'Deactivate account'. Cliqui al botó 'Close Account', i confirmi-ho.",
+        "notes_es": "Ve a la página 'Settings', desplázate hasta encontrar 'Deactivate account'. Haz clic en el botón 'Close Account', y confirma.",
+        "domains": [
+            "bambuser.com"
+        ]
+    },
+
+    {
+        "name": "Bandcamp",
+        "url": "https://bandcamp.com/settings?pane=fan",
+        "difficulty": "easy",
+        "notes": "To terminate an artist account, you must click on the 'Artists' pane, click on the desired artist's profile, and click the termination link there.",
+        "domains": [
+            "bandcamp.com"
+        ]
+    },
+
+    {
+        "name": "Barnes and Noble",
+        "url": "http://www.barnesandnoble.com/customerservice/contactus",
+        "difficulty": "impossible",
+        "notes": "It is not possible to delete your Barnes and Noble account.  The best you can do is delete any personal information that you have stored on their website.",
+        "domains": [
+            "barnesandnoble.com"
+        ]
+    },
+
+    {
+        "name": "Basecamp",
+        "url": "https://basecamp.com/help/guides/account/cancel",
+        "difficulty": "easy",
+        "notes": "Data will be permanantly deleted after 30 days.",
+        "notes_fr": "Les données seront supprimés définitivement dans 30 jours.",
+        "notes_pl": "Twoje dane zostaną całkowicie usunięte po upływie 30 dni.",
+        "domains": [
+            "basecamp.com"
+        ]
+    },
+
+    {
+        "name": "Basin",
+        "url": "http://usebasin.com/users/edit",
+        "difficulty": "easy",
+        "notes": "Scroll down to the bottom of the page and click the 'Completely obliterate all my data' button",
+        "domains": [
+            "usebasin.com"
+        ]
+    },
+
+    {
+        "name": "Battle.net",
+        "url": "https://eu.battle.net/support/en/ticket/submit",
+        "difficulty": "hard",
+        "notes": "Customer Support will require you to send a signed written letter confirming your wishes, your account details and a copy of legal identification (passport, drivers license) to your account region's office headquarters.",
+        "notes_fr": "Le support vous demandera une lettre écrite demandant la suppresion du compte, dans cette lettre donnez vos details de compte ainsi qu'un justificatif d'identité.",
+        "notes_it": "Il servizio clienti richiede di spedire una lettera firmata al quartier generale della tua nazione confermando le tue intenzioni, allegando i dettagli del tuo account e una copia di un documento (passaporto, patente)",
+        "notes_pt_br": "A Assistência ao Cliente irá pedir que você envie uma carta assinada confirmando os seus desejos, os detalhes de sua conta e uma cópia autenticada de identificação (passaporte, carteira de motorista) para o escritório da região de sua conta.",
+        "notes_cat": "L'Assistencia al Client li demanarà que envii una carta firmada confirmant els seus desitjos, els detalls de la seva conta i una copia d'identificació legal (Passaport, DNI...).",
+        "notes_es": "La asistencia al cliente te pedirá que envíes una carta firmada confirmando tus deseos, los detalles de la cuenta y una copia de una identificación legal (Pasaporte, DNI...).",
+        "notes_pl": "Dział wsparcia wymaga wysłania pisemnego potwierdzenia chęci usunięcia konta, wraz ze szczegółami konta użytkownika oraz kopii jednego z dokumentów potwierdzających tożsamość (paszport, prawo jazdy).",
+        "domains": [
+            "battle.net"
+        ]
+    },
+
+    {
+        "name": "BBC iD",
+        "url": "https://ssl.bbc.co.uk/id/settings/delete",
+        "difficulty": "easy",
+        "domains": [
+            "bbc.co.uk"
+        ]
+    },
+
+    {
+        "name": "Beam",
+        "url": "https://beam.pro/legal/privacy",
+        "difficulty": "hard",
+        "notes": "Remove all personal information from your account, then request deletion by emailing customer services.",
+        "email": "support@beam.pro",
+        "domains": [
+            "beam.pro"
+        ]
+    },
+
+    {
+        "name": "Beamly",
+        "url": "http://au.beamly.com/account/delete",
+        "difficulty": "easy",
+        "notes": "To delete your account, login and then next to your name select the drop down and go to 'Settings' once there scroll to the bottom of the page and select 'delete your account'.",
+        "domains": [
+            "beamly.com"
+        ]
+    },
+
+    {
+        "name": "Behance",
+        "url": "https://help.behance.net/hc/en-us/articles/204484854-How-do-I-delete-cancel-my-account-",
+        "difficulty": "easy",
+        "notes": "To delete your account, please click on your avatar in the top right navigation, visit Account Settings, and hit the 'Delete Account' tab. There, you'll have the option to delete.",
+        "domains": [
+            "behance.net"
+        ]
+    },
+
+    {
+        "name": "Betterment",
+        "url": "https://www.betterment.com/",
+        "difficulty": "impossible",
+        "notes": "Account can only be closed, but not trule deleted.",
+        "domains": [
+            "betterment.com"
+        ]
+    },
+
+    {
+        "name": "Bidoo",
+        "url": "https://it.bidoo.com",
+        "difficulty": "hard",
+        "notes": "Click the assistance link on the website and fill in the contact form. A representative will mail you to confirm the account deletion.",
+        "domains": [
+            "bidoo.com"
+        ]
+    },
+
+    {
+        "name": "Bitbucket",
+        "url": "https://bitbucket.org/account/",
+        "difficulty": "easy",
+        "notes": "On the side menu, click on 'Delete Account' and on the confirmation page click 'Delete Account', all repositories and the account is immediately wiped.",
+        "notes_fr": "Dans les parametres du compte cliquez sur supprimer le compte puis sur supprimer le compte. Tous les dépot ainsi que le compte seront immediatement supprimés.",
+        "notes_it": "Nel menu al lato, clicca su 'Delete Account' e fai lo stesso sulla pagina di conferma, l'account e i repositories saranno cancellati",
+        "notes_pt_br": "No menu lateral, clique em 'Delete Account' e na página de confirmação clique em 'Delete Account', todos os repositórios e contas serão imediatamente excluídos.",
+        "notes_cat": "Al menú lateral, cliqui a 'Delete Account', a la pagina de confirmació cliqui 'Delete Account', tots els comptes i repositoris serán cancel·lats",
+        "notes_es": "En el menú lateral, haz clic en 'Delete Account', y en la página de confirmación pulsa 'Delete Account', todas tus cuentas y repositorios serán cancelados.",
+        "notes_pl": "W menu bocznym kliknij 'Delete Account' i potwierdź klikając przycisk 'Delete Account', wszystkie repozytoria i konto zostaną natychmiast usunięte.",
+        "domains": [
+            "bitbucket.org"
+        ]
+    },
+
+    {
+        "name": "Bitdefender Central",
+        "url": "https://central.bitdefender.com/account",
+        "difficulty": "medium",
+        "notes": "To delete your account, login, go to the 'My Account' page, click the 'Delete Account' link, click the 'Delete Account' button, and click the 'Send Email' button. A confirmation email will be sent to the account email. Click the 'Delete Account' link in the email sent to you, log into your account, and click the 'Delete Account' button.",
+        "domains": [
+            "central.bitdefender.com"
+        ]
+    },
+
+    {
+        "name": "Bitly",
+        "url": "http://app.bitly.com/bitlinks/?actions=deactivate",
+        "difficulty": "easy",
+        "notes": "Go to \" Profile > Delete Account\" and select why you are deleting your account. Your account will be deleted but all your shortlinks will remain.",
+        "notes_pl": "Wybierz, dlaczego chcesz usunąć konto. Twoje konto zostanie usunięte, ale wszystkie twoje skrócone linki zostaną na serwerze.",
+        "notes_pt_br": "Vá para \" Profile > Delete Account\" e selecione uma razão pela qual você está excluindo sua conta. Sua conta será excluída, mais os seus links encurtados permanecerão ativos.",
+        "domains": [
+            "bitly.com",
+            "bit.ly"
+        ]
+    },
+
+    {
+        "name": "Blinkist",
+        "url": "https://www.blinkist.com/nc/settings/account/",
+        "difficulty": "easy",
+        "notes": "Click 'I want to delete my account' at the bottom of the page.",
+        "domains": [
+            "blinkist.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Blogger",
+        "url": "https://support.google.com/blogger/answer/41932",
+        "difficulty": "impossible",
+        "notes": "You can't delete your Blogger Account without deleting your entire Google Account. But you can delete your blog.",
+        "notes_fr": "Vous ne pouvez pas supprimer votre compte Blogger sans supprimer votre compte Google, mais vous pouvez supprimer votre blog.",
+        "notes_cat": "Hauries d'esborrar tot el compte de Google sencer, però si que pots eliminar el teu blog.",
+        "notes_es": "No puedes borrar tu cuenta de Blogger sin borrar toda la cuenta de Google, pero puedes borrar tu blog.",
+        "notes_pl": "Nie ma możliwości usunięcia konta w usłudze Blogger bez usuwania całego konta Google. Możesz jedynie usunąć swój blog.",
+        "domains": [
+            "blogger.com"
+        ]
+    },
+
+    {
+        "name": "Blue Apron",
+        "url": "https://www.blueapron.com/cancel_subscription",
+        "difficulty": "easy",
+        "domains": [
+            "blueapron.com"
+        ]
+    },
+
+    {
+        "name": "Bluebird by American Express",
+        "url": "https://secure.bluebird.com/manage/settings/ProfileSettings",
+        "difficulty": "medium",
+        "notes": "Remove all funds from your account. Then go to settings in your account, click on the profile tab, and click close account.",
+        "domains": [
+            "bluebird.com"
+        ]
+    },
+
+    {
+        "name": "BoardGameGeek",
+        "url": "http://www.boardgamegeek.com/geekaccount.php?action=requestdeletion",
+        "difficulty": "easy",
+        "notes": "Log-in and use the link provided to request account deletion.",
+        "notes_pt_br": "Faça login e use o link fornecido para requerir que a conta seja excluída.",
+        "notes_pl": "Zaloguj się i użyj podanego odnośnika, aby usunąc swoje konto.",
+        "domains": [
+            "boardgamegeek.com"
+        ]
+    },
+
+    {
+        "name": "BodBot",
+        "url": "http://www.bodbot.com/Account_Settings.html",
+        "difficulty": "easy",
+        "notes": "Click the “Delete My Account” link.",
+        "domains": [
+            "bodbot.com"
+        ]
+    },
+
+    {
+        "name": "Bodybuilding",
+        "url": "http://www.bodybuilding.com/store/help/delete-bodyspace-account.htm",
+        "difficulty": "impossible",
+        "notes": "You can only deactivate your account by contacting support as they state on the help page. There is no way to permanently delete your account or data, and an inactive public profile will always be visible to public.",
+        "notes_fr": "Vous pouvez seulement désactiver votre compte en contactant le support.",
+        "notes_it": "Puoi solo disattivare l'account contattando il supporto. Non esiste modo di eliminare permanentemente il tuo account o i dati, e un account inattivo resterà comunque visibile al pubblico",
+        "notes_pt_br": "Você pode apenas desativar sua conta contatando a assistência ao cliente como explicitado na página de ajuda. Não há como remover permanentemente sua conta ou seus dados, e um perfil publico inativo sempre estará visível ao público.",
+        "notes_cat": "Només pots desactivar el compte contactant amb l'Assistència al client. No podràs eliminar mai el compte, només desactivar-lo, els comptes desactivats són visibles al públic.",
+        "notes_es": "Solo puedes desactivar la cuenta contactando con Assistència al client. No podrás eliminar nunca la cuenta, solo desactivarla, les cuentas desactivadas son visibles al público.",
+        "domains": [
+            "bodybuilding.com"
+        ]
+    },
+
+    {
+        "name": "BoerseBZ",
+        "url": "http://www.boerse.bz/profile.php?do=delacc",
+        "difficulty": "impossible",
+        "notes": "Accounts cannot be removed at this time",
+        "notes_fr": "Les comptes ne peuvent pas être supprimés en ce moment.",
+        "notes_de": "Deaktivierung von Accounts bis auf weiteres nicht möglich",
+        "domains": [
+            "boerse.bz"
+        ]
+    },
+
+    {
+        "name": "BookBub",
+        "url": "https://www.bookbub.com/contact/new",
+        "difficulty": "hard",
+        "notes": "Fill out the contact form to request deletion.",
+        "domains": [
+            "bookbub.com"
+        ]
+    },
+
+    {
+        "name": "Booking",
+        "url": "https://secure.booking.com/login.en-us.html?tmpl=profile/delete_account",
+        "difficulty": "easy",
+        "domains": [
+            "booking.com"
+        ]
+    },
+
+    {
+        "name": "Booklooker",
+        "url": "https://secure.booklooker.de/pages/contact.php",
+        "difficulty": "hard",
+        "notes": "You need to request deletion of your data via the contact form after logging in.",
+        "notes_fr": "Il faut demander la suppression de votre compte par le support du site, après vous vous connectez.",
+        "notes_de": "Nach dem einloggen muss der Kundenservice zur Löschung kontaktiert werden.",
+        "notes_pl": "Poproś o usunięcie swoich danych za pomocą formularza kontaktowego.",
+        "domains": [
+            "booklooker.de"
+        ]
+    },
+
+    {
+        "name": "botlist.space",
+        "url": "https://botlist.space/server",
+        "difficulty": "hard",
+        "notes": "You need to request deletion of your account data by contacting a 'Website Staff' via their Discord server.",
+        "domains": [
+            "botlist.space"
+        ]
+    },
+
+    {
+        "name": "Box",
+        "meta": "popular",
+        "url": "https://app.box.com/account",
+        "difficulty": "easy",
+        "domains": [
+            "box.com"
+        ]
+    },
+
+    {
+        "name": "Boxcryptor",
+        "url": "https://www.boxcryptor.com/app/account/delete-account/",
+        "difficulty": "easy",
+        "domains": [
+            "boxcryptor.com"
+        ]
+    },
+
+    {
+        "name": "Bring!",
+        "url": "https://getbring.com/#!/contact",
+        "difficulty": "hard",
+        "notes": "Contact support and ask for your account to be deleted.",
+        "notes_de": "Kontaktiere den Support und fordere eine Löschung des Accounts an.",
+        "email": "feedback@getbring.com",
+        "domains": [
+            "getbring.com"
+        ]
+    },
+
+    {
+        "name": "British Airways",
+        "url": "https://naprepin.custhelp.com/app/answers/detail/a_id/770/~/cancelling-your-executive-club-membership",
+        "difficulty": "hard",
+        "notes": "Must send a request in writing. See this page for contact details <a href=\"https://www.britishairways.com/travel/contact-executive-club/execclub/_gf/en_us\">https://www.britishairways.com/travel/contact-executive-club/execclub/_gf/en_us</a>",
+        "domains": [
+            "britishairways.com"
+        ]
+    },
+
+    {
+        "name": "BrowserStack",
+        "url": "https://www.browserstack.com/contact",
+        "difficulty": "hard",
+        "notes": "Must send contact form requesting account deletion, using the \"Other\" category.",
+        "domains": [
+            "browserstack.com"
+        ]
+    },
+
+    {
+        "name": "Buffer",
+        "url": "https://bufferapp.com/app/account/leave",
+        "difficulty": "easy",
+        "domains": [
+            "bufferapp.com"
+        ]
+    },
+
+    {
+        "name": "Bukalapak",
+        "difficulty": "medium",
+        "notes": "Open Akun (Account)>BukaBantuan (Open Help)>In Akun & Info Personal (Account & Personal Info), tap Selanjutnya (Next)>Tap Menonaktifkan Akun (Disable Account)>Tap Isi Form Bantuan (Type on Help Form)>Explain the reason why you delete it>Tap Kirim (Send).",
+        "domains": [
+            "bukalapak.com"
+        ]
+    },
+
+    {
+        "name": "Bungie.net",
+        "url": "http://www.bungie.net/en-US/Forum/Post/66636671/0/0",
+        "difficulty": "impossible",
+        "notes": "TL;DR you can't do it. Discussion at <a href=\"http://www.bungie.net/en-US/Forum/Post/66636671/0/0\">http://www.bungie.net/en-US/Forum/Post/66636671/0/0</a>",
+        "notes_pl": "TL;DR: nie możesz tego zrobić. Dyskusja na <a href=\"http://www.bungie.net/en-US/Forum/Post/66636671/0/0\">http://www.bungie.net/en-US/Forum/Post/66636671/0/0</a>",
+        "domains": [
+            "bungie.net"
+        ]
+    },
+
+    {
+        "name": "BurstNET",
+        "url": "http://burst.net/",
+        "difficulty": "impossible",
+        "notes": "Support staff refuses to delete accounts due to 'accounting purposes'",
+        "notes_fr": "Le personnel refuse de supprimer les comptes.",
+        "domains": [
+            "burst.net"
+        ]
+    },
+
+    {
+        "name": "Buycott",
+        "url": "https://www.buycott.com/",
+        "difficulty": "hard",
+        "notes": "To cancel your account you have to send them an email",
+        "email": "info@buycott.com",
+        "domains": [
+            "buycott.com"
+        ]
+    },
+
+    {
+        "name": "C&M News by Rеss.at",
+        "url": "http://www.ress.at/profil/profil_entfernen.php",
+        "difficulty": "easy",
+        "notes": "Just click 'Abschicken'",
+        "notes_fr": "Cliquez juste 'Abschicken'.",
+        "notes_it": "Clicca semplicemente 'Abschicken'",
+        "notes_de": "Einfach auf 'Abschicken' klicken",
+        "notes_pt_br": "Apenas clique em 'Abschicken'",
+        "notes_cat": "Només cal clicar a 'Abschicken'",
+        "notes_es": "Solo tienes que clicar en 'Abschicken'",
+        "notes_pl": "Wystarczy, że klikniesz 'Abschicken'",
+        "domains": [
+            "ress.at"
+        ]
+    },
+
+    {
+        "name": "Cacoo",
+        "url": "https://cacoo.com/unsubscribe",
+        "difficulty": "easy",
+        "domains": [
+            "cacoo.com"
+        ]
+    },
+
+    {
+        "name": "CafePress",
+        "url": "https://members.cafepress.com/account/closeaccount.aspx",
+        "difficulty": "easy",
+        "domains": [
+            "cafepress.com"
+        ]
+    },
+
+    {
+        "name": "Call of Duty (Activision)",
+        "url": "http://www.callofduty.com/",
+        "difficulty": "impossible",
+        "notes": "'There is no way to close or shut down an account.'",
+        "notes_pl": "Nie ma możliwości zamknięcia konta.",
+        "notes_fr": "Il n'y a pas de façon de supprimer les comptes.",
+        "domains": [
+            "callofduty.com"
+        ]
+    },
+
+    {
+        "name": "CamelCamelCamel",
+        "url": "https://camelcamelcamel.com/close_account",
+        "difficulty": "easy",
+        "notes": "Login to your account first. Confirm by ticking both boxes, 'I want to close my Camel account.' and 'I’m really sure!', and click 'Close Account'.",
+        "domains": [
+            "camelcamelcamel.com"
+        ]
+    },
+
+    {
+        "name": "car2go",
+        "url": "https://www.car2go.com/US/en/#footer-contactus",
+        "difficulty": "hard",
+        "notes": "You need to call customer support and even after that can take weeks before confirmation of deletion",
+        "domains": [
+            "car2go.com"
+        ]
+    },
+
+    {
+        "name": "CareerBuilder.com",
+        "url": "http://www.careerbuilder.com/User/UserConfirmation.aspx",
+        "difficulty": "easy",
+        "notes": "Must remove uploaded files first",
+        "notes_fr": "Il faut supprimer les fichiers téléchargés avant de supprimer votre compte.",
+        "domains": [
+            "careerbuilder.com"
+        ]
+    },
+
+    {
+        "name": "cda",
+        "url": "https://www.cda.pl/kontakt",
+        "difficulty": "hard",
+        "notes": "You need to contact with support",
+        "domains": [
+            "cda.pl"
+        ]
+    },
+
+    {
+        "name": "CDON.COM",
+        "url": "http://cdon.eu/#support-hub",
+        "difficulty": "hard",
+        "notes": "Contact customer service via the support e-mail form and request deletion of your account under General Questions.",
+        "domains": [
+            "cdon.se",
+            "cdon.dk",
+            "cdon.no",
+            "cdon.fi",
+            "cdon.eu"
+        ]
+    },
+
+    {
+        "name": "CEX.IO",
+        "url": "https://support.cex.io/hc/en-us/articles/201516097-How-can-I-delete-my-account-from-CEX-IO-and-GHash-IO-",
+        "email": "support@cex.io",
+        "email_subject": "Delete Account",
+        "difficulty": "hard",
+        "notes": "You can't delete your account without contacting them. You must set the subject to 'Delete Account'",
+        "notes_de": "Sie können Ihren Account nicht löschen ohne den Support zu kontaktieren. Sie müssen den Betreff auf 'Delete Account' setzen.",
+        "notes_pl": "Nie ma możliwości usunięcia konta bez kontaktu z obsługą. W temacie wpisz wiadomości 'Delete Account'",
+        "domains": [
+            "cex.io"
+        ]
+    },
+
+    {
+        "name": "Change.org",
+        "url": "https://www.change.org/account_settings/disable_account",
+        "difficulty": "easy",
+        "domains": [
+            "change.org"
+        ]
+    },
+
+    {
+        "name": "Channel 4",
+        "url": "https://4id.channel4.com/account/remove",
+        "difficulty": "easy",
+        "domains": [
+            "channel4.com"
+        ]
+    },
+
+    {
+        "name": "Cheap Ass Gamer",
+        "url": "https://www.cheapassgamer.com/index.php?app=core&module=help&do=01&HID=15",
+        "difficulty": "hard",
+        "notes": "Please email cheapyd@cheapassgamer.com from your account on file with CAG.",
+        "email": "cheapyd@cheapassgamer.com",
+        "domains": [
+            "cheapassgamer.com"
+        ]
+    },
+
+    {
+        "name": "Checklist",
+        "url": "https://api.checklist.com/account/account",
+        "difficulty": "easy",
+        "notes": "Log in and go to your account. Scroll to 'Close your account' and click on 'Close Account'. Confirm by clicking on 'Yes' in the pop-up window. The account will be deleted immediately.",
+        "domains": [
+            "checklist.com"
+        ]
+    },
+
+    {
+        "name": "Cheddar",
+        "url": "https://cheddarapp.com/account",
+        "difficulty": "easy",
+        "domains": [
+            "cheddarapp.com"
+        ]
+    },
+
+    {
+        "name": "Chegg",
+        "url": "http://www.chegg.com/contactus",
+        "difficulty": "hard",
+        "notes": "Call customer service or contact them via chat and ask them to delete your account, or request assistance via their Twitter account, <a href=\"https://twitter.com/chegghelp\">@CheggHelp</a>. There is also no option to delete your payment methods, you need to contact customer support as well.",
+        "domains": [
+            "chegg.com"
+        ]
+    },
+
+    {
+        "name": "Chess.com",
+        "url": "https://chess.com/settings/close-account",
+        "difficulty": "impossible",
+        "notes": "Your account will not be deleted but disabled.",
+        "domains": [
+            "chess.com"
+        ]
+    },
+
+    {
+        "name": "CiteULike",
+        "url": "http://www.citeulike.org",
+        "difficulty": "impossible",
+        "notes": "We don't delete old accounts. You can however delete your own articles, remove yourself from any groups you're a member of, remove your profile information, clear your watchlist, and delete blog articles.",
+        "domains": [
+            "citeulike.org"
+        ]
+    },
+
+    {
+        "name": "ClassPass",
+        "url": "https://classpass.com/settings/membership",
+        "difficulty": "impossible",
+        "notes": "You can deactivate your account from settings but not entirely delete the account itself.",
+        "domains": [
+            "classpass.com"
+        ]
+    },
+
+    {
+        "name": "CleverReach",
+        "url": "https://www.cleverreach.com",
+        "difficulty": "hard",
+        "notes": "Email customer services to request deletion",
+        "notes_fr": "Envoyez un e-mail au service clients pour demander la suppression de votre compte.",
+        "email": "info@cleverreach.de",
+        "domains": [
+            "cleverreach.com"
+        ]
+    },
+
+    {
+        "name": "ClickAndBuy",
+        "url": "http://clickandbuy.com/faqs",
+        "difficulty": "easy",
+        "notes": "Login to your account, then click 'delete account' on the page.",
+        "notes_fr": "Connectez-vous et cliquez sur « delete account ».",
+        "notes_de": "Logge dich in deinen Account ein und klicke auf der Seite auf 'Account löschen'.",
+        "domains": [
+            "clickandbuy.com"
+        ]
+    },
+
+    {
+        "name": "CloudApp",
+        "url": "http://my.cl.ly/account/delete",
+        "email": "support@getcloudapp.com",
+        "difficulty": "hard",
+        "notes": "The site claims that you must call their support line (888-988-5036, ext 1), but they deactivated my account over email.",
+        "domains": [
+            "cl.ly"
+        ]
+    },
+
+    {
+        "name": "Cloudflare",
+        "url": "https://support.cloudflare.com/requests/new",
+        "difficulty": "hard",
+        "notes": "Submit a support ticket using the \"Account\" category, and request account deletion in the message body. You must have no domains or credit cards attached to your account prior to requesting deletion.",
+        "domains": [
+            "cloudflare.com"
+        ]
+    },
+
+    {
+        "name": "CloudMagic",
+        "url": "https://cloudmagic.com/a/v2/preferences",
+        "difficulty": "easy",
+        "domains": [
+            "cloudmagic.com"
+        ]
+    },
+
+    {
+        "name": "CNET Download",
+        "url": "https://cbsi.secure.force.com/CBSi/submitcase?template=template_cnet&referer=cnet.com&cfs=SFS_1",
+        "difficulty": "hard",
+        "notes": "You have to ask the support to get your account deleted. Choose the category CNET Registration",
+        "domains": [
+            "cnet.com"
+        ]
+    },
+
+    {
+        "name": "Code Red",
+        "url": "https://cne.coderedweb.com",
+        "difficulty": "impossible",
+        "notes": "You can't delete yourself. You can only change your phone nr. to a bogus number.",
+        "notes_fr": "Vous ne pouvez pas supprimer votre compte. Vous pouvez seulement donner un faux numéro.",
+        "notes_it": "Non puoi eliminarti. Puoi solamente cambiare il tuo numero di telefono con uno inventato",
+        "notes_pt_br": "Você não pode deletar sua conta. Você pode mudar o número de telefone para um número qualquer.",
+        "notes_cat": "No podrà eliminar el compte. Només pots canviar-te el número de telèfon.",
+        "notes_es": "No podrá eliminar la cuenta. Solo puedes cambiar tu número de teléfono a un falso.",
+        "domains": [
+            "coderedweb.com"
+        ]
+    },
+
+    {
+        "name": "Code School",
+        "url": "https://www.codeschool.com/account/edit",
+        "difficulty": "easy",
+        "notes": "Go to your Profile, at the bottom you will find a 'Delete Account' button.",
+        "notes_fr": "Allez dans votre Profil, en bas vous trouverez un bouton 'Delete Account'.",
+        "notes_it": "Inizia una discussione privata con loro e se ne occuperanno loro",
+        "notes_de": "Starte eine private Diskussion mit ihnen und sie 'Kümmern sich drum'.",
+        "notes_pt_br": "Inicie uma discussão privada com eles e eles irão 'cuidar disso'.",
+        "notes_cat": "Comenci una discusió privada amb ells i 'procuraran fer-ho'.",
+        "notes_es": "Empieza una discusión privada con ellos y 'procurarán hacerlo'.",
+        "domains": [
+            "codeschool.com"
+        ]
+    },
+
+    {
+        "name": "Codeanywhere",
+        "url": "https://codeanywhere.com/dashboard",
+        "difficulty": "easy",
+        "notes": "Login then click Delete Account button and enter your password.",
+        "domains": [
+            "codeanywhere.com"
+        ]
+    },
+
+    {
+        "name": "Codecademy",
+        "url": "https://www.codecademy.com/account/delete_acct",
+        "difficulty": "easy",
+        "notes": "Simply click the \"I understand, delete my account.\" button.",
+        "notes_es": "Simplemente haz clic en el botón \"Entiendo, borrar mi cuenta\".",
+        "notes_fr": "Il faut simplement confirmer que vous voulez supprimmer votre compte.",
+        "domains": [
+            "codecademy.com"
+        ]
+    },
+
+    {
+        "name": "Codenvy",
+        "url": "https://codenvy.io/dashboard/#/account",
+        "difficulty": "easy",
+        "notes": "Deletion option can be found in the \"Security\" tab",
+        "domains": [
+            "codenvy.com",
+            "codenvy.io"
+        ]
+    },
+
+    {
+        "name": "CodePen",
+        "url": "http://blog.codepen.io/documentation/faq/how-do-i-delete-my-account/",
+        "difficulty": "easy",
+        "domains": [
+            "codepen.io"
+        ]
+    },
+
+    {
+        "name": "CodeProject",
+        "url": "https://www.codeproject.com/script/Membership/Modify.aspx",
+        "difficulty": "easy",
+        "notes": "Beneath the gravatar image, check the 'Close my account' checkbox. Then click on 'Save my Settings'.",
+        "domains": [
+            "codeproject.com"
+        ]
+    },
+
+    {
+        "name": "Coderwall",
+        "url": "https://coderwall.com/delete_account",
+        "difficulty": "easy",
+        "notes": "Sign in then visit <a href=\"https://coderwall.com/delete_account\">https://coderwall.com/delete_account</a>",
+        "notes_fr": "Identifiez-vous puis visitez <a href=\"https://coderwall.com/delete_account\">https://coderwall.com/delete_account</a>",
+        "notes_cat": "Identifica't al lloc web i entra <a href=\"https://coderwall.com/delete_account\">https://coderwall.com/delete_account</a>",
+        "notes_es": "Identifícate en el sitio web y entra en <a href=\"https://coderwall.com/delete_account\">https://coderwall.com/delete_account</a>",
+        "notes_pl": "Zaloguj się i przejdź do <a href=\"https://coderwall.com/delete_account\">https://coderwall.com/delete_account</a>",
+        "domains": [
+            "coderwall.com"
+        ]
+    },
+
+    {
+        "name": "Codewars",
+        "url": "https://www.codewars.com/users/edit",
+        "difficulty": "easy",
+        "notes": "Go to your 'Account Settings' and scroll to the bottom to find the 'Delete Account' section",
+        "domains": [
+            "codewars.com"
+        ]
+    },
+
+    {
+        "name": "Coinbase",
+        "url": "http://coinbase.com/close_account",
+        "difficulty": "medium",
+        "notes": "Sign in then visit <a href=\"http://coinbase.com/close_account\">http://coinbase.com/close_account</a> and scroll to the bottom to find a button to close you account. In order to be deleted, your account can not have pending transactions.",
+        "notes_pt_br": "Faça login e acesse <a href=\"http://coinbase.com/close_account\">http://coinbase.com/close_account</a>. Role até o final da página para encontrar o botão para fechar sua conta. Para que possa ser excluída, sua conta não deve haver nenhum tipo de transação pendente.",
+        "domains": [
+            "coinbase.com"
+        ]
+    },
+
+    {
+        "name": "CoinBR/Stratum",
+        "url": "http://stratum.hk/support",
+        "difficulty": "hard",
+        "notes": "Contact the customer support via email and request the deletion of your account. In order for them to identify your account, make the request through the same email address that you have used to create your CoinBR/Stratum account.",
+        "notes_pt_br": "Entre em contato com o suporte via e-mail e solicite que sua conta seja excluída. Para que eles possam identificar sua conta, faça a requisição a partir da mesma conta de e-mail que você usou para criar sua conta CoinBR/Stratum.",
+        "email": "support@stratum.hk",
+        "email_subject": "[ Permanently Account Deletion Request ]",
+        "email_body": "I have no further interest in using the services provided by Stratum, so I would like my account to be permanently deleted.",
+        "domains": [
+            "stratum.hk",
+            "coinbr.net",
+            "coinbr.io"
+        ]
+    },
+
+    {
+        "name": "CoinPayments",
+        "url": "https://www.coinpayments.net/help-support",
+        "difficulty": "impossible",
+        "notes": "According to their own policy, accounts can never be deleted.",
+        "domains": [
+            "coinpayments.net"
+        ]
+    },
+
+    {
+        "name": "Collegeboard",
+        "url": "https://pages.collegeboard.org/account-help/how-do-i-delete-my-account",
+        "difficulty": "hard",
+        "notes": "You have to call their customer service at 866-315-6068",
+        "domains": [
+            "collegeboard.org"
+        ]
+    },
+
+    {
+        "name": "Comment ça marche",
+        "url": "http://www.commentcamarche.net/communaute/remove.php3",
+        "difficulty": "medium",
+        "notes": "Your messages will remain on the forums.",
+        "notes_fr": "Vos messages seront guardés.",
+        "domains": [
+            "commentcamarche.net"
+        ]
+    },
+
+    {
+        "name": "Conte.it",
+        "url": "http://www.conte.it/privacy-unsubscribe/",
+        "difficulty": "easy",
+        "notes": "Fill out the form to request cancellation from Conte.it's insurance services.",
+        "notes_it": "Compila il form per richiedere la cancellazione dai servizi assicurativi di Conte.it",
+        "domains": [
+            "conte.it"
+        ]
+    },
+
+    {
+        "name": "Cook It",
+        "url": "https://www.chefcookit.com/unsubscribe",
+        "difficulty": "impossible",
+        "notes": "It is only possible to permanently disable the automatic subscription fee. Doing so will also set your stars back to 0.",
+        "notes_fr": "Il est seulement possible de désactiver le frais de renouvellement automatique. Lorsque le renouvellement sera désactivé vos étoiles seront remis à 0.",
+        "domains": [
+            "chefcookit.com"
+        ]
+    },
+
+    {
+        "name": "Couchsurfing",
+        "url": "https://support.couchsurfing.org/hc/en-us/articles/200640880-How-can-I-Hide-or-Delete-my-profile",
+        "difficulty": "impossible",
+        "notes": "Cannot be deleted fully, reactivation is always available. Fill out the request form.",
+        "domains": [
+            "couchsurfing.org",
+            "couchsurfing.com"
+        ]
+    },
+
+    {
+        "name": "Coursera",
+        "url": "https://www.coursera.org/account-settings",
+        "difficulty": "easy",
+        "notes": "Delete acccount button is at the bottom of the page.",
+        "notes_es": "El botón para borrar la cuenta está al final de la página.",
+        "domains": [
+            "coursera.org"
+        ]
+    },
+
+    {
+        "name": "Craigslist",
+        "url": "http://www.craigslist.org/about/help/user_accounts",
+        "difficulty": "hard",
+        "notes": "Send an email to abuse@craigslist.org and request deletion.",
+        "notes_fr": "Envoyez un mail à abuse@craigslist.org et demandez la suppression du compte. ",
+        "notes_it": "Spedisci un email a abuse@craigslist.org e richiedi la cancellazione",
+        "notes_de": "Sende eine E-Mail an abuse@craigslist.org und beantrage die Löschung",
+        "notes_pt_br": "Envie um e-mail para abuse@craigslist.org e peça a remoção.",
+        "notes_cat": "Enviï un e-mail a abuse@craigslist.org i demani la supressió del compte.",
+        "notes_es": "Envía un e-mail a abuse@craigslist.org y pide que eliminen tu cuenta.",
+        "email": "abuse@craigslist.org",
+        "domains": [
+            "craigslist.org"
+        ]
+    },
+
+    {
+        "name": "CrashPlan",
+        "url": "http://support.crashplan.com/",
+        "difficulty": "hard",
+        "notes": "Start a live chat session and a representative will delete your account.",
+        "notes_fr": "Démarrez une session Live Chat et un représentant supprimera votre compte.",
+        "domains": [
+            "crashplan.com"
+        ]
+    },
+
+    {
+        "name": "Credit Karma",
+        "url": "https://www.creditkarma.com/myprofile/security/deactivate",
+        "difficulty": "easy",
+        "notes": "Membership can be canceled either online or by mail. Once you cancel, you will no longer have access to your Credit Karma account history and you won’t be able to create a new account for six months.",
+        "domains": [
+            "creditkarma.com"
+        ]
+    },
+
+    {
+        "name": "CreditExpert",
+        "url": "https://www.creditexpert.co.uk/",
+        "difficulty": "hard",
+        "notes": "You can cancel by email but only if your membership includes insurance. Otherwise, an email cancellation will be ignored. You have to call 0800 561 0083 to cancel your account. This is the only way. More info here: <a href=\"http://experian.metafaq.com/help/CreditExpertBRS/Cancel_and_duration/CancelBRS\">http://experian.metafaq.com/help/CreditExpertBRS/Cancel_and_duration/CancelBRS</a>",
+        "email": "Customerservice@creditexpert.co.uk",
+        "domains": [
+            "creditexpert.co.uk"
+        ]
+    },
+
+    {
+        "name": "Crowdcast.io",
+        "url": "http://docs.crowdcast.io/account/how-do-i-cancel-my-account",
+        "difficulty": "impossible",
+        "notes": "You can pause your account for $10/mo or cancel your account.",
+        "domains": [
+            "crowdcast.io"
+        ]
+    },
+
+    {
+        "name": "Crowdin",
+        "url": "https://crowdin.com/settings#account",
+        "difficulty": "easy",
+        "notes": "Login to your account. Click on 'Settings', then 'Remove Account' (at the bottom). Choose one of the options why you want to delete your account and click 'Remove Account'.",
+        "domains": [
+            "crowdin.com"
+        ]
+    },
+
+    {
+        "name": "Crunchyroll",
+        "url": "http://www.crunchyroll.com/nuke",
+        "difficulty": "easy",
+        "notes": "You can deactivate the account after filling out a form containing the reason for doing so (radio button list) and typing your password",
+        "domains": [
+            "crunchyroll.com"
+        ]
+    },
+
+    {
+        "name": "Crushee",
+        "url": "http://www.crushee.com/pages/faq",
+        "difficulty": "impossible",
+        "notes": "They mock the very idea of wanting to delete your account in their faq: \"Can I delete my account cause I totally h8 you guise??!!!111\"",
+        "domains": [
+            "crushee.com"
+        ]
+    },
+
+    {
+        "name": "CryptFolio",
+        "url": "https://cryptfolio.com/user#user_delete",
+        "difficulty": "easy",
+        "domains": [
+            "cryptfolio.com"
+        ]
+    },
+
+    {
+        "name": "Cryptocat",
+        "url": "https://crypto.cat/help.html#deleteAccount",
+        "difficulty": "easy",
+        "notes": "In order to delete your Cryptocat account, open the Account menu, navigate to the Settings submenu and click on Delete Account.",
+        "domains": [
+            "crypto.cat"
+        ]
+    },
+
+    {
+        "name": "CryptPad",
+        "url": "https://cryptpad.fr/settings/",
+        "difficulty": "easy",
+        "notes": "Scroll down to the red 'Delete your account' button and then select 'OK (enter)'",
+        "domains": [
+            "cryptpad.fr"
+        ]
+    },
+
+    {
+        "name": "Cybrary",
+        "url": "https://www.cybrary.it/members",
+        "difficulty": "easy",
+        "notes": "Login to your account first. Go to 'Settings, then 'Delete Account'. 'Confirm by ticking 'I understand the consequences.' and click 'Delete Account'.",
+        "domains": [
+            "cybrary.com"
+        ]
+    },
+
+    {
+        "name": "Daily Mile",
+        "url": "http://www.dailymile.com/account/settings/edit",
+        "difficulty": "easy",
+        "notes": "Edit your account and select 'Remove my account'.",
+        "notes_fr": "Modifiez vos infos et selectionnez Remove my account.",
+        "notes_de": "Editiere deinen Account und wähle 'Remove my account'",
+        "notes_it": "Edita il tuo account e clicca il pulsante 'Remove my account'",
+        "notes_pt_br": "Edite sua conta e seleciona 'Remove my account'.",
+        "notes_cat": "Editi el seu compte i seleccioni 'Remove my account'.",
+        "notes_es": "Edita tu cuenta y seleccione 'Remove my account'.",
+        "domains": [
+            "dailymile.com"
+        ]
+    },
+
+    {
+        "name": "DansTonChat",
+        "url": "https://danstonchat.com/user/delete.html",
+        "difficulty": "easy",
+        "domains": [
+            "danstonchat.com"
+        ]
+    },
+
+    {
+        "name": "Dark Creations",
+        "url": "https://www.darkcreations.org/",
+        "difficulty": "impossible",
+        "notes": "Their community rules state that accounts will never be deleted.",
+        "domains": [
+            "darkcreations.org"
+        ]
+    },
+
+    {
+        "name": "Dashlane",
+        "url": "https://www.dashlane.com/deleteaccount",
+        "difficulty": "easy",
+        "notes": "You have to enter your mailadress and have to choose a 'why are you leaving' answer'. To verify this step you'll become a mail with a security code to fill into the form. After that your account is deleted.",
+        "notes_de": "Nach Angabe der E-Mail-Adresse und der Auswahl eines Grunds der Löschung, erhält man per Mail einen Sicherheitscode. Dieser wird im Löschformular eingetragen und abgeschickt. Danach wird der Account unwiederbringlich gelöscht.",
+        "domains": [
+            "dashlane.com"
+        ]
+    },
+
+    {
+        "name": "Day One",
+        "url": "http://dayone.me/user/request-account-deletion",
+        "difficulty": "easy",
+        "domains": [
+            "dayone.me"
+        ]
+    },
+
+    {
+        "name": "Deadspin (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Vosté pot parar de fer servir el servei en qualsevol moment. Nosaltres, si més no mantindrem i continuarem utilitzant qualsevol contingut que hagi enviat al nostre servei.",
+        "notes_es": "«Usted puede parar de usar el servicio en cualquier momento. Nosotros, mantendremos y continuaremos utilizando cualquier contenido que haya enviado a nuestro servicio.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "Deezer",
+        "url": "http://www.deezer.com/account",
+        "difficulty": "medium",
+        "notes": "If you signed up via Google/Facebook setup a Deezer password at <a href=\"http://www.deezer.com/password/reset\">http://www.deezer.com/password/reset</a> and click the confirmation link you'll get via mail. If you have your Deezer password, open your account settings. Click 'Delete my Account' at the bottom of the page. Enter your Deezer password and confirm the deletion in the confirmation mail.",
+        "notes_de": "Wenn du dich mit Google/Facebook registriert hast, fordere unter <a href=\"http://www.deezer.com/password/reset\">http://www.deezer.com/password/reset</a> ein Deezer-Passwort an und bestätige einen Link, den du per Mail erhältst. Wenn du ein Deezer-Passwort hast, öffne deine Konto-Einstellungen und klicke unten auf 'Mein Konto löschen'. Gib dort dein Deezer-Passwort ein und bestätige das Löschen in der Bestätigungsmail.",
+        "domains": [
+            "deezer.com"
+        ]
+    },
+
+    {
+        "name": "Delivery Code",
+        "difficulty": "medium",
+        "notes": "Go to My Account and select Edit Profile and then Delete Account. A confirmation e-mail will be sent to the address on file with a link you must visit.",
+        "domains": [
+            "deliverycode.com"
+        ]
+    },
+
+    {
+        "name": "Delta Airlines (SkyMiles)",
+        "url": "http://www.delta.com/contactus/pages/comment_complaint/index.jsp",
+        "difficulty": "hard",
+        "notes": "You can not delete your account on the site. You must use the linked form. Then select SkyMiles → Update SkyMiles Account and request them to close your account.",
+        "notes_fr": "Vous ne pouvez pas supprimer votre compte sur le site. Vous devez utiliser le formulaire lié. Ensuite, sélectionnez SkyMiles → Mise à jour compte SkyMiles et de leur demander de fermer votre compte.",
+        "domains": [
+            "delta.com"
+        ]
+    },
+
+    {
+        "name": "Depositphotos",
+        "url": "depositphotos.com",
+        "difficulty": "hard",
+        "notes": "Enter live chat in the other department and request cancellation of your account or if it is not available use the contact form.",
+        "notes_it": "Entra in live chat nel reparto altro e richiedi la cancellazione del tuo account o se non è disponibile utilizza il modulo di contatto.",
+        "domains": [
+            "depositphotos.com"
+        ]
+    },
+
+    {
+        "name": "Desk.com",
+        "url": "desk.com",
+        "difficulty": "hard",
+        "email": "support@desk.com",
+        "notes": "Required to send e-mail, but it is quickly responded.",
+        "domains": [
+            "desk.com"
+        ]
+    },
+
+    {
+        "name": "Desktoppr",
+        "url": "https://www.desktoppr.co/settings",
+        "difficulty": "easy",
+        "domains": [
+            "desktoppr.co"
+        ]
+    },
+
+    {
+        "name": "DEV",
+        "url": "https://dev.to/settings/account",
+        "difficulty": "easy",
+        "notes": "Go to your 'Settings'. On the left select 'Account'. You can 'Remove OAuth Associations' and 'Request Account Deletion', the latter via email.",
+        "domains": [
+            "dev.to"
+        ]
+    },
+
+    {
+        "name": "DeviantArt",
+        "url": "https://www.deviantart.com/settings/deactivation",
+        "difficulty": "medium",
+        "notes": "All your data is ereased immediately, except comments which will remain. Accounts can be reactivated within 30 days. After that, Accounts can't be reactivated.",
+        "notes_fr": "Toutes vos données seront effacées immédiatement. Les comptes peuvent être réactivés pour 30 jours. Après ce periode, ils ne peuvent pas être réactivés.",
+        "notes_de": "Alle Daten sind sofort gelöscht. Accounts können innerhalb von 30 Tagen reaktiviert werden. Nach dieser Zeitspanne können sie nicht mehr wiederhergestellt werden.",
+        "notes_it": "Tutti i dati saranno immediatamente cancellati. L'account potrà essere riattivato entro 30 giorni, dopodichè non sarà piu recuperabile.",
+        "notes_pt_br": "Todos os dados são apagados imediatamente. Contas podem ser reativadas em até 30 dias, após este prazo não poderão mais ser recuperadas.",
+        "notes_cat": "Totes les seves dades son esborrades inmediatament. Els comptes poden ser reactivats abans de 30 dies, després d'aquest termini no podrà ser reactivat.",
+        "notes_es": "Todos tus datos son borrados inmediatamente. Todas las cuentas pueden ser reactivadas antes de 30 días, después de ese plazo no podrá ser recuperada.",
+        "notes_pl": "Wszystkie Twoje dane zostana natychmiast usunięte. Jeśli zmienisz zdanie, możesz reaktywować swoje konto w ciągu 30 dni.",
+        "domains": [
+            "deviantart.com"
+        ]
+    },
+
+    {
+        "name": "DHL (Paket.de)",
+        "url": "https://www.paket.de/pkp/appmanager/pkp/desktop?_nfpb=true&_nfxr=false&_pageLabel=pkp_portal_page_footer_cah_faqs",
+        "difficulty": "impossible",
+        "notes": "There's no information about account-deletion in their FAQ. The hotline also says that account-deletion isn't possible.",
+        "notes_fr": "Il n'y a pas d'informations sur la suppresion des comptes dans le FAQ. La ligne directe dit aussi qu'il n'est pas possible de le faire.",
+        "notes_de": "Keine Informationen in den FAQ über Account-Löschung. Der Mitarbeiter an der Hotline bestätigte, dass die Löschung nicht möglich ist.",
+        "notes_it": "Nessuna informazione nelle FAQ riguardo la cancellazione dell'account, l'operatore al telefono ha confermato che la cancellazione non è possibile.",
+        "notes_pt_br": "Nenhuma informação no FAQ sobre remoção de contas, o operador no telefone disse que deletar não é possível.",
+        "notes_cat": "No hi ha cap informació al FAQ sobre la cancel·lació de comptes, l'operador telefonic diu que no es poden esborrar els comptes.",
+        "notes_es": "No hay información en el FAQ sobre la cancelación de cuentas, el operador telefónico dice que no se pueden borrar las cuentas.",
+        "domains": [
+            "paket.de"
+        ]
+    },
+
+    {
+        "name": "diasp.eu (Diaspora)",
+        "url": "https://diasp.eu/user/edit#close_account_pane",
+        "difficulty": "easy",
+        "notes": "Click close my account and confirm with your password.",
+        "notes_fr": "Cliquez sur fermez mon compte et confirmer avec votre mot de passe.",
+        "notes_it": "Clicca chiudi il mio account e conferma inserendo la tua password.",
+        "notes_de": "Klicke auf 'close my account' und bestätige dies mit deinem Passwort.",
+        "notes_pt_br": "Clique em 'close my account' e confirme com sua senha.",
+        "notes_cat": "Cliqui a 'close my account' i confirmi-ho amb la seva contrasenya.",
+        "notes_es": "Haz clic en 'close my account' y confirmelo con tu contraseña.",
+        "notes_pl": "Kliknij 'close my account' i potwierdź podając swoje hasło.",
+        "domains": [
+            "diasp.eu"
+        ]
+    },
+
+    {
+        "name": "Dice",
+        "url": "https://www.dice.com/dashboard/settings",
+        "difficulty": "easy",
+        "notes": "Go to your 'Settings'. Scroll to the bottom to find the 'Delete Account' section.",
+        "domains": [
+            "dice.com"
+        ]
+    },
+
+    {
+        "name": "dict.cc",
+        "url": "http://users.dict.cc/my-account/close-account",
+        "difficulty": "easy",
+        "notes": "Account data will be deleted; the user name will be blocked to prevent reuse.",
+        "domains": [
+            "dict.cc"
+        ]
+    },
+
+    {
+        "name": "Digg",
+        "url": "http://digg.com/contact",
+        "difficulty": "hard",
+        "notes": "Contact Digg’s customer support and request for your account to be closed.",
+        "notes_fr": "Contactez le support Digg et demandez la suppresion du compte.",
+        "notes_it": "Contatta il servizio clienti e richiedi che il tuo account sia chiuso.",
+        "notes_de": "Kontaktiere Digg's Kundensupport und beantrage die Löschung deines Accounts.",
+        "notes_pt_br": "Contate a assistência ao cliente da Digg e peça que sua conta seja fechada.",
+        "notes_cat": "Contacti amb l'assistència al client de Digg i demani que es clausuri el seu compte.",
+        "notes_es": "Contacta con asistencia al cliente de Digg y pide que se clausure tu cuenta.",
+        "notes_pl": "Skontaktuj się z obsługą techniczną i poproś o usunięcie swojego konta",
+        "domains": [
+            "digg.com"
+        ]
+    },
+
+    {
+        "name": "DigitalOcean",
+        "url": "https://cloud.digitalocean.com/settings/account",
+        "difficulty": "easy",
+        "notes": "Check the \"Deactivate Account\" box in the settings.",
+        "notes_pl": "Zaznacz pole \"Deactivate Account\" w ustawieniach.",
+        "domains": [
+            "digitalocean.com"
+        ]
+    },
+
+    {
+        "name": "Diigo",
+        "url": "https://www.diigo.com/",
+        "difficulty": "easy",
+        "domains": [
+            "diigo.com"
+        ]
+    },
+
+    {
+        "name": "Discogs",
+        "url": "http://www.discogs.com/users/delete",
+        "difficulty": "easy",
+        "domains": [
+            "discogs.com"
+        ]
+    },
+
+    {
+        "name": "Discord",
+        "url": "https://support.discordapp.com/hc/en-us/articles/212500837-How-do-I-permanently-delete-my-account-",
+        "difficulty": "easy",
+        "notes": "If you're a server owner, you'll need to either <a href=\"https://support.discordapp.com/hc/en-us/articles/213595197-How-do-I-delete-a-server-\">delete the server</a>, or <a href=\"https://support.discordapp.com/hc/en-us/articles/216273938-How-do-I-transfer-server-ownership-\">transfer ownership</a> for account deletion to succeed.",
+        "domains": [
+            "discordapp.com"
+        ]
+    },
+
+    {
+        "name": "Discshop.fi",
+        "url": "https://www.discshop.fi/ota_yhteytta",
+        "difficulty": "hard",
+        "notes": "Contact Discshop.fi's customer support and request for your account to be closed.",
+        "domains": [
+            "discshop.fi"
+        ]
+    },
+
+    {
+        "name": "Disney Movies Anywhere",
+        "url": "https://www.disneymoviesanywhere.com/setting/account/device-management",
+        "difficulty": "easy",
+        "notes": "Log into your account, go to the settings page, click on 'Profile', scroll to the bottom, click 'Delete Account', and 'Yes, delete this account'.",
+        "domains": [
+            "disneymoviesanywhere.com"
+        ]
+    },
+
+    {
+        "name": "Disqus",
+        "url": "https://disqus.com/home/settings/account/",
+        "difficulty": "easy",
+        "domains": [
+            "disqus.com"
+        ]
+    },
+
+    {
+        "name": "DNSimple",
+        "url": "https://dnsimple.com/user/cancellation",
+        "difficulty": "easy",
+        "domains": [
+            "dnsimple.com"
+        ]
+    },
+
+    {
+        "name": "Dock.io",
+        "url": "https://app.dock.io/settings",
+        "notes": "Log in, go to settings and click 'Delete my account'. Confirm by clicking 'Yes, delete my account'.",
+        "difficulty": "easy",
+        "domains": [
+            "dock.io"
+        ]
+    },
+
+    {
+        "name": "DocuSign",
+        "url": "https://support.docusign.com/en/articles/How-do-I-cancel-or-downgrade-my-account#steps",
+        "notes": "Follow the instructions at the linked support page; directions vary depending on account type and privileges.",
+        "difficulty": "hard",
+        "domains": [
+            "docusign.com"
+        ]
+    },
+
+    {
+        "name": "Doodle",
+        "url": "https://doodle.com/account",
+        "difficulty": "easy",
+        "notes": "In your Doodle account select 'Delete Doodle account' at the bottom of the page.",
+        "notes_de": "Wähle 'Doodle Konto löschen' unten in den Konto-Einstellungen.",
+        "domains": [
+            "doodle.com"
+        ]
+    },
+
+    {
+        "name": "Douban",
+        "url": "http://www.douban.com/accounts/suicide/",
+        "difficulty": "easy",
+        "domains": [
+            "douban.com"
+        ]
+    },
+
+    {
+        "name": "DOWN",
+        "url": "https://www.downapp.com/settings",
+        "difficulty": "easy",
+        "domains": [
+            "downapp.com"
+        ],
+        "notes": "You can delete it in the settings page",
+        "email": "feedback@downapp.com"
+    },
+
+    {
+        "name": "Draft",
+        "url": "https://draftin.com/draft/users/edit",
+        "difficulty": "easy",
+        "domains": [
+            "draftin.com"
+        ]
+    },
+
+    {
+        "name": "Dragdis",
+        "url": "https://dragdis.com/Account/Settings/remove",
+        "difficulty": "easy",
+        "notes": "Enter a reason for leaving the service and then click on 'Delete account'.",
+        "domains": [
+            "dragdis.com"
+        ]
+    },
+
+    {
+        "name": "Dreamwidth",
+        "url": "https://www.dreamwidth.org/accountstatus",
+        "difficulty": "medium",
+        "notes": "Changing your account status to Deleted will immediately hide your profile and journal from other users, but your account will not be removed for 30 days.",
+        "domains": [
+            "dreamwidth.org"
+        ]
+    },
+
+    {
+        "name": "Dribbble",
+        "url": "http://dribbble.com/account",
+        "difficulty": "easy",
+        "domains": [
+            "dribbble.com"
+        ]
+    },
+
+    {
+        "name": "Drone.io",
+        "url": "https://drone.io/admin",
+        "difficulty": "easy",
+        "domains": [
+            "drone.io"
+        ]
+    },
+
+    {
+        "name": "Dronebase",
+        "url": "https://dronebase.com/contact",
+        "difficulty": "hard",
+        "notes": "Contact support to find out if you can delete your account.",
+        "domains": [
+            "dronebase.com"
+        ]
+    },
+
+    {
+        "name": "Dropbox",
+        "url": "https://www.dropbox.com/account/delete",
+        "difficulty": "easy",
+        "domains": [
+            "dropbox.com"
+        ]
+    },
+
+    {
+        "name": "Droplr",
+        "url": "https://d.pr/account",
+        "difficulty": "easy",
+        "domains": [
+            "droplr.com",
+            "d.pr"
+        ]
+    },
+
+    {
+        "name": "Dropmark",
+        "url": "https://support.dropmark.com/article/92-how-do-i-delete-my-account",
+        "difficulty": "medium",
+        "notes": "Personal accounts can be deleted from the \"Danger Zone\" section at the bottom of your <a href=\"https://app.dropmark.com/account\">Account page</a>. Note: Before deleting your personal account, you must first <a href=\"https://support.dropmark.com/article/53-transferring-collection-ownership\">transfer ownership</a> or <a href=\"https://support.dropmark.com/article/20-deleting-a-collection\">delete all collections</a> owned by your account.",
+        "domains": [
+            "dropmark.com"
+        ]
+    },
+
+    {
+        "name": "Duolingo",
+        "url": "http://www.duolingo.com/settings/deactivate",
+        "difficulty": "easy",
+        "domains": [
+            "duolingo.com"
+        ]
+    },
+
+    {
+        "name": "Dwell",
+        "url": "https://dwell.co.uk/contactus.php",
+        "difficulty": "impossible",
+        "notes": "It’s not possible to delete an account, you can either remove or replace your contact information with bogus details.",
+        "domains": [
+            "dwell.co.uk"
+        ]
+    },
+
+    {
+        "name": "Dwolla",
+        "url": "http://www.dwolla.com/deactivate",
+        "difficulty": "hard",
+        "notes": "All accounts stay in their system for at least 3 years. Remove any banking information before you delete.",
+        "notes_fr": "Tous les comptes restent dans le système pour 3 ans au moins. Enlevez toutes les informations bancaires avant la suppression.",
+        "notes_de": "Alle Accounts bleiben 3 Tage lang in ihrem System. Lösche alle Bank-Informationen bevor du deinen Account löschst.",
+        "notes_it": "Tutti gli account rimangono nei loro sistemi per almeno 3 anni. Rimuovi qualsiasi credenziale bancaria prima di cancellarti.",
+        "notes_pt_br": "Todas as contas permanecem no sistema por pelo menos 3 anos. Remova qualquer informação de bancos antes de deletar.",
+        "notes_cat": "Tots els comptes romandran al sistema durant 3 anys. Esborri qualsevol informació bancaria abans de suprimir el compte.",
+        "notes_es": "Todas las cuentas permanecerán en el sistema durante 3 años. Borra toda información bancaria antes de eliminar tu cuenta.",
+        "domains": [
+            "dwolla.com"
+        ]
+    },
+
+    {
+        "name": "DynDNS",
+        "url": "https://account.dyn.com/profile/close.html",
+        "difficulty": "easy"
+    },
+
+    {
+        "name": "EA Origin",
+        "url": "https://help.ea.com/en/contact-us/",
+        "difficulty": "hard",
+        "notes": "Contact customer services to request deletion. If you're outside the US this must be by phone.",
+        "notes_fr": "Contactez le support pour demander la suppression du compte. Si vous n'êtes pas americain cela se fait par téléphone.",
+        "notes_it": "Contatta il sistema clienti per cancellarti. Se sei fuori dagli Stati Uniti questa azione va effettuata via telefono.",
+        "notes_de": "Kontaktiere den Support um die Löschung zu beantragen. Wenn du außerhalb der USA bist, muss dies per Telefon geschehen.",
+        "notes_pt_br": "Contate a assistência ao cliente e peça que sua conta seja deletada. Se você estiver fora dos EUA você deve fazer isso pelo telefone.",
+        "notes_cat": "Contacti amb assistència al client i demani que es clausuri el seu compte. Si vius fora dels EEUU ho hauràs de fer per telèfon.",
+        "notes_es": "Contacta con asistencia al cliente y pide que se cierre tu cuenta. Si vives fuera de EEUU deberás hacerlo por teléfono.",
+        "notes_pl": "Skontaktuj się z obsługą techniczną i poproś o usunięcie konta.",
+        "domains": [
+            "ea.com"
+        ]
+    },
+
+    {
+        "name": "easyJet",
+        "url": "https://www.easyjet.com/en/policy/privacy-promise/request-data-form",
+        "difficulty": "hard",
+        "notes": "You have to fill out the Data protection request form on their website, providing your identification.",
+        "domains": [
+            "easyjet.com"
+        ]
+    },
+
+    {
+        "name": "EATags",
+        "url": "https://eatags.com/account/profile",
+        "difficulty": "easy",
+        "notes": "Click on the 'Unregister' button near the bottom of the page. Enter password and click on 'Delete account'.",
+        "domains": [
+            "eatags.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "eBay",
+        "url": "http://cgi1.ebay.com/ws/eBayISAPI.dll?CloseAccount",
+        "difficulty": "easy",
+        "notes": "A few survey questions will be asked prior to account deletion.",
+        "notes_fr": "Quelques questions d'opinion sera demandées avant la suppression du compte.",
+        "notes_de": "Ein paar Fragen werden dir vor dem Löschen gestellt.",
+        "notes_it": "Ti sarà chiesto di compilare qualche questionario prima che l'account sia eliminato",
+        "notes_pt_br": "Algumas perguntas serão feitas antes de deletar sua conta.",
+        "notes_cat": "Se li farà un petit qüestionari abans desborrar el compte.",
+        "notes_es": "Se le hará un pequeño cuestionario antes de borrar la cuenta.",
+        "domains": [
+            "ebay.com"
+        ]
+    },
+
+    {
+        "name": "ebonus",
+        "url": "https://ebonus.gg/contact",
+        "difficulty": "hard",
+        "notes": "After submitting a contact form, they will ask for confirmation using email. After confirmation, account deletion takes 30 days.",
+        "domains": [
+            "ebonus.gg"
+        ]
+    },
+
+    {
+        "name": "eddb",
+        "url": "https://eddb.io/contact",
+        "difficulty": "hard",
+        "notes": "Request deletion in the contact form",
+        "domains": [
+            "eddb.io"
+        ]
+    },
+
+    {
+        "name": "Edpuzzle",
+        "url": "https://edpuzzle.com",
+        "difficulty": "hard",
+        "notes": "click on the contrat popup on the bottom of the screen and fill out the form, an admin will email asking for your username and will then delete it"
+    },
+
+    {
+        "name": "eDreams",
+        "url": "http://www.edreams.com/edreams/english/about/copyright.jhtml",
+        "difficulty": "impossible",
+        "notes": "FAQ states that account can be deleted upon request, but e-mails requesting it are completely ignored.",
+        "notes_pt_br": "FAQ diz que a conta pode ser deletada mediante requisição, mas e-mails que requerem isso são sumariamente ignorados.",
+        "domains": [
+            "edreams.co.uk",
+            "edreams.net",
+            "edreams.pt"
+        ]
+    },
+
+    {
+        "name": "EdX",
+        "url": "https://www.edx.org/student-faq",
+        "difficulty": "impossible",
+        "notes": "There's no need to delete your account. An old, unused edX account with no course completions associated with it will disappear.",
+        "notes_fr": "Il ne faut pas supprimer votre compte. Un compte edX qui n'est pas utilisé et qui n'a pas d'achèvement de cours disparaîtra.",
+        "notes_de": "Es gibt keine Notwendigkeit deinen Account zu löschen. Ein alter, unbenutzter edX Account ohne fertiggestellte Kurse wird automatisch gelöscht.",
+        "notes_it": "Non è necessario cancellare il tuo account. Un vecchio, inusato edX account scomparirà da solo",
+        "notes_pt_br": "Não há porque deletar sua conta. Uma conta antiga, e não usada sem cursos completos irá desaparecer.",
+        "notes_cat": "No té perqué esborrar el seu compte. Un compte antic sens ús ni cursos completats serà eliminat.",
+        "notes_es": "«No hay necesidad de borrar la cuenta. Una cuenta antigua no usada y sin cursos completos será eliminado.»",
+        "domains": [
+            "edx.org"
+        ]
+    },
+
+    {
+        "name": "Elevate",
+        "url": "http://elevateapp.com/",
+        "difficulty": "hard",
+        "notes": "You must send an e-mail to hello@elevateapp.com requesting deletion. You will then receive a response from support asking for feedback and to confirm the deletion. The next e-mail you receive from support will notify you that your account has been deleted.",
+        "notes_fr": "Il faut que vous demandez la suppression de votre compte dans un e-mail que vous envoyez à hello@elevateapp.com. Vous recevrez une réponse qui demande à la fois vos impressions de l'appli et une confirmation de la suppression. L'e-mail prochain que vous recevrez vous notifiera la suppression de votre compte.",
+        "email": "hello@elevateapp.com",
+        "domains": [
+            "elevateapp.com"
+        ]
+    },
+
+    {
+        "name": "Ello",
+        "url": "https://ello.co/wtf/help/settings/",
+        "difficulty": "easy",
+        "notes": "Quoted from Ello: Go to your Settings page and click the “Delete Account” link. Once you delete your account neither you, nor we, can recover it. Also note that your username may become available for another person to use.",
+        "notes_de": "Zitiert von Ello: Besuchen Sie Ihre Einstellungen und klicken Sie auf “Konto löschen“. Sobald Ihr Konto gelöscht ist, können weder Sie, noch wir ihn wiederherstellen. Beachten Sie auch, dass Ihr Nutzername möglicherweise für eine andere Person verfügbar sein wird.",
+        "domains": [
+            "ello.co"
+        ]
+    },
+
+    {
+        "name": "Elpais",
+        "url": "https://registro.elpais.com.uy/regasistencia.asp",
+        "difficulty": "hard",
+        "notes": "Complete the form, they will send you an email where you must respond indicating the identity document.",
+        "notes_es": "Complete el formulario, le enviarán un correo electrónico donde deberá responder indicando el documento de identidad.",
+        "domains": [
+            "elpais.com.uy"
+        ]
+    },
+
+    {
+        "name": "Endomondo",
+        "url": "https://www.endomondo.com/settings/privacy",
+        "difficulty": "easy",
+        "notes": "Select 'Close Profile' at the bottom of the page, select any reason for closing your profile. After that you have to complete the process by clicking a link in an email sent to you.",
+        "notes_fr": "Selectionnez une raison pour la suppression de votre compte. Puis, vouz pourrez terminer le processus en cliquant sur un lien que vous recevrez par e-mail.",
+        "domains": [
+            "endomondo.com"
+        ]
+    },
+
+    {
+        "name": "Envato",
+        "url": "https://help.market.envato.com/hc/en-us/articles/202500394-How-Do-I-Close-My-Account-",
+        "difficulty": "hard",
+        "notes": "You have to send them a request to delete the account using the contact form.",
+        "domains": [
+            "envato.com",
+            "themeforest.net",
+            "codecanyon.net",
+            "videohive.net",
+            "audiojungle.net",
+            "graphicriver.net",
+            "photodune.net",
+            "3docean.net",
+            "activeden.net"
+        ]
+    },
+
+    {
+        "name": "Epic Games",
+        "url": "https://epicgames.helpshift.com/a/epic-accounts/?s=epic-account-support&f=how-can-i-disable-my-epic-account&l=en&contact=1",
+        "difficulty": "hard",
+        "notes": "Select 'Delete Epic Games Account' from the dropdown in the contact page and submit a request. Support will respond to you in about 5 days asking for confirmation",
+        "domains": [
+            "epicgames.com"
+        ]
+    },
+
+    {
+        "name": "eProject.me",
+        "url": "http://eproject.me",
+        "difficulty": "hard",
+        "notes": "Send an e-mail asking for the deletion.",
+        "email": "services@eproject.me",
+        "domains": [
+            "eproject.me"
+        ]
+    },
+
+    {
+        "name": "eRepublik",
+        "url": "http://www.erepublik.com/en/contact/none/none",
+        "difficulty": "hard",
+        "notes": "Create new Game Support ticket to request account removal.",
+        "domains": [
+            "erepublik.com"
+        ]
+    },
+
+    {
+        "name": "ESPN",
+        "url": "http://www.espn.com",
+        "difficulty": "easy",
+        "notes": "At the bottom of the account settings page there is a Remove Account button",
+        "domains": [
+            "espn.com"
+        ]
+    },
+
+    {
+        "name": "eToro",
+        "url": "https://www.etoro.com/settings/account",
+        "difficulty": "easy",
+        "notes": "At the bottom of the page, click the button to close your account, select the reason for your deletion and continue to confirm it.",
+        "domains": [
+            "etoro.com"
+        ]
+    },
+
+    {
+        "name": "Etsy",
+        "url": "http://www.etsy.com/help/article/53",
+        "difficulty": "hard",
+        "notes": "You have to contact Etsy. As they've stated, \"when a member closes an account, it becomes inaccessible and will remain deactivated, unless the member requests it reopened. Account information remains securely on file with them, and Etsy has a detailed Privacy Policy that explains how we use members' information. This policy includes a statement regarding data retention.\"",
+        "notes_fr": "Vous devez contactez Etsy. Lorsqu'un membre ferme un compte, il devient inaccessible et reste désactivé, à moins que le membre demande sa réouverture. Les informations du compte restent conservées de manière sécuritsée, et Etsy a une politique de confidentialité détaillée expliquant comment ils utilisent les informations des membres. Cette politique inclut une déclaration concernant la conservation des données.",
+        "notes_pt_br": "Tem de contactar o Etsy. Como eles afirmam, quando uma conta é fechada, fica inacessível e desactivada, a menos que o dono da conta a queira reabrir. A informação da conta é guardada pelo Etsy e regulada pela Política de Privacidade. A Política inclui informação sobre retenção de dados.",
+        "domains": [
+            "etsy.com"
+        ]
+    },
+
+    {
+        "name": "Eventbrite",
+        "url": "https://www.eventbrite.com/account-close",
+        "difficulty": "easy",
+        "domains": [
+            "eventbrite.com"
+        ]
+    },
+
+    {
+        "name": "Eventful",
+        "url": "http://support.eventful.com/entries/25351895-How-do-I-cancel-delete-my-account-",
+        "difficulty": "hard",
+        "notes": "Contact support and they will delete your account",
+        "domains": [
+            "eventful.com"
+        ]
+    },
+
+    {
+        "name": "Evernote",
+        "url": "https://www.evernote.com/Deactivate.action",
+        "difficulty": "impossible",
+        "notes": "You cannot delete your Evernote account, just deactivate it temporarily. Deactivation does not remove your data so you will have to manually delete all notes and personal info, perform a sync and then deactivate the account.",
+        "notes_fr": "Vous ne pouvez pas supprimer votre compte Evernote, seulement le désactiver temporairement. La désactivation ne supprime pas vos données donc vous devrez les supprimer manuellement avant de syncroniser, puis vous pourrez réaliser la désactivation du compte.",
+        "notes_it": "Non puoi eliminare il tuo account Evernote, solo disattivarlo temporaneamente. La disattivazione non cancella nessuno dei tuoi dati quindi dovrai cancellarli manualmente prima di effettuare la disattivazione.",
+        "notes_de": "Du kannst deinen Evernote-Account nicht löschen, du kannst ihn nur temporär deaktivieren. Deaktivierung löscht nicht deine Daten, deshalb musst du manuell jede Notiz und persönliche Information löschen. Schließe dann eine Synchronisation ab und deaktiviere deinen Account dann.",
+        "notes_pt_br": "Você não pode deletar sua conta Evernote, apenas desativá-la temporariamente. Desativação não remove seus dados então você terá que remover manualmente todas suas informações, realizar uma sincronização e então desativar sua conta.",
+        "notes_cat": "No pot eliminar un compte d'Evernote, només pot desactivar-la temporalment. La desactivaciò no esborra les seves dades, ho haurà de fer manualment, després sincronitzar i desactivar.",
+        "notes_es": "No puedes eliminar una cuenta de Evernote, solo puedes desactivarla temporalmente. La desactivación no borra tus datos, lo deberás hacer a mano, y después sincronizalo y desactivalo.",
+        "notes_pl": "Nie możesz usunąć konta tylko je tymczasowo zdeaktywować. Deaktywacja nie usuwa żadnych danych - należy to zrobić samemu.",
+        "domains": [
+            "evernote.com"
+        ]
+    },
+
+    {
+        "name": "Experian",
+        "url": "https://www.experiandirect.com/triplealert/Message.aspx?PageTypeID=FAQ&WT.svl=faq&SiteVersionID=473&SiteID=100173&sc=657900&bcd=",
+        "difficulty": "hard",
+        "notes": "You have to call or email them. They respond to email quickly, however, so it is not that painful.",
+        "email": "support@experiandirect.com"
+    },
+
+    {
+        "meta": "popular",
+        "name": "Facebook",
+        "url": "https://www.facebook.com/help/delete_account?rdrhc",
+        "difficulty": "medium",
+        "notes": "While you can delete your account easily, some of the data including messages, are there to stay forever, just as stated in the website's privacy policy.",
+        "notes_fr": "Bien que vous puissiez supprimer votre compte facilement, quelques données y compris les messages restent pour jamais, comme déclaré dans le politique de confidentialité.",
+        "notes_it": "Mentre puoi eliminare il tuo account facilmente, qualche dato come le chat o i messaggi di gruppo rimarranno nei loro database, come scritto sul loro sito nella pagina Privacy",
+        "notes_de": "Während du deinen Account leicht löschen kannst, bleiben einige deiner Daten dauerhaft. z.B. Chat- und Gruppennachrichten. Dies ist so in den Datenschutzbestimmungen bestimmt.",
+        "notes_pt_br": "Você pode deletar sua conta facilmente, porém dados de conversas ficarão armazenados para sempre, como explicitado na Privacidade do site.",
+        "notes_cat": "Pot esborrar el compte facilment, algunes dades com el chat o missatges en grup son guardades per sempre, com s'explica als termes de privacitat del lloc.",
+        "notes_es": "Aunque puedes borrar la cuenta facilmente, algunos de los datos como el chat o mensajes en grupo son guardados para siempre, como se explica en los Terminos de privacidad del sitio.",
+        "notes_pl": "Możesz usunąć swoje konto, ale zgodnie z polityką prywatności wszystkie dane razem z wiadomościami zostaną w bazie danych na zawsze.",
+        "domains": [
+            "facebook.com"
+        ]
+    },
+
+    {
+        "name": "Facebook Messenger",
+        "url": "https://www.messenger.com",
+        "difficulty": "impossible",
+        "notes": "If you logged in with your Facebook account, you can just delete that account. If you registered using your phone number, there's no way to delete your account",
+        "notes_es": "Si iniciaste sesión con tu cuenta de Facebook, podés borrar esa cuenta. Si te registraste con tu número de celular, no hay forma de eliminar tu cuenta"
+    },
+
+    {
+        "name": "Faceit",
+        "url": "https://support.faceit.com/hc/en-us/requests/new",
+        "difficulty": "hard",
+        "notes": "See <a href=\"https://support.faceit.com/hc/en-us/articles/360001449004-How-do-I-get-my-personal-details-deleted-on-FACEIT-\">'How do I get my personal details deleted on FACEIT?'</a>",
+        "domains": [
+            "faceit.com"
+        ]
+    },
+
+    {
+        "name": "Facile.it",
+        "url": "https://www.facile.it/cancellazione/",
+        "difficulty": "easy",
+        "domains": [
+            "facile.it"
+        ]
+    },
+
+    {
+        "name": "Fandom Wikia",
+        "url": "http://community.wikia.com/wiki/Special:CloseMyAccount",
+        "difficulty": "medium",
+        "notes": "Click on 'Close my account'. Disables the account but cannot delete user data completely. Retains user contributions and username is not released.",
+        "domains": [
+            "fandom.wikia.com"
+        ]
+    },
+
+    {
+        "name": "FanFiction",
+        "url": "https://www.fanfiction.net/",
+        "difficulty": "impossible",
+        "domains": [
+            "fanfiction.net"
+        ]
+    },
+
+    {
+        "name": "FaucetHub",
+        "url": "https://faucethub.io/dashboard/security/deleteaccount",
+        "difficulty": "easy",
+        "domains": [
+            "faucethub.io"
+        ]
+    },
+
+    {
+        "name": "Feedly",
+        "url": "https://feedly.com/#erase",
+        "difficulty": "easy",
+        "notes": "Log in and click the 'Delete Account' button.",
+        "notes_de": "Melde dich an und klicke auf den 'Account löschen' Button.",
+        "domains": [
+            "feedly.com"
+        ]
+    },
+
+    {
+        "name": "Finanzblick",
+        "url": "https://finanzblick.de/webapp",
+        "difficulty": "medium",
+        "notes": "Click on your username (top left) → click on 'Profileinstellungen' → 'Account löschen'. All data is fully erased.",
+        "notes_it": "Clicca sul tuo username (in alto a sinistra) → clicca su 'Profileinstellungen' → 'Account löschen'. Tutti i dati saranno cancellati.",
+        "notes_de": "Klicke auf deinen username (oben rechts) → klicke auf 'Profileinstellungen' → 'Account löschen'. Alle Daten sind augenblicklich gelöscht.",
+        "notes_pt_br": "Clique em seu usuário (topo esquerdo) → clique em 'Profileinstellungen' → 'Account löschen'. Todos os seus dados serão completamente apagados.",
+        "notes_cat": "Cliqui al seu usuari (adalt esquerra) → cliqui a 'Profileinstellungen' → 'Account löschen'. Totes les seves dades seràn eliminades.",
+        "notes_es": "Haz clic en tu usuario (arriba a la izquierda) → haz clic en 'Profileinstellungen' → 'Account löschen'. Todos tus datos serán eliminados.",
+        "domains": [
+            "finanzblick.de"
+        ]
+    },
+
+    {
+        "name": "Fitbit",
+        "url": "https://help.fitbit.com/articles/en_US/Help_article/1285/",
+        "difficulty": "hard",
+        "notes": "From the mobile app, tap the Account icon and select 'Manage Data' and then 'Delete Account'. Contact Customer Support (phone, chat, or Twitter) if you do not have access to the app.",
+        "domains": [
+            "fitbit.com"
+        ]
+    },
+
+    {
+        "name": "Fitocracy",
+        "url": "https://www.fitocracy.com/account/deletion/",
+        "difficulty": "easy",
+        "domains": [
+            "fitocracy.com"
+        ]
+    },
+
+    {
+        "name": "Flattr",
+        "url": "https://flattr.com/deleteaccount",
+        "difficulty": "easy",
+        "domains": [
+            "flattr.com"
+        ]
+    },
+
+    {
+        "name": "Flickr",
+        "url": "http://www.flickr.com/profile_delete.gne",
+        "difficulty": "easy",
+        "domains": [
+            "flickr.com"
+        ]
+    },
+
+    {
+        "name": "Flipboard",
+        "url": "https://accounts.flipboard.com/accounts/remove",
+        "difficulty": "easy",
+        "domains": [
+            "flipboard.com"
+        ]
+    },
+
+    {
+        "name": "Flixster",
+        "url": "https://www.flixster.com",
+        "difficulty": "hard",
+        "notes": "Email privacy@flixster-inc.com and ask to have your account deleted.",
+        "email": "privacy@flixster-inc.com",
+        "domains": [
+            "flixster.com"
+        ]
+    },
+
+    {
+        "name": "Foap",
+        "url": "https://www.foap.com/pages/contact",
+        "difficulty": "hard",
+        "notes": "Account deletion requires contacting customer support.",
+        "domains": [
+            "foap.com"
+        ]
+    },
+
+    {
+        "name": "FogBugz",
+        "url": "https://www.fogcreek.com/fogbugz/",
+        "difficulty": "easy",
+        "notes": "On the top right corner, click 'Admin' then 'Your On Demand Account' and search for the close account button at the bottom right. It is not really deleted, just closed.",
+        "domains": [
+            "fogbugz.com"
+        ]
+    },
+
+    {
+        "name": "Foodspotting",
+        "url": "http://www.foodspotting.com/settings",
+        "difficulty": "medium",
+        "notes": "Account can only be disabled, not deleted.",
+        "domains": [
+            "foodspotting.com"
+        ]
+    },
+
+    {
+        "name": "Fotka",
+        "url": "http://www.fotka.pl/ustawienia/konto_usun",
+        "difficulty": "medium",
+        "notes": "To delete your account, you must not post anything for at least three days.",
+        "notes_fr": "Pour supprimer votre compte, ne postez rien pendant 3 jours.",
+        "notes_it": "Per eliminare il tuo account, non devi pubblicare niente per almeno tre giorni.",
+        "notes_de": "Um deinen Account zu löschen, schreibe nichts für mindestens drei Tage.",
+        "notes_pt_br": "Para deletar sua conta, você deve postar nada por pelo menos três dias.",
+        "notes_pl": "Aby usunąć swoje konto, nie możesz dodawać żadnych treści przez co najmniej trzy dni.",
+        "notes_cat": "Per esborrar el seu compte no ha de pujar res en 3 dies.",
+        "notes_es": "Para borrar tu cuenta no debes subir nada por lo menos 3 días."
+    },
+
+    {
+        "meta": "popular",
+        "name": "Foursquare",
+        "url": "https://foursquare.com/delete_me",
+        "difficulty": "easy",
+        "domains": [
+            "foursquare.com"
+        ]
+    },
+
+    {
+        "name": "FreeCodeCamp",
+        "url": "https://www.freecodecamp.org/settings",
+        "difficulty": "easy",
+        "notes": "You'll need to access your account settings; it's under a section labeled Danger Zone",
+        "domains": [
+            "freecodecamp.org"
+        ]
+    },
+
+    {
+        "name": "Freelancer",
+        "url": "http://www.freelancer.com/report/contact.php",
+        "difficulty": "hard",
+        "notes": "Make sure your account balance is positive, then issue a support ticket requesting to close your account.",
+        "notes_fr": "Vous assurez que votre solde est positif, puis créez un ticket de support pour demander la suppression de votre compte.",
+        "notes_de": "Stelle sicher, dass der Kontostand positiv ist, dann erstelle ein Support-Ticket um deinen Account zur Löschung zu beantragen.",
+        "notes_it": "Assicurati che il saldo sia positivo, quindi apri un ticket di supporto per chiudere il tuo account.",
+        "notes_pt_br": "Certifique-se de que seu balanço é positivo, então crie um ticket no suporte pedindo que sua conta seja fechada",
+        "notes_cat": "Fixa't si el balanç del compte es positiu, si ho és envía un 'ticket' a l'assistencia demanant que tanquin el seu compte",
+        "notes_es": "Asegurarte de que el saldo de tu cuenta es positivo, y después los envía un tiquet a la asistencia pidiendo que cierren tu cuenta.",
+        "domains": [
+            "freelancer.com"
+        ]
+    },
+
+    {
+        "name": "Freeletics",
+        "url": "https://www.freeletics.com/en/settings/account",
+        "difficulty": "medium",
+        "notes": "After choosing to delete your account, a confirmation e-mail will be sent with a link you must visit.",
+        "domains": [
+            "freeletics.com"
+        ]
+    },
+
+    {
+        "name": "Freesound",
+        "url": "http://www.freesound.org/home/delete/",
+        "difficulty": "medium",
+        "notes": "You cannot delete your account yourself if you have sounds uploaded to your account. In their own words: \"Because you have sounds on freesound, deleting your user is not a trivial task. As such, we ask you to please <a href=\"http://www.freesound.org/contact/\">contact the administrators via the Contact Form</a>. They will help you with the deletion of your account....\". Alternatively - you can go through all your sounds, delete them one-by-one, and then delete your account.",
+        "domains": [
+            "freesound.org"
+        ]
+    },
+
+    {
+        "name": "Freshdesk",
+        "url": "https://freshdesk.com/",
+        "difficulty": "easy",
+        "notes": "On the top tab, click 'Admin' then 'Account', at the bottom, and search for the 'cancel my account' on the right. It is not really deleted, just closed.",
+        "domains": [
+            "freshdesk.com"
+        ]
+    },
+
+    {
+        "name": "Fruux",
+        "url": "https://fruux.com/account/login/",
+        "difficulty": "easy",
+        "notes": "You will need to go to Account setting and click delete account",
+        "domains": [
+            "fruux.com"
+        ]
+    },
+
+    {
+        "name": "Gadu-Gadu",
+        "url": "http://www.gg.pl/pomoc/ustawienia-moje-konto-profil/",
+        "difficulty": "easy",
+        "notes": "You will find option to remove your account under Profile - My Account tab, after log in. Removed GG account number is going back to available numbers for new users.",
+        "notes_pl": "Po zalogowaniu się do konta w zakładce Moje konto - Profil znajduje się opcja usuń konto. Usunięty numer GG wraca do puli numerów dostępnych dla nowych użytkowników.",
+        "domains": [
+            "www.gg.pl"
+        ]
+    },
+
+    {
+        "name": "Gamehag",
+        "url": "https://www.gamehag.com",
+        "difficulty": "hard",
+        "email": "support@gamehag.com",
+        "notes": "Account deletion requires contacting Customer Support.",
+        "notes_fr": "Pour supprimer votre compte contactez le support.",
+        "notes_it": "La cancellazione account richiede di contattare il servizio clienti.",
+        "domains": [
+            "gamehag.com"
+        ]
+    },
+
+    {
+        "name": "Gamespot",
+        "url": "https://www.gamespot.com/help/#toc-0-14",
+        "difficulty": "hard",
+        "email": "support@gamespot.com",
+        "notes": "Account deletion requires contacting Customer Support.",
+        "notes_fr": "Pour supprimer votre compte contactez le support.",
+        "notes_it": "La cancellazione account richiede di contattare il servizio clienti.",
+        "notes_de": "Account-Löschung erfordert es den Kundensupport zu kontaktieren",
+        "notes_pt_br": "Para deletar a sua conta contate a assistência ao cliente",
+        "notes_cat": "Per esborrar el seu compte contacti amb l'assistència al client",
+        "notes_es": "Para borrar tu cuenta contacta con asistencia al cliente",
+        "domains": [
+            "custhelp.com"
+        ]
+    },
+
+    {
+        "name": "Garena",
+        "url": "https://www.garena.sg/support/",
+        "difficulty": "hard",
+        "notes": "Accounts are deleted with 6 months of inactivity or by opening a ticket to their support team.",
+        "domains": [
+            "garena.sg"
+        ]
+    },
+
+    {
+        "name": "Gauges",
+        "url": "http://get.gaug.es/tos/",
+        "difficulty": "hard",
+        "notes": "Contact support and request they delete your account.",
+        "notes_fr": "Contactez le support et demandez la suppression de vore compte.",
+        "notes_it": "Contatta il supporto e richiedi la cancellazione del tuo account.",
+        "notes_de": "Kontaktiere den Support und sie löschen deinen Account.",
+        "notes_pt_br": "Contate o suporte e peça que eles deletem sua conta.",
+        "notes_cat": "Contacti amb l'assistència al client i demani que li esborrrin el compte.",
+        "notes_es": "Contacta con asistencia al cliente y pide que te borren la cuenta.",
+        "domains": [
+            "gaug.es"
+        ]
+    },
+
+    {
+        "name": "Gawker (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_de": "Du solltest aufhören den Service zu nutzen, ohne uns zu informieren. Wir behalten uns vor, dein Inhalt und deine Daten, die du durch unseren Service hochgeladen hast weiterhin zu nutzen.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Pot deixar d'utilitzar el servei en qualsevol moment. Nosaltres, no obstant continuarém fent servir el Contingut que ha enviat.",
+        "notes_es": "«Puedes dejar de utilizar el servicio en cualquier momento. Nosotros, sin embargo continuaremos usando el contenido que has enviado.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "Gearbest",
+        "url": "http://wap-support.gearbest.com/ticket/ticket/ticket-add",
+        "difficulty": "hard",
+        "notes": "You will need to open a ticket. In the first field, select \"Account Management > Advanced Account Information\" and then send your message requesting the deletion of the account. Within 48 hours, the customer support will return your message asking if you confirm the deletion of the account. You can also contact them <a href=\"mailto:support@gearbest.com\">via email</a>.",
+        "notes_pt_br": "Você precisará abrir um ticket. No primeiro campo, selecione \"Account Management > Advanced Account Information\" e em seguida, envie sua mensagem solicitando a exclusão da conta. Em até 48 horas um atendente irá retornar sua mensagem perguntando se você confirma a exclusão da conta. Você também pode contatá-los <a href=\"mailto:support@gearbest.com\">via e-mail</a>.",
+        "domains": [
+            "gearbest.com"
+        ]
+    },
+
+    {
+        "name": "Gemscool",
+        "difficulty": "hard",
+        "notes": "Account is automatically deleted if inactive for a year.",
+        "domains": [
+            "gemscool.com"
+        ]
+    },
+
+    {
+        "name": "Geni",
+        "url": "http://www.geni.com/account_settings",
+        "difficulty": "medium",
+        "notes": "Delete any of the information you would like removed from the site. Then select 'Account Settings' and 'Close Account'",
+        "notes_fr": "Supprimez toutes les informations que vous voulez enlever du site. Puis, cliquer sur « Account Settings » et puis « Close Account ».",
+        "notes_de": "Lösche die Informationen, die du entfernt haben möchtest, von der Seite. Dann wähle 'Account Settings' und 'Close Account'",
+        "notes_it": "Elimina qualsiasi informazione che desideri sia rimossa. Quindi seleziona 'Account Settings' e 'Close Account'",
+        "notes_pt_br": "Delete qualquer informação que você deseja ser removida do site. Então selecione 'Account Settings' e 'Close Account'",
+        "notes_cat": "Elimini qualsevol informació que vulgui que no apareixi al lloc web. Després seleccioni 'Account Settings' i 'Close Account'",
+        "notes_es": "Elimina cualquier información que no quieras que aparezca en el sitio web. Luego selecciona 'Account Settings' y 'Close Account'",
+        "domains": [
+            "geni.com"
+        ]
+    },
+
+    {
+        "name": "Geocaching",
+        "url": "http://support.groundspeak.com/index.php?pg=kb.page&id=102",
+        "difficulty": "impossible",
+        "notes": "Each member ID on Geocaching.com is a historical record in their system and cannot be deleted. Therefore, your account can only be disabled, not be deleted.",
+        "domains": [
+            "geocaching.com",
+            "groundspeak.com"
+        ]
+    },
+
+    {
+        "name": "GetCreditScore",
+        "url": "https://www.getcreditscore.com.au/my-preferences",
+        "difficulty": "easy",
+        "notes": "Select the Delete My Account option on the preferences page and click submit.",
+        "domains": [
+            "getcreditscore.com.au"
+        ]
+    },
+
+    {
+        "name": "GFace",
+        "url": "https://crytek.kayako.com/Tickets/Submit",
+        "difficulty": "hard",
+        "notes": "You can't delete your account without contacting them. You must submit a ticket and set the subject to 'Delete Account'",
+        "notes_de": "Sie können Ihren Account nicht löschen ohne den Support zu kontaktieren. Sie müssen ein Ticket eröffnen und den Betreff auf 'Delete Account' setzen.",
+        "domains": [
+            "gface.com",
+            "crytek.kayako.com"
+        ]
+    },
+
+    {
+        "name": "GHash.IO",
+        "url": "https://support.cex.io/hc/en-us/articles/201516097-How-can-I-delete-my-account-from-CEX-IO-and-GHash-IO-",
+        "email": "support@cex.io",
+        "email_subject": "Delete Account",
+        "difficulty": "hard",
+        "notes": "You can't delete your account without contacting them. You must set the subject to 'Delete Account'",
+        "notes_de": "Sie können Ihren Account nicht löschen ohne den Support zu kontaktieren. Sie müssen den Betreff auf 'Delete Account' setzen.",
+        "domains": [
+            "ghash.io"
+        ]
+    },
+
+    {
+        "name": "Giant Bomb",
+        "url": "https://auth.giantbomb.com/account/",
+        "email": "support@giantbomb.com",
+        "difficulty": "impossible",
+        "notes": "You can't delete your account without contacting support.",
+        "notes_fr": "Il est impossible de supprimer votre compte sans contacter le support.",
+        "domains": [
+            "giantbomb.com"
+        ]
+    },
+
+    {
+        "name": "GitHub",
+        "url": "https://github.com/settings/admin",
+        "difficulty": "easy",
+        "domains": [
+            "github.com"
+        ]
+    },
+
+    {
+        "name": "GitLab",
+        "url": "https://gitlab.com/profile/account",
+        "difficulty": "easy",
+        "notes": "Click on 'Delete account' near the bottom of the page. Some user content will continue to exist anonymously on the website.",
+        "domains": [
+            "gitlab.com"
+        ]
+    },
+
+    {
+        "name": "Gitorious",
+        "url": "https://gitorious.org",
+        "difficulty": "impossible",
+        "notes": "Gitorious is now an archived, read-only copy of the prior code hosting website. Data cannot be altered on this mirror.",
+        "domains": [
+            "gitorious.org"
+        ]
+    },
+
+    {
+        "name": "Gizmodo (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_de": "Du solltest aufhören den Service zu nutzen, ohne uns zu informieren. Wir behalten uns vor, dein Inhalt und deine Daten, die du durch unseren Service hochgeladen hast weiterhin zu nutzen.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Pot parar d'utilitzar el servei en qualsevol moment. Nosaltres seguirem fent servir el Contingut que ha enviat al lloc.",
+        "notes_es": "«Puedes dejar de utilizar el servicio en cualquier momento. Nosotros, sin embargo continuaremos usando el contenido que has enviado.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "Glassboard",
+        "url": "https://glassboard.com",
+        "difficulty": "hard",
+        "notes": "Use the support email address to ask them to close your account.",
+        "notes_fr": "Utilisez l'adresse e-mail du support du site pour les contacter en demandant la suppresion de votre compte.",
+        "notes_de": "Nutze die Support-Mail-Adresse und beantrage die Löschung dort.",
+        "notes_it": "Usa l'email del supporto per richiedere la cancellazione del tuo account.",
+        "notes_pt_br": "Use o e-mail de suporte para pedir que encerrem sua conta.",
+        "notes_cat": "Fagi servir l'e-mail d'assistència al client per demanar que tanquem el seu compte",
+        "notes_es": "Usa el e-mail de asistencia al cliente para pedir que cierren tu cuenta",
+        "email": "support@sepialabs.com",
+        "domains": [
+            "glassboard.com"
+        ]
+    },
+
+    {
+        "name": "Glassdoor",
+        "url": "https://help.glassdoor.com/article/Delete-my-user-account/en_US",
+        "difficulty": "easy",
+        "notes": "Sign in to Glassdoor, click the Glassdoor profile icon in the upper-right-hand side of the page, click Account in the dropdown menu, scroll to the bottom of the page and click Delete Account, and confirm deletion of your account by clicking Delete Account again.",
+        "domains": [
+            "glassdoor.com"
+        ]
+    },
+
+    {
+        "name": "Gmail",
+        "url": "https://myaccount.google.com/deleteservices",
+        "difficulty": "medium",
+        "notes": "Click the trash can next to gmail, enter your new email address, and confirm the verification email",
+        "domains": [
+            "gmail.com",
+            "mail.google.com"
+        ]
+    },
+
+    {
+        "name": "GMX",
+        "url": "http://www.gmx.net/",
+        "difficulty": "easy",
+        "notes": "You can delete your account, by following the steps provided here: 'https://hilfe.gmx.net/account/verwalten/loeschen.html'",
+        "domains": [
+            "gmx.net"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "GoDaddy",
+        "url": "https://www.godaddy.com/help/contact-godaddy-customer-support-20320",
+        "difficulty": "impossible",
+        "notes": "GoDaddy Accounts are apparently retained “to comply with [their] legal obligations” though you are able to clear out most of your information by editing your profile.",
+        "notes_fr": "Les comptes GoDaddy sont guardés « pour satisfaire [leurs] obligations legales ». Cela dit, vous pouvez vider le compte de vos informations en éditant votre profil.",
+        "notes_it": "Gli account GoDaddy sono apparentemente mantenuti per “per rispettare i [loro] obblighi di legge.” ma puoi comunque eliminare la maggior parte delle tue informazioni editando il tuo profilo.",
+        "notes_pt_br": "Contas do GoDaddy são aparentemente retidas “para comparecer com as obrigações legais [deles]” porém você pode remover grande parte de suas informações editando seu perfil.",
+        "notes_cat": "Els comptes de GoDaddy son aparentment retinguts “per complir amb les [seves] obligacions legals ” pots esborrar molta informació editant el teu perfil.",
+        "notes_es": "Las cuentas de GoDaddy son aparentemente retenidos «para cumplir con las [sus] obligaciones legales». Sin embargo, puedes borrar mucha información en editando tu perfil.",
+        "domains": [
+            "godaddy.com"
+        ]
+    },
+
+    {
+        "name": "Gogo",
+        "url": "http://custhelp.gogoinflight.com/",
+        "difficulty": "hard",
+        "notes": "Email customercare@gogoair.com and ask to have your account deleted.",
+        "email": "customercare@gogoair.com",
+        "domains": [
+            "gogoair.com"
+        ]
+    },
+
+    {
+        "name": "GoJek",
+        "url": "https://www.go-jek.com/contact/",
+        "difficulty": "hard",
+        "notes": "Email customer service to request deletion.",
+        "domains": [
+            "go-jek.com"
+        ]
+    },
+
+    {
+        "name": "Good Noows",
+        "url": "http://goodnoows.com",
+        "difficulty": "easy",
+        "notes": "On the top bar, click on 'Your name', then click on the 'Delete Account' button at the bottom of the dialog.",
+        "notes_fr": "Dans le menu en haut, cliquez sur votre nom, puis cliquez sur « Delete Account » au bas du dialogue.",
+        "notes_it": "Sul menu in alto, clicca sul tuo nome, quindi clicca sul pulsante 'Delete Account' che è posizionato in fondo.",
+        "notes_pt_br": "Na barra superior, clique em 'seu nome', então clique no botão 'Delete Account' no final do diálogo.",
+        "notes_cat": "A la barra superior, cliqui al 'seu nom', després cliqui a 'Delete Account' al final del quadre de diàleg.",
+        "notes_es": "En la barra superior, haz clic en 'tu nombre', después haz clic en 'Delete Account', al final del cuadro de diálogo.",
+        "domains": [
+            "goodnoows.com"
+        ]
+    },
+
+    {
+        "name": "Good.Co",
+        "url": "http://www.good.co/",
+        "difficulty": "easy",
+        "notes": "On the top bar, click on your photo, go to 'Settings', go to 'Miscellaneous' and then hit 'Cancel Account'.",
+        "notes_fr": "Dans le menu en haut, cliquez sur votre photo, allez dans vos parametres, allez dans le menu « Miscellaneous » et puis cliquez sur « Cancel Account ».",
+        "domains": [
+            "good.co"
+        ]
+    },
+
+    {
+        "name": "Goodreads",
+        "url": "http://www.goodreads.com/user/destroy",
+        "difficulty": "easy",
+        "domains": [
+            "goodreads.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Google",
+        "url": "https://security.google.com/settings/security/deleteaccount",
+        "difficulty": "easy",
+        "domains": [
+            "google.com",
+            "google.co.uk"
+        ]
+    },
+
+    {
+        "name": "Google+",
+        "url": "https://plus.google.com/downgrade",
+        "difficulty": "easy",
+        "domains": [
+            "plus.google.com"
+        ]
+    },
+
+    {
+        "name": "GoPetition",
+        "url": "https://www.gopetition.com/accountclosure.php",
+        "difficulty": "easy",
+        "notes": "Enter a reason for closing and your password and click delete, however this is more like a deactivation as you can contact them to undelete it",
+        "notes_fr": "Saisissez une raison pour fermer et votre mot de passe et cliquez sur supprimer, mais cela est plus comme une désactivation que vous pouvez les contacter pour annuler la suppression",
+        "notes_de": "Geben Sie einen Grund für die Schließung und Ihr Passwort ein und klicken Sie auf löschen, was jedoch eher wie eine Deaktivierung ist, wie Sie sie es undelete kontaktieren",
+        "notes_it": "Inserisci un motivo per la chiusura e la password e fare clic su Elimina, tuttavia questo è più simile a una disattivazione, come si può contattarli per annullare l'eliminazione",
+        "notes_pt_br": "Entre com um motivo para o fechamento e sua senha e clique em excluir, no entanto, este é mais como uma desativação como você pode contatá-los para anular a eliminação",
+        "notes_cat": "Introduir un motiu per al tancament i la contrasenya i feu clic a Suprimeix, però, això s'assembla més a una desactivació com es pot contactar amb ells per restituir-lo de",
+        "notes_es": "Introducir un motivo para el cierre y su contraseña y haga clic en Eliminar, sin embargo, esto se parece más a una desactivación como se puede contactar con ellos para deshacer el borrado",
+        "domains": [
+            "gopetition.com"
+        ]
+    },
+
+    {
+        "name": "GoSquared",
+        "url": "https://www.gosquared.com/home/account/close",
+        "difficulty": "easy",
+        "notes": "Select a reason for closing and it'll take 2 clicks.",
+        "notes_de": "Wähle einen Grund für die Löschung. Es braucht nur 2 clicks.",
+        "notes_fr": "Choisissez la raison de la suppression et cela se fait en 2 cliques.",
+        "notes_it": "Logga il tuo account, quindi clicca su 'My Profile'. Vedrai un link 'Close my account'. Cliccaci e segui le istruzioni.",
+        "notes_pt_br": "Selecione um motivo para fechar a conta e irá levar dois cliques.",
+        "notes_cat": "Seleccioni un motiu per tancar el compte, només seran 2 clics",
+        "notes_es": "Seleccione un motivo para cerrar la cuenta, sólo serán 2 clics",
+        "domains": [
+            "gosquared.com"
+        ]
+    },
+
+    {
+        "name": "gPodder",
+        "url": "https://www.gpodder.net/account/",
+        "difficulty": "easy",
+        "notes": "Go to account, select Delete Account at bottom of page, and click the red button labeled Delete Account.",
+        "domains": [
+            "gpodder.net"
+        ]
+    },
+
+    {
+        "name": "Grab",
+        "difficulty": "easy",
+        "notes": "Swipe left to right from the edge of screen, tap the profile picture, scroll down until you see delete account.",
+        "domains": [
+            "grab.com"
+        ]
+    },
+
+    {
+        "name": "Grailed",
+        "url": "http://www.grailed.com/",
+        "difficulty": "hard",
+        "notes": "Send an email to arun@grailed.com and request deletion.",
+        "notes_fr": "Envoyez un e-mail à arun@grailed.com pour demander la suppression de votre compte.",
+        "email": "arun@grailed.com",
+        "domains": [
+            "grailed.com"
+        ]
+    },
+
+    {
+        "name": "Grammarly",
+        "url": "https://app.grammarly.com/profile/account",
+        "difficulty": "easy",
+        "domains": [
+            "grammarly.com"
+        ]
+    },
+
+    {
+        "name": "Gravatar",
+        "url": "http://gravatar.com",
+        "difficulty": "impossible",
+        "notes": "You can't delete your Gravatar Account without deleting your entire WordPress Account.",
+        "notes_fr": "Gravatar appartient à WordPress, ce qui veut dire que vous ne pouvez pas supprimer votre compte.",
+        "notes_cat": "No es pot esborrar el seu compte de Gravatar sense borrar tot el compte de WordPress.",
+        "notes_es": "No puedes borrar tu cuenta de Gravatar sin borrar toda tu cuenta de WordPress.",
+        "notes_pl": "Nie ma możliwości usunięcia konta Gravatar bez usunięcia całego konta WordPress.",
+        "domains": [
+            "gravatar.com"
+        ]
+    },
+
+    {
+        "name": "Green Man Gaming",
+        "url": "https://corporate.greenmangaming.com/privacy-policy",
+        "difficulty": "hard",
+        "email": "dataprotection@greenmangaming.com",
+        "domains": [
+            "greenmangaming.com"
+        ]
+    },
+
+    {
+        "name": "Grindr",
+        "url": "https://help.grindr.com/hc/en-us/requests/new?ticket_form_id=24054",
+        "difficulty": "hard",
+        "notes": "Submit an account deletion request via their web form, including all requested account details.",
+        "domains": [
+            "grindr.com"
+        ]
+    },
+
+    {
+        "name": "GroupMe",
+        "url": "https://app.groupme.com/profile",
+        "difficulty": "easy",
+        "notes": "Go to the GroupMe profile page, then click 'Delete GroupMe Account'. If you are the owner of any groups, you must transfer them to someone else first.",
+        "domains": [
+            "groupme.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Groupon",
+        "url": "https://groupon.com/customer_support",
+        "difficulty": "hard",
+        "notes": "According to Groupon's privacy statement, you have to contact support directly and ask them to delete your account.",
+        "notes_fr": "Selon le politique de confidentialité de Groupon, vous devez contacter le support du site directement pour demander la suppresion de votre compte.",
+        "domains": [
+            "groupon.com"
+        ]
+    },
+
+    {
+        "name": "GrubHub",
+        "url": "https://www.grubhub.com/legal/",
+        "difficulty": "hard",
+        "notes": "Privacy Policy Letter D: Account e-mail addresses cannot be deleted. However, an Account may be closed and GrubHub will cause the corresponding e-mail address to be scrambled.",
+        "notes_fr": "Aucune page n'explique comment supprimer votre compte. Vous devez contacter le support et ils le feront pour vous.",
+        "notes_it": "Nessuna pagina spiega come eliminare l'account. Devi contattare il supporto direttamente (il link si trova in fondo alla pagina) e lo faranno al posto tuo.",
+        "notes_pt_br": "Não há uma página explicando como deletar sua conta. Você terá de contatar o suporte diretamente (link no final da página) e eles irão deletá-la para você.",
+        "notes_cat": "No s'explica com eliminar el compte. Haurà de contactar directament amb el servei d'assistència (link al final de la pàgina) i ells li borraran el compte.",
+        "notes_es": "No hay una explicación en como eliminar las cuentas. Deberás contactar directamente con el servicio de asistencia (enlance al final de la página) y ellos borrarán la cuenta.",
+        "email": "accounts@grubhub.com",
+        "domains": [
+            "grubhub.com"
+        ]
+    },
+
+    {
+        "name": "Guild Wars",
+        "url": "https://help.guildwars2.com/hc/de/requests/new?ticket_form_id=38933",
+        "difficulty": "hard",
+        "notes": "You need to create a support ticket and request for them to delete your account. Before your account gets deleted you need to answer why you want the account to be deleted.",
+        "notes_de": "Über ein Support-Ticket kann eine Löschung des Accounts beantragt werden. Bevor der Account gelöscht wird, muss zuerst angegeben werden, warum der Account gelöscht werden soll.",
+        "domains": [
+            "arena.net",
+            "guildwars2.com",
+            "help.guildwars2.com"
+        ]
+    },
+
+    {
+        "name": "Gumroad",
+        "url": "https://gumroad.com/settings",
+        "difficulty": "easy",
+        "notes": "There is a link at the bottom of the Settings page to delete your account.",
+        "domains": [
+            "gumroad.com"
+        ]
+    },
+
+    {
+        "name": "Gumtree",
+        "url": "https://my.gumtree.com/manage/details/deactivate",
+        "difficulty": "easy",
+        "domains": [
+            "gumtree.com"
+        ]
+    },
+
+    {
+        "name": "Gyazo",
+        "url": "https://gyazo.com/settings",
+        "difficulty": "easy",
+        "domains": [
+            "gyazo.com"
+        ],
+        "notes": "Scroll to the bottom of the webpage, and click the red \"Delete Account\" button"
+    },
+
+    {
+        "name": "Habbo",
+        "url": "https://help.habbo.com/hc/en-us/requests/new",
+        "difficulty": "hard",
+        "notes": "Log in on the respective site and submit a request to delete your account.",
+        "notes_de": "Melden Sie sich auf der jeweiligen Website an und reichen Sie eine Anfrage zum Löschen Ihres Kontos ein.",
+        "notes_fr": "Connectez-vous sur le site correspondant et envoyez une demande pour supprimer votre compte.",
+        "notes_it": "Accedi al rispettivo sito e invia una richiesta per eliminare il tuo account.",
+        "notes_nl": "Log in op de betreffende site en dien een aanvraag in om uw account te verwijderen.",
+        "domains": [
+            "habbo.com",
+            "habbo.com.br",
+            "habbo.com.tr",
+            "habbo.de",
+            "habbo.es",
+            "habbo.fi",
+            "habbo.fr",
+            "habbo.it",
+            "habbo.nl"
+        ]
+    },
+
+    {
+        "name": "Habitica",
+        "url": "https://habitica.com/user/settings/site",
+        "difficulty": "easy",
+        "notes": "Log in to your account, click the User icon in the top-right corner, click Settings in the drop-down menu, and click the red Delete Account button at the bottom of the page.",
+        "domains": [
+            "habitica.com"
+        ]
+    },
+
+    {
+        "name": "Hack This Site",
+        "url": "https://www.hackthissite.org/forums/viewtopic.php?f=9&t=4800&sid=7edb515c2462108e30ddec760c2ddfebv",
+        "difficulty": "impossible",
+        "notes": "It is not possible to delete your Hack This Site account.  The best you can do is delete any personal information that you have stored on their website.",
+        "notes_fr": "Il n'est pas possible de supprimer votre compte de Hack This Site. Le meilleur que vous pouvez faire est d'enlever toutes les informations que vous avez enregistré dans le site.",
+        "domains": [
+            "hackthissite.org"
+        ]
+    },
+
+    {
+        "name": "Hacker News",
+        "url": "http://jacquesmattheij.com/The+Unofficial+HN+FAQ#deleteaccount",
+        "difficulty": "impossible",
+        "notes": "Your contributions are there to stay, but you can at least clear out your profile -- even your email address.",
+        "notes_fr": "Vos contributions resteront sur le site, mais vous pouvez 'vider' votre profil, même votre email.",
+        "notes_it": "Le tue donazioni resteranno, ma puoi almeno pulire il tuo profilo -- anche il tuo indirizzo email",
+        "notes_pt_br": "Suas contribuições serão mantidas, mas você pode limpar o seu perfil -- inclusive seu endereço de e-mail.",
+        "notes_cat": "Les seves contribucions es mantindran, però pot netejar el seu perfil -- incloent el seu e-mail.",
+        "notes_es": "Tus contribuciones se permanecerán, pero puedes borrar los datos en tu perfil (incluso tu e-mail).",
+        "domains": [
+            "jacquesmattheij.com"
+        ]
+    },
+
+    {
+        "name": "Hackerrank",
+        "url": "https://www.hackerrank.com/settings/account",
+        "difficulty": "easy",
+        "notes": "According to the site you must go to the profile settings url and there will be a button called 'delete account' which will delete the account if it is wished to. ",
+        "domains": [
+            "www.hackerrank.com"
+        ]
+    },
+
+    {
+        "name": "Hackpad",
+        "url": "https://hackpad.com/Hackpad-FAQ-tq56fI63mz3#:h=Account-settings",
+        "difficulty": "hard",
+        "notes": "Request acount deletion via email.",
+        "email": "support@hackpad.com",
+        "domains": [
+            "hackpad.com"
+        ]
+    },
+
+    {
+        "name": "Happy Scribe",
+        "url": "http://happyscribe.co/users/edit",
+        "difficulty": "easy",
+        "notes": "Go to \"Settings > Delete Account > Delete my account\".",
+        "notes_pt_br": "Vá para \"Settings > Delete Account > Delete my account\".",
+        "domains": [
+            "happyscribe.co"
+        ]
+    },
+
+    {
+        "name": "HelloFax",
+        "url": "https://www.hellofax.com/home/myAccount",
+        "difficulty": "easy",
+        "notes": "Click \"Delete my account\" and follow the instructions that appear.",
+        "domains": [
+            "hellofax.com"
+        ]
+    },
+
+    {
+        "name": "HelloWallet",
+        "url": "https://my.hellowallet.com/#MySettings",
+        "difficulty": "easy",
+        "notes": "Click 'Cancel My Membership' on the above URL and confirm.",
+        "domains": [
+            "hellowallet.com"
+        ]
+    },
+
+    {
+        "name": "Heroes of Newerth",
+        "url": "https://www.heroesofnewerth.com/",
+        "difficulty": "hard",
+        "email": "support@heroesofnewerth.com",
+        "notes": "The only way of deleting your account is by sending an e-mail to 'support@heroesofnewerth.com'.",
+        "domains": [
+            "heroesofnewerth.com"
+        ]
+    },
+
+    {
+        "name": "Heroku",
+        "url": "https://dashboard.heroku.com/account",
+        "difficulty": "easy",
+        "notes": "“Close your account...” link at the bottom of the page.",
+        "notes_fr": "Lien 'Fermez mon compte...' en bas de la page.",
+        "notes_it": "“Close your account...” link in fondo alla pagina",
+        "notes_pt_br": "Link “Close your account...” no final da página.",
+        "notes_cat": "Clica a l'enllaç “Close your account...” al final de la pàgina.",
+        "notes_es": "Haz clic en el enlace \"Close your account...\" al final de la página.",
+        "notes_pl": "Na dole strony kliknij 'Close your account', podaj hasło i zatwierdź przyciskiem.",
+        "domains": [
+            "heroku.com"
+        ]
+    },
+
+    {
+        "name": "Hi-Rez Studios",
+        "url": "https://hi-rez.custhelp.com/app/answers/detail/a_id/249/~/removing-your-account",
+        "difficulty": "impossible",
+        "domains": [
+            "hirezstudios.com"
+        ]
+    },
+
+    {
+        "name": "Hi5",
+        "url": "http://www.hi5.com/account_cancel.html",
+        "difficulty": "easy",
+        "domains": [
+            "hi5.com"
+        ]
+    },
+
+    {
+        "name": "HighBeam Research",
+        "url": "http://www.highbeam.com/Account/Cancel",
+        "difficulty": "easy",
+        "domains": [
+            "highbeam.com"
+        ]
+    },
+
+    {
+        "name": "HOL Virtual Hogwarts",
+        "url": "http://hol.org.uk/profile.php?view=quithol",
+        "difficulty": "impossible",
+        "notes": "You can remove information and manually quit HOL, but your account stays forever.",
+        "notes_fr": "Vous pouvez enlever vos infos perso. mais votre compte restera à vie.",
+        "notes_it": "Puoi rimuovere le tue informazioni e effettuare il logout, ma il tuo account resterà li.",
+        "notes_pt_br": "Você pode remover as informações e manualmente sair do HOL, mas sua conta é permanente.",
+        "notes_cat": "Pot esborrar la seva informaciò i manualment sortir d'HOL, però el seu compte es permanent.",
+        "notes_es": "Puedes borrar tu información y manualmente salir de HOL, pero tu cuenta es permanente.",
+        "notes_de": "Sie können Ihre daten manuell löschen und HOL schließen, aber Ihre Daten bleiben gespeichert",
+        "domains": [
+            "hol.org.uk"
+        ]
+    },
+
+    {
+        "name": "Hostelsclub",
+        "url": "http://www.hostelsclub.com/",
+        "difficulty": "impossible",
+        "notes": "You can remove every information from your account or if you signed up using a social network disconnect it.",
+        "notes_de": "Du kannst persönliche Daten Löschen. Wenn du Soziale Netzwerke zum Anmelden benutzt hast kannst du die Verbindung zu diesen trennen.",
+        "domains": [
+            "hostelsclub.com"
+        ]
+    },
+
+    {
+        "name": "Hot or Not",
+        "url": "http://hotornot.com",
+        "difficulty": "easy",
+        "notes": "Sign in to your account, go to the 'Account' options in your settings and delete your profile. See also <a href=\"http://hotornot.com/privacy/\">'Can I deactivate or delete my Profile?'</a>",
+        "notes_fr": "Connectez-vous, allez dans les paramatres du compte et supprimez votre profil. Voyez aussi l'article <a href=\"http://hotornot.com/privacy/\">« Can I deactivate or delete my Profile? »</a>",
+        "domains": [
+            "hotornot.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Hotmail",
+        "url": "https://account.live.com/CloseAccount.aspx",
+        "difficulty": "easy",
+        "domains": [
+            "live.com"
+        ]
+    },
+
+    {
+        "name": "Huddle",
+        "url": "https://huddle.zendesk.com/hc/en-us/articles/200124703-How-do-I-cancel-my-Huddle-account-",
+        "difficulty": "hard",
+        "domains": [
+            "huddle.com"
+        ]
+    },
+
+    {
+        "name": "Hulu",
+        "url": "https://secure.hulu.com/users/delete",
+        "difficulty": "easy",
+        "domains": [
+            "hulu.com"
+        ]
+    },
+
+    {
+        "name": "Humble Bundle",
+        "url": "https://www.humblebundle.com/",
+        "difficulty": "impossible",
+        "notes": "You must <a href=\"https://support.humblebundle.com/hc/en-us/requests/new\">contact Humble Bundle via their online contact form</a> to request account deletion and provide three or more transaction IDs from previous orders. They only deactivate your account though and state you can get back at any time.",
+        "domains": [
+            "humblebundle.com"
+        ]
+    },
+
+    {
+        "name": "Hypejar",
+        "url": "http://www.hypejar.com/settings/account",
+        "difficulty": "easy",
+        "domains": [
+            "hypejar.com"
+        ]
+    },
+
+    {
+        "name": "Iceber.gs",
+        "url": "https://iceber.gs/home",
+        "difficulty": "easy",
+        "notes": "On top bar: 'Your name', 'My Account' and just click on 'Delete Account' link at bottom.",
+        "notes_fr": "Sur la barre du haut 'Votre nom', 'Mon compte' et cliquez 'Supprimer mon compte.' ",
+        "notes_it": "Nel menu in alto: 'Tuo nome', 'My Account', e clicca sul link 'Delete Account' in fondo.",
+        "notes_pt_br": "Na barra superior: 'Seu nome', 'My Account' e clique no link 'Delete Account' no final.",
+        "notes_cat": "A la barra superior: 'El seu nom', 'My Account' i faci click a 'Delete Account' al final.",
+        "notes_es": "En la barra superior: 'Tu nombre', 'My Account' y haz clic en 'Delete Account' al final.",
+        "domains": [
+            "iceber.gs"
+        ]
+    },
+
+    {
+        "name": "ICQ",
+        "url": "http://www.icq.com/delete-account/",
+        "difficulty": "easy",
+        "domains": [
+            "icq.com"
+        ]
+    },
+
+    {
+        "name": "IFTTT",
+        "url": "https://ifttt.com/settings/deactivate",
+        "difficulty": "easy",
+        "domains": [
+            "ifttt.com"
+        ]
+    },
+
+    {
+        "name": "ImageShack",
+        "url": "http://imageshack.us/prefs/",
+        "difficulty": "easy",
+        "domains": [
+            "imageshack.us"
+        ]
+    },
+
+    {
+        "name": "IMDb",
+        "url": "https://secure.imdb.com/register-imdb/delete",
+        "difficulty": "easy",
+        "domains": [
+            "imdb.com"
+        ]
+    },
+
+    {
+        "name": "Imgur",
+        "url": "http://imgur.com/account/settings",
+        "difficulty": "easy",
+        "domains": [
+            "imgur.com"
+        ]
+    },
+
+    {
+        "name": "imo.im",
+        "url": "https://imo.im",
+        "difficulty": "easy",
+        "notes": "You must login, go to your account settings and then click on the 'Delete Account' link on the bottom left.",
+        "notes_fr": "Connectez-vous, allez dans vos parametres puis cliquez sur « Delete Account » en bas à gauche.",
+        "domains": [
+            "imo.im"
+        ]
+    },
+
+    {
+        "name": "IndieGala",
+        "url": "http://docs.indiegala.com/support/contacts.html",
+        "difficulty": "hard",
+        "notes": "Contact the customer support via email and request the deletion of your account. In order for them to identify your account, make the request through the same email address that you have used to create your IndieGala account.",
+        "notes_pt_br": "Entre em contato com o suporte via e-mail e solicite que sua conta seja excluída. Para que eles possam identificar sua conta, faça a requisição a partir da mesma conta de e-mail que você usou para criar sua conta IndieGala.",
+        "email": "support@indiegala.com",
+        "email_subject": "[ Permanently Account Deletion Request ]",
+        "email_body": "I have no further interest in using the services provided by IndieGala, so I would like my account to be permanently deleted.",
+        "domains": [
+            "indiegala.com"
+        ]
+    },
+
+    {
+        "name": "Indiegogo",
+        "url": "https://www.indiegogo.com",
+        "difficulty": "easy",
+        "notes": "Go to “My Settings”, scroll down to the bottom, and click the “Delete” button.",
+        "domains": [
+            "indiegogo.com"
+        ]
+    },
+
+    {
+        "name": "InfoCasas",
+        "url": "https://www.infocasas.com.uy/dashboard",
+        "difficulty": "hard",
+        "notes": "Contact the customer support via email and request the deletion of your account. In order for them to identify your account, make the request through the same email address that you have used to create your account.",
+        "email": "info@infocasas.com.uy",
+        "domains": [
+            "infocasas.com.uy"
+        ]
+    },
+
+    {
+        "name": "Ingress",
+        "url": "https://support.ingress.com/hc/en-us/articles/206618198-I-want-to-delete-my-account",
+        "difficulty": "hard",
+        "notes": "You need to fill in the form linked in the support article by clicking \"contact us\". Fill in your email address, agent name, device you play on and submit the form.",
+        "domains": [
+            "ingress.com"
+        ]
+    },
+
+    {
+        "name": "InnoGames",
+        "url": "http://goodbye.innogames.com/",
+        "difficulty": "easy",
+        "domains": [
+            "innogames.com"
+        ]
+    },
+
+    {
+        "name": "Inoreader",
+        "url": "https://www.inoreader.com",
+        "difficulty": "easy",
+        "notes": "Select 'Reset or cancel' under preferences and click on 'Cancel account'.",
+        "notes_de": "Gehe zu 'Zurücksetzen oder Abbrechen' in den Einstellungen und wähle 'Konto auflösen'.",
+        "domains": [
+            "inoreader.com"
+        ]
+    },
+
+    {
+        "name": "Instacast Cloud",
+        "url": "http://instacastcloud.com/dashboard/dangerzone",
+        "difficulty": "easy",
+        "domains": [
+            "instacastcloud.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Instagram",
+        "url": "https://instagram.com/accounts/remove/request/permanent/",
+        "difficulty": "easy",
+        "domains": [
+            "instagram.com"
+        ]
+    },
+
+    {
+        "name": "Instapaper",
+        "url": "https://www.instapaper.com/user/delete",
+        "difficulty": "easy",
+        "domains": [
+            "instapaper.com"
+        ]
+    },
+
+    {
+        "name": "Instructables",
+        "url": "http://www.instructables.com/",
+        "difficulty": "hard",
+        "notes": "You have to email them (service@instructables.com) to get your account deleted",
+        "notes_fr": "Vous devez envoyer un e-mail à service@instructables.com pour demander la suppresion de votre compte.",
+        "email": "service@instructables.com",
+        "domains": [
+            "instructables.com"
+        ]
+    },
+
+    {
+        "name": "Internetometer",
+        "url": "http://internetometer.com/",
+        "difficulty": "impossible",
+        "notes": "Site provides no user account management interface or account deletion options. Email sent to internets@technoized.com was never replied to.",
+        "notes_fr": "Le site n'offre pas d'option de suppresion des comptes. Un e-mail envoyé à internets@technoized.com n'a jamais réçu une réponse.",
+        "domains": [
+            "internetometer.com"
+        ]
+    },
+
+    {
+        "name": "Invision",
+        "url": "https://support.invisionapp.com/hc/en-us/requests/new",
+        "difficulty": "hard",
+        "notes": "You need to request them through the support form providing the email you signed up with. All files deleted will not be restorable.",
+        "domains": [
+            "invisionapp.com"
+        ]
+    },
+
+    {
+        "name": "IO9 (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Pot parar de fer servir el servei en qualsevol moment. Nosaltres, si més no mantindrém i continuarem utilitzant el contingut que ha enviat amb el servei.",
+        "notes_es": "«Puedes dejar de utilizar el servicio en cualquier momento. Nosotros, sin embargo continuaremos usando el contenido que has enviado.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "IRCCloud",
+        "url": "https://www.irccloud.com/",
+        "difficulty": "easy",
+        "notes": "Go to IRCCloud, sign in, click 'Settings', scroll down, enter your password in 'Delete your account', and confirm.",
+        "domains": [
+            "irccloud.com"
+        ]
+    },
+
+    {
+        "name": "issuu",
+        "url": "https://issuu.com/home/settings/billing",
+        "difficulty": "easy",
+        "notes": "Closing your account will delete your profile and all of your publications. There is no going back, so don't say we didn't warn you.",
+        "notes_fa": "با بستن حساب کاربریتان تمامی مجلات و اطلاعات شما حذف می‌شود. این اطلاعات غیز قابل بازگشت خواهند بود."
+    },
+
+    {
+        "name": "iStudiez",
+        "url": "https://support.istudentpro.com/support/solutions/articles/3000068641-delete-cloud-sync-account",
+        "difficulty": "hard",
+        "notes": "Contact support and ask for your account to be removed.",
+        "notes_de": "Kontaktiere den Support und fordere eine Löschung deines Accounts.",
+        "email": "support@istudentpro.com",
+        "domains": [
+            "istudentpro.com"
+        ]
+    },
+
+    {
+        "name": "iTunes / Apple ID",
+        "url": "https://privacy.apple.com/",
+        "difficulty": "easy",
+        "notes": "Login with your Apple ID, and then click Get Started under Delete Account",
+        "domains": [
+            "apple.com"
+        ]
+    },
+
+    {
+        "name": "iubenda",
+        "url": "https://www.iubenda.com/en/account",
+        "difficulty": "easy",
+        "notes": "Click Account & Billing info, then under General info click Delete your account.",
+        "domains": [
+            "iubenda.com"
+        ]
+    },
+
+    {
+        "name": "iversity",
+        "url": "https://iversity.org/de/user/deactivate",
+        "difficulty": "easy",
+        "domains": [
+            "iversity.com"
+        ]
+    },
+
+    {
+        "name": "Jalopnik (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Pot parar de fer servir el servei en qualsevol moment. Nosaltres, si més no mantindrém i continuarem utilitzant el contingut que ha enviat amb el servei.",
+        "notes_es": "«Puedes dejar de utilizar el servicio en cualquier momento. Nosotros, sin embargo continuaremos usando el contenido que has enviado.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "JDate.com",
+        "url": "http://www.jdate.com/",
+        "difficulty": "easy",
+        "notes": "Under 'Membership Management' click 'Remove my Profile'. Fill out the survey and submit to delete your profile.",
+        "domains": [
+            "jdate.com"
+        ]
+    },
+
+    {
+        "name": "Jezebel (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Pot parar de fer servir el servei en qualsevol moment. Nosaltres, si més no mantindrém i continuarem utilitzant el contingut que ha enviat amb el servei.",
+        "notes_es": "«Puedes dejar de utilizar el servicio en cualquier momento. Nosotros, sin embargo continuaremos usando el contenido que has enviado.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "Jolla Account",
+        "url": "https://account.jolla.com/profile/settings/confirm_delete_profile",
+        "difficulty": "easy",
+        "domains": [
+            "jolla.com"
+        ]
+    },
+
+    {
+        "name": "Jottacloud",
+        "url": "https://www.jottacloud.com/account/delete",
+        "difficulty": "easy",
+        "notes": "Log in. Type in password. Press 'delete'.",
+        "notes_fr": "Loggez vous, tapez votre mot de passe, cliquez sur Delete.",
+        "notes_it": "Log in. Digita la password. Premi 'delete'.",
+        "notes_de": "Logge dich ein, tippe dein Passwort ein. Klicke auf 'delete'.",
+        "notes_pt_br": "Logue-se. Digite sua senha. Pressione 'delete'.",
+        "notes_cat": "Entri al compte. Posi la seva contrassenya. Presioni 'delete'.",
+        "notes_es": "Entra en la cuenta. Pon tu contraseña. Pulsa 'delete'.",
+        "notes_pl": "Zaloguj się, podaj swoje hasło i kliknij 'delete'.",
+        "domains": [
+            "jottacloud.com"
+        ]
+    },
+
+    {
+        "name": "JS Bin",
+        "url": "http://jsbin.com/account/delete",
+        "difficulty": "easy",
+        "domains": [
+            "jsbin.com"
+        ]
+    },
+
+    {
+        "name": "JSFiddle",
+        "url": "http://doc.jsfiddle.net/meta/channels.html?highlight=contact",
+        "difficulty": "hard",
+        "notes": "Please email a request if you’d like your account to be deleted.",
+        "notes_fr": "Veuillez envoyer votre demande au support à support@jsfiddle.net si vous voulez qu'on supprime votre compte.",
+        "notes_it": "Spedisci una email a support@jsfiddle.net se desideri che il tuo account sia cancellato.",
+        "notes_pt_br": "Envie um pedido para support@jsfiddle.net se você deseja que sua conta seja deletada.",
+        "notes_cat": "Enviï un mail a support@jsfiddle.net per demanar que eliminin el seu compte.",
+        "notes_es": "Envía un mail a support@jsfiddle.net para pedir que eliminen tu cuenta.",
+        "email": "support@jsfiddle.net",
+        "domains": [
+            "jsfiddle.net"
+        ]
+    },
+
+    {
+        "name": "Keepa",
+        "url": "https://keepa.com/#!channels",
+        "difficulty": "easy",
+        "notes": "Login to your account. Click on 'Settings', then 'Account'. Click 'Yes, delete my account', enter your password and click 'Delete account'.",
+        "domains": [
+            "keepa.com"
+        ]
+    },
+
+    {
+        "name": "Keybase.io",
+        "url": "https://keybase.io/account/delete_me",
+        "difficulty": "easy",
+        "notes": "Account is deleted instantly, though username might be kept to keep service functioning properly and avoiding impersonation.",
+        "domains": [
+            "keybase.io"
+        ]
+    },
+
+    {
+        "name": "Khan Academy",
+        "url": "https://www.khanacademy.org/settings",
+        "difficulty": "easy",
+        "domains": [
+            "khanacademy.org"
+        ]
+    },
+
+    {
+        "name": "Kickstarter",
+        "url": "https://www.kickstarter.com/profile/destroy",
+        "difficulty": "easy",
+        "domains": [
+            "kickstarter.com"
+        ]
+    },
+
+    {
+        "name": "Kik",
+        "url": "https://help.kik.com/hc/en-us/articles/115006077428-Deactivate-your-account",
+        "difficulty": "impossible",
+        "notes": "You can only deactivate your account. There appears to be no way to permanently delete your account or data.",
+        "notes_fr": "Vous ne pouvez que désactiver votre compte. Il ne paraît pas qu'il y ait de façon de supprimer votre compte définitivement.",
+        "notes_it": "Puoi solo disattivare il tuo account. Non c'è modo di eliminare il tuo account o le informazioni.",
+        "notes_pt_br": "Você apenas pode desativar sua conta. Aparentemente não há como deletar sua conta ou dados.",
+        "notes_cat": "Només podrà inhabilitar el compte, no hi ha manera de fer-ho permanentment.",
+        "notes_es": "Sólo podrás desactivar la cuenta, no hay manera de hacerlo permanentemente.",
+        "domains": [
+            "kikinteractive.zendesk.com",
+            "kik.com"
+        ]
+    },
+
+    {
+        "name": "Kinja (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Pot parar de fer servir el servei en qualsevol moment. Nosaltres, si més no mantindrém i continuarem utilitzant el contingut que ha enviat amb el servei.",
+        "notes_es": "«Puedes dejar de utilizar el servicio en cualquier momento. Nosotros, sin embargo continuaremos usando el contenido que has enviado.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "Kit.com",
+        "url": "https://kit.com/terms#contact",
+        "difficulty": "hard",
+        "notes": "If you need to contact us for any reason, you can do so by emailing us.",
+        "email": "support@kit.com",
+        "domains": [
+            "kit.com/"
+        ]
+    },
+
+    {
+        "name": "Klout",
+        "url": "http://klout.com/#/edit-settings/optout",
+        "difficulty": "medium",
+        "notes": "It can take up to 180 days for all your data to be removed from the system.",
+        "notes_fr": "La suppression totale de votre compte peut prendre 180 jours.",
+        "notes_it": "La cancellazione dei dati dal sistema può richiedere fino a 180 giorni.",
+        "notes_de": "Es kann bis zu 180 Tage dauern, bis all deine Daten aus dem System entfernt sind",
+        "notes_pt_br": "Pode levar até 180 dias para que todos os seus dados sejam removidos do sistema.",
+        "notes_cat": "Trigaran aproximadament 180 dies per eliminar les teves dades del sistema .",
+        "notes_es": "Tardarán aproximadamente 180 días para eliminar tus datos del sistema.",
+        "domains": [
+            "klout.com"
+        ]
+    },
+
+    {
+        "name": "Koding",
+        "url": "https://koding.com/Account/Delete",
+        "difficulty": "easy",
+        "domains": [
+            "koding.com"
+        ]
+    },
+
+    {
+        "name": "Koingo Software",
+        "url": "https://www.koingosw.com/account/delete.php",
+        "difficulty": "medium",
+        "notes": "Enter your E-Mail in the account deletion form and confirm the deletion in the E-Mail sent to you.",
+        "notes_de": "Fülle das Online-Formular zum Löschen des Accounts mit deiner E-Mail aus und bestätige die Löschung in der gesendeten E-Mail.",
+        "domains": [
+            "koingosw.com"
+        ]
+    },
+
+    {
+        "name": "Kongregate",
+        "url": "http://www.kongregate.com/forums/7/topics/241772?page=1#posts-5207538",
+        "difficulty": "hard",
+        "notes": "You are unable to remove an account, but they can permanently ban your account upon request. They will remove stored information upon request as well, such as e-mail address, developer payment information, and stored payment information.",
+        "email": "support@kongregate.com",
+        "domains": [
+            "kongregate.com"
+        ]
+    },
+
+    {
+        "name": "Kotaku (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Pot parar de fer servir el servei en qualsevol moment. Nosaltres, si més no mantindrém i continuarem utilitzant el contingut que ha enviat amb el servei.",
+        "notes_es": "«Puedes dejar de utilizar el servicio en cualquier momento. Nosotros, sin embargo continuaremos usando el contenido que has enviado.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "Kraken",
+        "url": "https://support.kraken.com/hc/en-us/articles/203727206-How-can-I-delete-my-Kraken-account-",
+        "difficulty": "hard",
+        "notes": "To close your account, you need to submit a request to support, which may take up to 24 hours to process.",
+        "domains": [
+            "kraken.com"
+        ]
+    },
+
+    {
+        "name": "Krrb",
+        "url": "http://krrb.com/settings/disable-account",
+        "difficulty": "easy",
+        "domains": [
+            "krrb.com"
+        ]
+    },
+
+    {
+        "name": "Kununu",
+        "url": "https://www.kununu.com/user/delete",
+        "difficulty": "easy",
+        "notes": "An email will be sent with a link to delete your account.",
+        "notes_de": "Es wird eine E-Mail mit einem Link zum Löschen des Accounts gesendet.",
+        "domains": [
+            "kununu.com"
+        ]
+    },
+
+    {
+        "name": "Last.fm",
+        "url": "https://www.last.fm/settings/account/delete",
+        "difficulty": "impossible",
+        "notes": "After deactivating your account, you are able to restore it at any time by logging in. There does not appear to be a point after which your data is actually purged.",
+        "domains": [
+            "last.fm"
+        ]
+    },
+
+    {
+        "name": "LastPass",
+        "url": "https://lastpass.com/delete_account.php",
+        "difficulty": "easy",
+        "domains": [
+            "lastpass.com"
+        ]
+    },
+
+    {
+        "name": "Launchpad",
+        "url": "https://help.launchpad.net/YourAccount/Closing",
+        "difficulty": "easy",
+        "domains": [
+            "launchpad.net"
+        ]
+    },
+
+    {
+        "name": "League of Legends",
+        "url": "https://support.riotgames.com/hc/en-us/articles/202647784-Account-Deletion-FAQ#h2q4",
+        "difficulty": "hard",
+        "notes": "<a href=\"https://support.riotgames.com/anonymous_requests/new\">Send Riot Games a ticket</a> with the following information: account name, summoner name, server, email address used for account registration, registration location (City, Country), last IP used to play League of Legends, Internet Service Provider used during registration, and payment methods used to purchase RP. (if applicable)",
+        "domains": [
+            "leagueoflegends.com"
+        ]
+    },
+
+    {
+        "name": "Leetcode",
+        "url": "https://leetcode.com/",
+        "difficulty": "impossible",
+        "notes": "You can't delete your account, though you can create a new session to reset your progress",
+        "domains": [
+            "leetcode.com"
+        ]
+    },
+
+    {
+        "name": "Letterboxd",
+        "url": "http://letterboxd.com/user/disableaccount/",
+        "difficulty": "easy",
+        "domains": [
+            "letterboxd.com"
+        ]
+    },
+
+    {
+        "name": "Liberland",
+        "url": "https://liberland.org/",
+        "difficulty": "impossible",
+        "notes": "You can only disable the account, but never delete it.",
+        "domains": [
+            "liberland.org",
+            "market.ll.land"
+        ]
+    },
+
+    {
+        "name": "LibraryThing",
+        "url": "http://www.librarything.de/editprofile/change",
+        "difficulty": "easy",
+        "domains": [
+            "librarything.de"
+        ]
+    },
+
+    {
+        "name": "Libre.fm",
+        "url": "http://libre.fm/user-edit.php#",
+        "difficulty": "easy",
+        "notes": "Click 'Profile', then 'Edit', then 'Show advanced settings', and finally check the 'Delete my account' checkbox.",
+        "notes_fr": "Cliquez sur « Profile », puis « Edit », puis « Show advanced settings », et enfin cochez la case « Delete my account ».",
+        "notes_it": "Clicca 'Profile', quindi 'Edit', quindi 'Show advanced settings', e per ultimo fai un tick su 'Delete my account'",
+        "notes_pt_br": "Clique em 'Profile', então 'Edit', então 'Show advanced settings', e finalmente marque a caixa 'Delete my account'.",
+        "notes_cat": "Cliqui a 'Profile', després 'Edit', 'Show advanced settings', i finalment marqui 'Delete my account'.",
+        "notes_es": "Haz clic en 'Profile', después 'Edit', 'Show advanced settings', y finalmente marca 'Delete my account'.",
+        "domains": [
+            "libre.fm"
+        ]
+    },
+
+    {
+        "name": "Lifehacker (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Pot parar de fer servir el servei en qualsevol moment. Nosaltres, si més no mantindrém i continuarem utilitzant el contingut que ha enviat amb el servei.",
+        "notes_es": "«Puedes dejar de utilizar el servicio en cualquier momento. Nosotros, sin embargo continuaremos usando el contenido que has enviado.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "Lingvist",
+        "url": "https://lingvist.com/forum/topic/32/how-to-and-faq/4",
+        "email": "hello@lingvist.io",
+        "difficulty": "hard",
+        "notes": "You must contact Lingvist to request account deletion.",
+        "domains": [
+            "lingvist.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "LinkedIn",
+        "url": "http://help.linkedin.com/app/answers/detail/a_id/63/kw/delete%20account",
+        "difficulty": "medium",
+        "notes": "There are reports that LinkedIn continues to email people with a closed account. You may need to contact customer services to delete account instead of just closing it.",
+        "notes_fr": "Il y a des rapports que LinkedIn continue d'envoyer des e-mails aux gens qui ferment leur compte. Il est bien possible qu'il faudra contactez le support du site pour demander la suppresion de votre compte.",
+        "notes_cat": "Hi han informes que diuen que LinkedIn segueix enviant correu electrònic a les persones amb comptes tancats. Podria ser necessari posar-se en contacte amb el servei al client per eliminar el compte en lloc de tancar-lo.",
+        "notes_es": "Hay informes que dicen que LinkedIn sigue enviando correo electrónico a las personas con cuentas cerradas. Podría ser necesario ponerte en contacto con el servicio al cliente para eliminar la cuenta en lugar de cerrarla.",
+        "domains": [
+            "linkedin.com"
+        ]
+    },
+
+    {
+        "name": "Linsensuppe",
+        "url": "https://www.linsensuppe.de",
+        "difficulty": "impossible",
+        "notes": "One cannot even change the password"
+    },
+
+    {
+        "name": "The Linux Counter Project",
+        "url": "https://linuxcounter.net/deleteaccount/profile.html",
+        "difficulty": "easy",
+        "notes": "Login -> Profile -> Delete account -> Yes"
+    },
+
+    {
+        "name": "LiveJournal",
+        "url": "http://www.livejournal.com/accountstatus.bml",
+        "difficulty": "medium",
+        "notes": "Once you delete your journal you have 30 days to undelete it, in case you change your mind. After 30 days, the journal will be permanently deleted and there will be no way to recover it.",
+        "notes_fr": "Quand vous supprimez votre Journal vous avez 30 jours pour le restaurer, au cas où vous changez votre avis. Après les 30 jours, le Journal est supprimé définitivement.",
+        "notes_it": "Una volta eliminato il tuo Journal hai 30 giorni per recuperarlo, nel caso cambiassi idea. Dopo 30 giorni, il tuo Journal sarà permanentemente cancellato e non ci sarà modo di recuperarlo.",
+        "notes_pt_br": "Uma vez que você tenha deletado seu jornal você tem 30 dias para desfazer a remoção, caso você mude de ideia. Após 30 dias, o seu jornal permanecerá deletado e não haverá como recuperá-lo.",
+        "notes_cat": "Una vegada que hagi eliminat el seu Journal, tindrà 30 dies per tirar enderrera la decisiò. Després de 30 dies el seu contingut serà borrat permanentment i no es podrà recuperar.",
+        "notes_es": "Cuando has eliminado tu Journal, tendrás 30 días para cancelar la decisión. Después de 30 días tu contenido será borrado permanentemente y no será posible de recuperarlo.",
+        "domains": [
+            "livejournal.com"
+        ]
+    },
+
+    {
+        "name": "Lobsters",
+        "url": "https://lobste.rs/settings",
+        "difficulty": "easy",
+        "domains": [
+            "lobste.rs"
+        ]
+    },
+
+    {
+        "name": "Lookout",
+        "url": "https://www.lookout.com/d/settings",
+        "difficulty": "easy",
+        "notes": "log into your account, in the middle right.",
+        "domains": [
+            "lookout.com"
+        ]
+    },
+
+    {
+        "name": "LoseIt",
+        "url": "http://www.loseit.com/#Settings:Account%20Information^Account%20Information",
+        "difficulty": "easy",
+        "notes": "Click “Close account”.",
+        "domains": [
+            "loseit.com"
+        ]
+    },
+
+    {
+        "name": "Lovefilm",
+        "url": "https://www.lovefilm.com/account/cancel",
+        "difficulty": "medium",
+        "notes": "Requires any physical discs to be returned—account will be “cancellation pending” until received.",
+        "notes_fr": "Il faut rendre tous les disques que vous avez emprunté. Votre compte est classifié « suppresion en attente » avant que vous l'avez fait.",
+        "notes_it": "Richiede che ogni disco fisico sia restituito-L'account verrà classificato come “In attesa di cancellazione” fino all'arrivo dei dischi.",
+        "notes_pt_br": "Você precisa devolver todos os discos físico, sua conta estará em “cancelamento pendente” até que eles recebam os discos.",
+        "notes_cat": "Ha de tornar tots els discs físics, el seu compte estarà en “cancelament pendent” fins que es rebin els discs.",
+        "notes_es": "Debes devolver todos los discos físicos, tu cuenta estará en “cancelación pendiente” hasta que se reciban los discos.",
+        "domains": [
+            "lovefilm.com"
+        ]
+    },
+
+    {
+        "name": "Lucidchart/Lucidpress",
+        "url": "https://www.lucidchart.com/users/login",
+        "difficulty": "easy",
+        "notes": "Click in the top right corner on your Username, then \"Account settings\" and at the tab \"Close Account\"",
+        "domains": [
+            "lucidchart.com",
+            "lucidpress.com"
+        ]
+    },
+
+    {
+        "name": "Lufthansa",
+        "url": "https://www.lufthansa.com/online/myportal/lh/uk/my_account/profile/update?action=deleteProfileAction",
+        "difficulty": "easy",
+        "domains": [
+            "lh.com",
+            "lufthansa.com",
+            "lufthansa.de"
+        ]
+    },
+
+    {
+        "name": "Lumi",
+        "url": "https://lumi.do/account/privacy/delete/user",
+        "difficulty": "easy",
+        "domains": [
+            "lumi.do"
+        ]
+    },
+
+    {
+        "name": "Lumosity",
+        "url": "https://www.lumosity.com/app/v4/settings/account_deletion/new",
+        "difficulty": "easy",
+        "domains": [
+            "lumosity.com"
+        ]
+    },
+
+    {
+        "name": "MacTrade",
+        "url": "https://www.mactrade.de/goodahead_customer/account/delete/",
+        "notes": "In your user account go to 'Delete Account' and confirm the deletion via the 'Delete account now' button.",
+        "notes_de": "Wähle 'Konto löschen' in deinem Benutzerkonto und bestätige die Löschung mit dem Button 'Benutzerkonto jetzt löschen'.",
+        "difficulty": "easy",
+        "domains": [
+            "mactrade.de"
+        ]
+    },
+
+    {
+        "name": "MacUpdate",
+        "url": "https://www.macupdate.com/member/account-preferences",
+        "difficulty": "easy",
+        "notes": "In your account preferences select 'Delete all my personal data' in the bottom left. 14 days after your request all your data will be deleted. During the 14 days the delete request may be cancelled.",
+        "notes_de": "In den Account-Einstellungen kann der Account links unten mit 'Delete all my personal data' gelöscht werden. Die Daten werden erst nach einer 14 tägigen Frist gelöscht. Während der 14 Tage kann der Löschvorgang abgebrochen werden.",
+        "domains": [
+            "macupdate.com"
+        ]
+    },
+
+    {
+        "name": "Magoosh",
+        "url": "https://magoosh.zendesk.com/hc/en-us/articles/204307485-How-do-I-delete-my-account-",
+        "email": "help@magoosh.com",
+        "email_subject": "Need to delete my account",
+        "difficulty": "easy",
+        "notes": "Send an email to help@magoosh.com with the subject line, 'Need to delete my account'. Might need to send another email for the deletion to finally go through.",
+        "domains": [
+            "magoosh.com"
+        ]
+    },
+
+    {
+        "name": "mailbox.org",
+        "url": "https://mailbox.org/en/",
+        "difficulty": "easy",
+        "notes": "Account Settings → Delete Account.",
+        "domains": [
+            "mailbox.org"
+        ]
+    },
+
+    {
+        "name": "MailChimp",
+        "url": "http://kb.mailchimp.com/article/how-do-i-close-my-account",
+        "difficulty": "easy",
+        "notes": "Account Settings → Account Settings Drop-down → Close my account → Type DELETE and press Delete Account button.",
+        "notes_pl": "Account Settings → Account Settings Drop-down → Close my account → Wpisz DELETE i kliknij Delete Account.",
+        "notes_fr": "« Account Settings » → menu déroulant « Account Settings » → « Close my account » → Tapez « DELETE » et appuyez sur « Delete Account ».",
+        "notes_it": "Account Settings → Account Settings Drop-down → Close my account → Digita DELETE e premi il pulsante Delete Account.",
+        "notes_pt_br": "Account Settings → Account Settings Drop-down → Close my account → Digite DELETE e pressione o botão Delete Account.",
+        "notes_cat": "Account Settings → Account Settings Drop-down → Close my account → Marca DELETE i presioni el botó 'Delete Account'.",
+        "notes_es": "Account Settings → Account Settings Drop-down → Close my account → Marca DELETE y presiona el botón 'Delete Account'.",
+        "domains": [
+            "mailchimp.com"
+        ]
+    },
+
+    {
+        "name": "Mailspring",
+        "url": "https://id.getmailspring.com",
+        "difficulty": "easy",
+        "notes": "Sign in → Click the 'Delete your Mailspring ID' button → Confirm",
+        "notes_de": "Anmelden → Auf 'Löschen Sie alle Daten, die Ihrer Mailspring-ID zugeordnet sind' klicken → Bestätigen",
+        "domains": [
+            "getmailspring.com"
+        ]
+    },
+
+    {
+        "name": "Mapbox",
+        "url": "https://www.mapbox.com/account/billing/",
+        "difficulty": "easy",
+        "notes": "Enter Password -> Scroll to bottom -> Click 'Delete Account'",
+        "notes_de": "Passwort eingeben -> An das Ende der Seite scrollen -> 'Delete Account' klicken",
+        "domains": [
+            "mapbox.com"
+        ]
+    },
+
+    {
+        "name": "Mapstr",
+        "url": "https://mapstr.com/faq.html",
+        "difficulty": "easy",
+        "notes": "Log in to your account in the app, then in the account settings choose 'Delete my account'.",
+        "notes_de": "Melde dich in der App mit deinem Account an. Wähle dann in den Konto-Einstellungen 'Mein Konto löschen'.",
+        "domains": [
+            "mapstr.com"
+        ]
+    },
+
+    {
+        "name": "Marvel",
+        "url": "https://marvelapp.com/account/",
+        "difficulty": "easy",
+        "notes": "Log into your account -> My Account -> click on Delete Account at the bottom of page.",
+        "domains": [
+            "marvelapp.com"
+        ]
+    },
+
+    {
+        "name": "Massdrop",
+        "url": "https://helpdesk.massdrop.com/hc/en-us/articles/360019265073-How-do-I-delete-my-account-",
+        "difficulty": "hard",
+        "notes": "Contact support via the online form and ask for your account to be deleted.",
+        "notes_de": "Kontaktiere den Support über das Online-Formular und fordere eine Löschung des Accounts.",
+        "domains": [
+            "drop.com"
+        ]
+    },
+
+    {
+        "name": "Mastodon.social",
+        "url": "https://mastodon.social/settings/delete",
+        "difficulty": "easy",
+        "notes": "Login -> Account Settings -> Security > Delete Account",
+        "domains": [
+            "mastodon.social"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Match",
+        "url": "https://www.match.com/resign/resign.aspx",
+        "difficulty": "impossible",
+        "notes": "You can only ever deactivate your account",
+        "domains": [
+            "match.com"
+        ]
+    },
+
+    {
+        "name": "McAfee",
+        "url": "http://home.mcafee.com/supportpages/unsub.aspx",
+        "difficulty": "easy",
+        "domains": [
+            "mcafee.com"
+        ]
+    },
+
+    {
+        "name": "McVIP",
+        "url": "https://mcvip.mcdonalds.de/#/profil",
+        "difficulty": "easy",
+        "notes": "Click on 'Edit profile', scroll down to 'You want to delete your profile?', type in your password, click on 'Delete' and then 'Yes, delete it'.",
+        "notes_de": "Klick auf 'Profil bearbeiten, hinunter zu 'Du willst dein Profil löschen?' scrollen, Passwort eintippen, dann auf 'Löschen' und 'Ja, Profil löschen' klicken.",
+        "domains": [
+            "mcvip.mcdonalds.de"
+        ]
+    },
+
+    {
+        "name": "MediaFire",
+        "url": "https://www.mediafire.com/myaccount/accountbilling.php",
+        "difficulty": "easy",
+        "domains": [
+            "mediafire.com"
+        ]
+    },
+
+    {
+        "name": "Mediapart",
+        "url": "https://www.mediapart.fr/contenu/conditions-generales-d-utilisation",
+        "email": "contact@mediapart.fr",
+        "email_body": "Please delete all information and data associated with my account. My username is XXXXXX.",
+        "difficulty": "hard",
+        "notes": "No information is clearly provided how to delete account. You have to send an email to explicitly ask for deletion of every information related to your account otherwise they will only disable it.",
+        "notes_fr": "Il faut envoyer un mail et demander la suppression définitive de toute information liée au compte, sinon ils vont uniquement le désactiver(ex: les données bancaires demeurent). Conseil: Invoquer la CNIL (<a href\"https://www.cnil.fr/fr/modele/courrier/supprimer-des-informations-vous-concernant-dun-site-internet\">https://www.cnil.fr/fr/modele/courrier/supprimer-des-informations-vous-concernant-dun-site-internet</a>).",
+        "domains": [
+            "mediapart.fr"
+        ]
+    },
+
+    {
+        "name": "Medium",
+        "url": "https://medium.com/me/settings",
+        "difficulty": "easy",
+        "domains": [
+            "medium.com"
+        ]
+    },
+
+    {
+        "name": "Meetup",
+        "url": "http://www.meetup.com/account/remove/",
+        "difficulty": "easy",
+        "domains": [
+            "meetup.com"
+        ]
+    },
+
+    {
+        "name": "Megaxus",
+        "difficulty": "impossible",
+        "domains": [
+            "megaxus.com"
+        ]
+    },
+
+    {
+        "name": "Memrise",
+        "url": "http://www.memrise.com/settings/deactivate/",
+        "difficulty": "easy",
+        "notes": "A 'Delete my account' button is available from your account settings page.",
+        "domains": [
+            "memrise.com"
+        ]
+    },
+
+    {
+        "name": "MePergunte",
+        "url": "http://mepergunte.com/perfil/configuracoes/excluir/",
+        "difficulty": "easy",
+        "domains": [
+            "mepergunte.com"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Uruguay",
+        "url": "https://myaccount.mercadolibre.com.uy/cancelar-cuenta",
+        "difficulty": "easy",
+        "domains": [
+            "mercadolibre.com.uy",
+            "mercadopago.com.uy"
+        ]
+    },
+
+    {
+        "name": "Mercado Livre Brasil",
+        "url": "http://myaccount.mercadolivre.com.br/cancelar-conta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estou de acordo\", and confirm your action by clinking \"Aceito\".</br></br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Livre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Livre account, your Mercado Pago account will be deleted too.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estou de acordo\" e clique em \"Aceitar\".</br></br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Livre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Livre, sua conta do Mercado Pago também será excluída.",
+        "domains": [
+            "mercadolivre.com.br",
+            "mercadopago.com.br",
+            "mercadolivre.com"
+        ]
+    },
+
+    {
+        "name": "Metacafe",
+        "url": "http://www.metacafe.com/feedback/",
+        "difficulty": "hard",
+        "notes": "Request to delete account by contacting support.",
+        "domains": [
+            "metacafe.com"
+        ]
+    },
+
+    {
+        "name": "Mi Account",
+        "url": "https://account.xiaomi.com/pass/del",
+        "difficulty": "easy",
+        "domains": [
+            "account.xiaomi.com"
+        ]
+    },
+
+    {
+        "name": "Microsoft Account",
+        "url": "https://account.live.com/closeaccount.aspx",
+        "difficulty": "easy",
+        "domains": [
+            "live.com"
+        ]
+    },
+
+    {
+        "name": "Microsoft Office 365",
+        "url": "http://office.com/myaccount",
+        "difficulty": "easy",
+        "domains": [
+            "office.com"
+        ]
+    },
+
+    {
+        "name": "Mint",
+        "url": "https://mint.com",
+        "difficulty": "easy",
+        "notes": "Go to 'Settings', then 'Sign In & Security', then scroll down to 'Delete your Mint account'. Enter your email and password again and click 'Delete'.",
+        "domains": [
+            "mint.com"
+        ]
+    },
+
+    {
+        "name": "MisterWong",
+        "url": "http://www.mister-wong.de",
+        "email": "support@mister-wong.de",
+        "difficulty": "hard",
+        "notes": "You need to send an email to support and it may take up to 48 hours to process your request.",
+        "notes_de": "Sie müssen eine E-Mail an den Support senden. Es kann bis zu 48 Stunden brauchen Ihre Anfrage zu bearbeiten.",
+        "domains": [
+            "mister-wong.de"
+        ]
+    },
+
+    {
+        "name": "MixCloud",
+        "url": "http://www.mixcloud.com/myaccount/account/",
+        "difficulty": "easy",
+        "domains": [
+            "mixcloud.com"
+        ]
+    },
+
+    {
+        "name": "Mixlr",
+        "url": "http://mixlr.com/settings/account/delete/",
+        "difficulty": "easy",
+        "notes": "Login to your account, go to account section of the settings page and choose the \"delete account\" option.",
+        "domains": [
+            "mixlr.com"
+        ]
+    },
+
+    {
+        "name": "Mobify",
+        "url": "http://www.mobify.com/contact/",
+        "difficulty": "hard",
+        "notes": "You have to send a message in order to remove your account.",
+        "domains": [
+            "mobify.com"
+        ]
+    },
+
+    {
+        "name": "Mobills",
+        "url": "https://web.mobillsapp.com/Configuracoes/DeletaConta",
+        "difficulty": "easy",
+        "notes": "Just click the delete button. Note that if you have made an account via Google or Facebook, you'll have to change the password first.",
+        "notes_es": "Solo haz clic en el boton de borrar cuenta. Si creaste tu cuenta con Google o Facebook, primero debes cambiar tu contraseña.",
+        "domains": [
+            "mobillsapp.com"
+        ]
+    },
+
+    {
+        "name": "Mockflow",
+        "url": "http://support.mockflow.com/article/10-can-i-delete-my-mockflow-account",
+        "difficulty": "easy",
+        "notes": "Login to your account -> Open the menu and choose My Account -> In the Profile Details tab click on 'Delete Account' & confirm deletion by entering your password.",
+        "domains": [
+            "mockflow.com"
+        ]
+    },
+
+    {
+        "name": "Mojang",
+        "url": "https://account.mojang.com/me/settings",
+        "difficulty": "easy",
+        "notes": "If you have registered a Mojang account and would like to delete your account, please visit your account settings page. Please be aware that if your account is deleted, you will no longer be able to log into Mojang services, and will not be able to purchase future Mojang games.",
+        "notes_fr": "Si vous avez créé un compte Mojang et vous voulez le supprimer, veuillez visitez vos parametres. Sachez que si vous supprimez votre compte, vous ne pourrez plus vous connecter aux services Mojang, et vous ne pourrez plus acheter les jeux de Mojang à l'avenir.",
+        "notes_it": "Se desideri cancellare il tuo account, visita la pagina impostazioni. Se elimini il tuo account, non potrai piu loggare nei servizi Mojang, e non potrai piu acquistare dei giochi Mojang in futuro.",
+        "notes_pt_br": "Se você registrou uma conta Mojango e gostaria de deletá-la, visite a página de configurações da conta. Lembre-se de que se sua conta for deletada, você não poderá mais fazer login nos serviços Mojang, e não poderá adquirir futuros jogos da Mojang.",
+        "notes_cat": "Si vostè es va registrar a Mojang i ara vol esborrar el seu compte, visiti la página de configuració del compte. Tingui en compte que si l'elimina no podrà entrar més amb els serveis de Mojang i no podrà adquirir futurs jocs de Mojang.",
+        "notes_es": "Si te habías registrado en Mojang y ahora quieres borrar tu cuenta, visita la página de configuración de la cuenta. Te comunicas que si lo eliminaras, no podrás usar los servicios de Mojang y no podrás comprar juegos de Mojang en el futuro.",
+        "domains": [
+            "mojang.com"
+        ]
+    },
+
+    {
+        "name": "Money Dashboard",
+        "url": "http://help.moneydashboard.com/hc/requests/new",
+        "difficulty": "hard",
+        "notes": "If you wish to delete your account and its belonging data and bank accounts held within it, you have to submit a request to the user support (or send an e-mail to support@moneydashboard.com). Make it clear that you require the full deletion of your account, not simply the deletion of one of your bank accounts. If you only want to delete/remove a bank account, but keep your Money Dashboard account open, please visit <a href=\"http://help.moneydashboard.com/entries/21936798\">http://help.moneydashboard.com/entries/21936798</a>",
+        "email": "support@moneydashboard.com",
+        "domains": [
+            "moneydashboard.com"
+        ]
+    },
+
+    {
+        "name": "Monster",
+        "url": "http://my.monster.com/Account/CancelMembership",
+        "difficulty": "easy",
+        "domains": [
+            "monster.com"
+        ]
+    },
+
+    {
+        "name": "Moonpig",
+        "url": "https://photobox-mp.custhelp.com/",
+        "difficulty": "hard",
+        "notes": "Contact customer services and they'll respond in 24-48 hours. Not to mention the ways they try to hide you removing your card details. If you want to remove your card details, do the following: The easiest way to do this would be to go to the My Account page then click on the ‘Add Moonpig Prepay Credit’ link, click on the Buy link and your saved card details will be shown onscreen. Click on the ‘Remove Card’ option.",
+        "domains": [
+            "moonpig.com",
+            "moonpig.co.uk"
+        ]
+    },
+
+    {
+        "name": "Morningstar",
+        "url": "http://socialize.morningstar.com/feedback/feedbackform.asp",
+        "difficulty": "hard",
+        "notes": "Fill out the feedback form, asking them to delete your account. Be sure to specify that you’re not just unsubscribing from e-mail but that you want your account deleted entirely.",
+        "notes_fr": "Completez le formulaire d'opinion en les demandant de supprimer votre compte. Soyez sûr que vous supprime votre compte totalement.",
+        "domains": [
+            "morningstar.com"
+        ]
+    },
+
+    {
+        "name": "Moviepilot.de",
+        "url": "http://www.moviepilot.de/users/null/edit_membership",
+        "difficulty": "easy",
+        "domains": [
+            "moviepilot.de"
+        ]
+    },
+
+    {
+        "name": "Mozilla Developer Network (MDN)",
+        "url": "http://bugzilla.mozilla.org/enter_bug.cgi?product=developer.mozilla.org",
+        "difficulty": "hard",
+        "notes": "Log in to <a href=\"http://bugzilla.mozilla.org\">Bugzilla</a> and <a href=\"http://bugzilla.mozilla.org/enter_bug.cgi?product=developer.mozilla.org\">create a bug report</a> to request the deletion of your account. (examples: <a href=\"http://bugzilla.mozilla.org/show_bug.cgi?id=1576401\">#1576401</a> and <a href=\"http://bugzilla.mozilla.org/show_bug.cgi?id=1353345\">#1353345</a>)</br></br><strong>Warning:</strong> MDN cannot handle account deletes automatically. In order to delete your account, you will need to create a \"Bug Report\" on Bugzilla and make your request trough it. If you have made contributions to the <a href=\"http://developer.mozilla.org/docs/Web\">MDN Web Docs</a>, you will also need to specify what you would like to happen with them after deleting your account..",
+        "notes_pt_br": "Faça login na <a href=\"http://bugzilla.mozilla.org\">Bugzilla</a> e <a href=\"http://bugzilla.mozilla.org/enter_bug.cgi?product=developer.mozilla.org\">crie um bug report</a> para solicitar a exclusão da sua conta. (exemplos: <a href=\"http://bugzilla.mozilla.org/show_bug.cgi?id=1576401\">#1576401</a> e <a href=\"http://bugzilla.mozilla.org/show_bug.cgi?id=1353345\">#1353345</a>)</br></br><strong>Aviso:</strong> A MDN não pode processar exclusões de contas de forma automática. Para que seja possível excluir sua conta, você precisará criar um \"Bug Report\" na Bugzilla e requisitar a exclusão da sua conta a partir de lá. Caso você tenha feito contribuições ao <a href=\"http://developer.mozilla.org/docs/Web\">MDN Web Docs</a>, você também precisará especificar o que gostaria que acontecesse com suas contribuições após a exclusão da sua conta.",
+        "domains": [
+            "developer.mozilla.org"
+        ]
+    },
+
+    {
+        "name": "Mozilla/Firefox",
+        "url": "http://accounts.firefox.com/settings/delete_account",
+        "difficulty": "easy",
+        "notes": "“Cancel your account” link at the bottom of the page.",
+        "notes_fr": "Cliquez le lien « Cancel your account » au bas de la page.",
+        "notes_it": "“Cancel your account” in fondo alla pagina.",
+        "notes_pt_br": "Link “Cancel your account” no final da página.",
+        "notes_cat": "“Cancel your account” al final de la pàgina.",
+        "notes_es": "“Cancel your account” al final de la página.",
+        "notes_pl": "Kliknij “Cancel your account” na dole strony.",
+        "domains": [
+            "addons.mozilla.org",
+            "accounts.firefox.com"
+        ]
+    },
+
+    {
+        "name": "Multiplay.co.uk",
+        "url": "https://multiplay.com/contactus/",
+        "difficulty": "hard",
+        "notes": "You have to contact Multiplay by their contact us page.",
+        "notes_fr": "Vous devez contactez Multiplay par le formulaire de contact.",
+        "notes_es": "Tienes que contactar a Multiplay a través de su página contactanos.",
+        "domains": [
+            "multiplay.com"
+        ]
+    },
+
+    {
+        "name": "Munzee",
+        "url": "https://www.munzee.com/privacy/",
+        "difficulty": "hard",
+        "notes": "Send an e-mail to privacy@freezetag.com. This email should include your first name, last name, e-mail address and, if applicable, your social network ID for the social network from which you access these services. (for example, your Facebook user ID)",
+        "email": "privacy@freezetag.com",
+        "domains": [
+            "munzee.com"
+        ]
+    },
+
+    {
+        "name": "MusicBrainz",
+        "url": "https://musicbrainz.org/account/edit",
+        "difficulty": "easy",
+        "notes": "Click on delete my account at the bottom of the page",
+        "domains": [
+            "musicbrainz.org"
+        ]
+    },
+
+    {
+        "name": "My Fitness Pal",
+        "url": "http://www.myfitnesspal.com/en/account/confirm_delete",
+        "difficulty": "easy",
+        "notes": "Just login and head to the account settings to click on delete account.",
+        "domains": [
+            "myfitnesspal.com"
+        ]
+    },
+
+    {
+        "name": "MyFRITZ!",
+        "url": "https://sso.myfritz.net/account/#/delete",
+        "difficulty": "easy",
+        "notes": "Login and select 'Delete Account' in the sidebar in your account settings",
+        "notes_de": "Einloggen und in den Kontoeinstellungen 'Konto löschen' aus der Seitenleiste wählen.",
+        "domains": [
+            "myfritz.net",
+            "sso.myfritz.net"
+        ]
+    },
+
+    {
+        "name": "myJdownloader",
+        "url": "http://my.jdownloader.org/",
+        "difficulty": "easy",
+        "notes": "Go to your account settings (top right, click on your E-Mail-Adress) and select 'Delete Account'",
+        "notes_de": "Gehe zu deinen Account-Einstellungen (oben rechts, klicke auf deine E-Mail-Adresse) und wähle 'Delete Account' aus.",
+        "domains": [
+            "jdownloader.org"
+        ]
+    },
+
+    {
+        "name": "MyLife.com",
+        "url": "http://www.mylife.com/showDeleteAccount.do",
+        "difficulty": "easy",
+        "domains": [
+            "mylife.com"
+        ]
+    },
+
+    {
+        "name": "MyScript",
+        "url": "https://sso.myscript.com/v1/api/account/delete/request",
+        "difficulty": "easy",
+        "notes": "Accessing the URL triggers a confirmation mail containing a deletion link. Click this link and your account will be deleted immediately.",
+        "notes_de": "Die URL sendet eine E-Mail mit einem Löschen-Link. Wird dieser Link angeklickt, wird das Konto sofort gelöscht.",
+        "domains": [
+            "myscript.com"
+        ]
+    },
+
+    {
+        "name": "MySpace",
+        "url": "https://myspace.com/settings/profile",
+        "difficulty": "easy",
+        "domains": [
+            "myspace.com"
+        ]
+    },
+
+    {
+        "name": "Namecheap",
+        "url": "https://www.namecheap.com/support/knowledgebase/article.aspx/303/44/how-do-i-cancel-or-close-my-account-with-you",
+        "difficulty": "hard",
+        "notes": "You have to contact Customer Support to delete your account, and provide your account username, support pin and reason why you would like to close your account.",
+        "domains": [
+            "namecheap.com"
+        ]
+    },
+
+    {
+        "name": "NaNoWriMo",
+        "url": "https://nanowrimo.org/account_settings",
+        "difficulty": "easy",
+        "notes": "At the bottom of the Account Settings page is a \"Delete My Account\" button. Your account will be \"disabled and scheduled for permanent deletion.\" After 30 days, \"your past novels, author profile, and unique account info will be permanently deleted.\" It is unclear if forum posts will be deleted.",
+        "domains": [
+            "nanowrimo.org"
+        ]
+    },
+
+    {
+        "name": "Napster",
+        "url": "http://www.napster.com/",
+        "difficulty": "impossible",
+        "domains": [
+            "napster.com"
+        ]
+    },
+
+    {
+        "name": "Native Instruments",
+        "url": "https://support.native-instruments.com/hc/requests/new",
+        "difficulty": "hard",
+        "notes": "Fill the ticket form and wait for response.",
+        "domains": [
+            "native-instruments.com",
+            "support.native-instruments.com"
+        ]
+    },
+
+    {
+        "name": "Nearpod",
+        "url": "http://www.nearpod.com/contact/",
+        "difficulty": "hard",
+        "notes": "Requires to fill out contact form. Will still get Promotional emails until you also unsubscribe from them",
+        "domains": [
+            "nearpod.com"
+        ]
+    },
+
+    {
+        "name": "Neopets",
+        "url": "http://www.neopets.com/help_search.phtml?help_id=4",
+        "difficulty": "hard",
+        "notes": "Send an email to the unsubscribe@neopets.com stating you wish to delete your account.",
+        "notes_fr": "Envoyez un e-mail à unsubscribe@neopets.com, en déclarant que vous voulez supprimer votre compte.",
+        "email": "unsubscribe@neopets.com",
+        "domains": [
+            "neopets.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Netflix",
+        "url": "https://help.netflix.com/en/node/407",
+        "difficulty": "impossible",
+        "notes": "Contact customer services. Even then they may not delete your account under the premise that you might want to rejoin and keep your history and recommendations.",
+        "notes_fr": "Contactez le service clients.",
+        "notes_it": "Contatta il servizio clienti.",
+        "notes_pt_br": "Contate a assistência ao cliente. Mesmo assim eles não deletarão sua conta sobre a premissa que talvez você queira retornar em manter seu histórico e recomendações.",
+        "notes_cat": "Contacti amb el servei d'assistència al client. No s'eliminarà completament, sota la premisa de que potser voldràs reobrir el compte i mantindre l'historial i les notificacions.",
+        "notes_es": "Contacta con el servicio de asistencia al cliente. No se eliminará completamente, bajo la suposición de que quizás querrás reabrir la cuenta y mantener el historial y las notificaciones.",
+        "domains": [
+            "netflix.com"
+        ]
+    },
+
+    {
+        "name": "Netlify",
+        "url": "https://app.netlify.com/account/settings/general#danger-zone",
+        "difficulty": "easy",
+        "notes": "Press the 'delete' button and then enter your name to confirm.",
+        "domains": [
+            "netlify.com"
+        ]
+    },
+
+    {
+        "name": "Netlog",
+        "url": "http://en.netlog.com/go/login",
+        "difficulty": "easy",
+        "notes": "Select 'settings', then 'account', then 'delete'.",
+        "notes_fr": "Selectionnez « Settings », puis « Account », puis « Delete ».",
+        "notes_it": "Seleziona 'settings', quindi 'account' e infine 'delete'.",
+        "notes_pt_br": "Selecione 'settings', então 'account', e 'delete'.",
+        "notes_cat": "Seleccioni 'settings', a continuació 'account' i 'delete'.",
+        "notes_es": "Selecciona 'settings', a continuación 'account' y 'delete'.",
+        "domains": [
+            "netlog.com"
+        ]
+    },
+
+    {
+        "name": "Netology",
+        "url": "http://netology.ru",
+        "difficulty": "impossible",
+        "notes": "It is not possible to delete your account.  The best you can do is delete any personal information that you have stored on their website.",
+        "notes_ru": "Никаких пунктов для удаления профиля нет, и похоже, обращение через техподдержку для такого не предусмотрено; проще потереть все персональные данные с их сайта",
+        "domains": [
+            "netology.ru"
+        ]
+    },
+
+    {
+        "name": "Netvibes",
+        "url": "http://www.netvibes.com/account/unsubscribe",
+        "difficulty": "easy",
+        "domains": [
+            "netvibes.com"
+        ]
+    },
+
+    {
+        "name": "New Relic",
+        "url": "https://docs.newrelic.com/docs/accounts-partnerships/accounts/account-maintenance/delete-your-new-relic-account",
+        "difficulty": "easy",
+        "notes": "From the New Relic menu bar, select (account) > Upgrade subscription > Cancel account. Select the confirmation prompt.",
+        "domains": [
+            "newrelic.com"
+        ]
+    },
+
+    {
+        "name": "New York Times",
+        "url": "https://myaccount.nytimes.com/membercenter/help.html",
+        "difficulty": "hard",
+        "notes": "Use the form to write to customer services and ask them to close your account.",
+        "notes_fr": "Vous pouvez utilisez le formulaire pour écrire au service clients et pour leur demander de supprimer votre compte.",
+        "notes_it": "Usa il modulo per scrivere all'assistenza clienti e chiedere la chiusura del tuo account.",
+        "notes_pt_br": "Use o formulário para escrever à assistência ao cliente e peça-os para fechar sua conta.",
+        "notes_cat": "Utilitzi el formulari per escriure a l'assistència al client i demar-lis la clausura del compte.",
+        "notes_es": "Usa el formulario para escribir a asistencia al cliente y pideles el cierre de la cuenta.",
+        "domains": [
+            "nytimes.com"
+        ]
+    },
+
+    {
+        "name": "NewsBlur",
+        "url": "https://www.newsblur.com/profile/delete_account",
+        "difficulty": "easy",
+        "domains": [
+            "newsblur.com"
+        ]
+    },
+
+    {
+        "name": "Nexus mods",
+        "url": "https://www.nexusmods.com/",
+        "difficulty": "impossible",
+        "notes": "Accounts can only be closed, but not deleted.",
+        "domains": [
+            "nexusmods.com"
+        ]
+    },
+
+    {
+        "name": "Nike+",
+        "url": "https://secure-nikeplus.nike.com/plus/settings/",
+        "difficulty": "easy",
+        "notes": "At the bottom of the account form, there is a 'Deactivate Account' button. Upon clicking, there will be a set of information that explains the process of account deactivation. All account information will be deleted.",
+        "notes_fr": "Au bas du formulaire du compte, il y a un lien « Deactivate Account ». En le cliquant, il y aura une liste des informations qui expliquent le processus de la désactivation du compte. Toutes les informations seront supprimées.",
+        "domains": [
+            "nike.com"
+        ]
+    },
+
+    {
+        "name": "Ninox",
+        "url": "https://ninoxdb.de/de/support/contactus",
+        "difficulty": "hard",
+        "notes": "Contact Support via the online contact form and request your account to be deleted. Alternatively you can use the support E-Mail address.",
+        "notes_de": "Über das Online-Kontaktformular kann der Support gebeten werden, den Account zu löschen. Alternativ lässt sich auch per E-Mail Kontakt aufnehmen.",
+        "email": "support@ninoxdb.de",
+        "domains": [
+            "ninoxdb.de"
+        ]
+    },
+
+    {
+        "name": "njal.la",
+        "url": "https://njal.la/",
+        "difficulty": "hard",
+        "notes": "You have to mail them to request deletion",
+        "email": "contact@njal.la",
+        "domains": [
+            "njal.la"
+        ]
+    },
+
+    {
+        "name": "NoIP",
+        "url": "http://www.noip.com/members/account/delete.php",
+        "difficulty": "easy",
+        "notes": "Check the box to confirm and then click 'Change'.",
+        "notes_fr": "Cochez la case pour confirmer, puis cliquez « Change ».",
+        "domains": [
+            "noip.com"
+        ]
+    },
+
+    {
+        "name": "The Noun Project",
+        "url": "https://thenounproject.zendesk.com/hc/en-us/articles/200509678-How-can-I-deactivate-my-user-account-",
+        "email": "info@thenounproject.com",
+        "difficulty": "hard",
+        "notes": "'Email us at info@thenounproject.com and we'll deactivate your account.'",
+        "domains": [
+            "thenounproject.com"
+        ]
+    },
+
+    {
+        "name": "NOW TV",
+        "url": "https://help.nowtv.com/contact-us/how-do-i-cancel-now-tv",
+        "difficulty": "impossible",
+        "notes": "You must first cancel any active passes under 'My Account' > 'My Passes'. After this, you can contact the live chat and ask for your billing information to be removed. Your account must remain inactive for an indeterminate amount of time before the remaining data will be removed 'in accordance with our group data retention and deletion policies'.",
+        "domains": [
+            "nowtv.com"
+        ]
+    },
+
+    {
+        "name": "Odnoklassniki",
+        "url": "http://www.odnoklassniki.ru/regulations",
+        "difficulty": "easy",
+        "notes": "Login to your account, scroll License Agreement down, click Delete profile, check any boxes you want, enter password and press Remove button.",
+        "notes_fr": "Connectez-vous, faites défiler le contrat, cliquez sur « Delete profile », cochez les cases que vous voulez, entrez votre mot de passe et cliquez sur « Remove ».",
+        "notes_it": "Fai il login, scorri il contratto, premi Delete profile, fai il tick sulle caselle che vuoi, inserisci la password e premi il pulsante Remove.",
+        "notes_pt_br": "Faça login em sua conta, vá até o License Agreement, clique em Delete profile, marque as caixas que você quiser, digite sua senha e pressione o botão Remove.",
+        "notes_cat": "Entri al seu compte, baixi fins a 'License Agreement', cliqui a 'Delete profile', marqui les caselles que desitgi, entri la seva clau i faci clic a 'Remove'.",
+        "notes_es": "Entra en tu cuenta, desplázate hasta 'License Agreement', pulsa 'Delete profile', marca las casillas que desees, entra tu contraseña y haz clic en 'Remove'.",
+        "domains": [
+            "odnoklassniki.ru"
+        ]
+    },
+
+    {
+        "name": "OkCupid",
+        "url": "https://www.okcupid.com/settings",
+        "difficulty": "easy",
+        "notes": "Visit your settings page, and select 'Delete Account'",
+        "notes_fr": "Visitez vos paramatres et selectionnez « Delete Account ».",
+        "notes_it": "Visita la pagina impostazioni, quindi seleziona 'Delete Account'",
+        "notes_pt_br": "Visite a sua página de configurações, e selecione 'Delete Account'",
+        "notes_cat": "Visiti la pàgina de paràmetres, i seleccioni 'Delete Account'",
+        "notes_es": "Visita la página de parámetros, y selecciona 'Delete Account'",
+        "domains": [
+            "okcupid.com"
+        ]
+    },
+
+    {
+        "name": "Onet",
+        "url": "https://konto.onet.pl/data.html",
+        "difficulty": "easy",
+        "notes": "You just need to click 'Delete account', then enter your account password and tick the checkbox",
+        "domains": [
+            "onet.pl"
+        ]
+    },
+
+    {
+        "name": "Online.net",
+        "url": "https://console.online.net/fr/assistance/ticket",
+        "difficulty": "impossible",
+        "notes": "The french law forces them to keep your account because it's linked to your bills.",
+        "domains": [
+            "online.net"
+        ]
+    },
+
+    {
+        "name": "OnlineTVRecorder.com",
+        "url": "http://www.onlinetvrecorder.com/v2/index.php?go=account&do=cancel",
+        "difficulty": "impossible",
+        "notes": "You can deactivate your account with the link. But the data isn't deleted. Even if you contact the support they don't delete your data.",
+        "notes_fr": "Vous pouvez désactiver votre compte avec le lien. Cependant, les données ne sont pas supprimées. Même si vous contactez le support du site, il ne supprime pas vos données.",
+        "notes_it": "Puoi disattivare il tuo account. Ma i dati non saranno cancellati neanche se contatti il supporto.",
+        "notes_de": "Du kannst deinen Account mit dem Link deaktivieren, aber deine Daten werden nicht gelöscht. Auch wenn du den Support kontaktierst, können sie deine Daten nicht löschen.",
+        "notes_pt_br": "Você pode desativar sua conta neste link. Mas os dados não são deletados. Mesmo se você contatar o suporte eles não irão apagar seus dados.",
+        "notes_cat": "Pot desactivar el seu compte amb l'enllaç. Però les dades no poden ser esborrades. Encara que contacti amb Atenció al client no esborraran les seves dades.",
+        "notes_es": "Puedes desactivar tu cuenta con el enlace. Pero los datos no pueden ser borrados, aunque contacta con atención al cliente no borrarán sus datos.",
+        "domains": [
+            "onlinetvrecorder.com"
+        ]
+    },
+
+    {
+        "name": "OpenCores",
+        "url": "https://opencores.org/",
+        "difficulty": "impossible",
+        "notes": "Though they state you can mail them, the e-mail bounces back.",
+        "domains": [
+            "opencores.org"
+        ]
+    },
+
+    {
+        "name": "OpenDNS",
+        "url": "http://www.opendns.com/support/contact/",
+        "difficulty": "easy",
+        "notes": "Seems to have a button to delete account when heading to open the ticket.",
+        "notes_pt_br": "Parece ter um botão para deletar a conta ao ir abrir o ticket.",
+        "notes_es": "Parece que tiene un botón para eliminar la cuenta en el camino donde se abre el billete.",
+        "email": "contact@opendns.com",
+        "domains": [
+            "opendns.com"
+        ]
+    },
+
+    {
+        "name": "OpenShift",
+        "url": "https://developers.openshift.com/en/account-overview.html#_how_do_i_delete_my_account",
+        "difficulty": "impossible",
+        "notes": "You can't delete your account including all data, only a ‘soft delete’ is possible where you can always re-enable your account.",
+        "notes_de": "Es ist nicht möglich das Konto mit allen Daten zu löschen, es ist nur ein 'weiches Löschen' möglich, bei dem es immer die Möglichkeit des Wieder-Aktivierens gibt."
+    },
+
+    {
+        "name": "Orkut",
+        "url": "https://support.google.com/orkut/",
+        "difficulty": "easy",
+        "domains": [
+            "orkut.google.com"
+        ]
+    },
+
+    {
+        "name": "OSBuddy",
+        "url": "https://rsbuddy.com/osbuddy/docs/privacy",
+        "email": "support@rsbuddy.com",
+        "difficulty": "hard",
+        "notes": "You must contact support via your account's registered email address to request deletion.",
+        "domains": [
+            "osbuddy.com",
+            "rsbuddy.com"
+        ]
+    },
+
+    {
+        "name": "Osu!",
+        "url": "https://osu.ppy.sh/help/wiki/Help_Center",
+        "difficulty": "impossible",
+        "domains": [
+            "osu.ppy.sh"
+        ]
+    },
+
+    {
+        "name": "Outdooractive",
+        "url": "https://support.outdooractive.com/hc/en-us/articles/201186213-How-can-I-delete-my-community-account-",
+        "difficulty": "hard",
+        "notes": "Contact Support via the online form and request your account to be deleted.",
+        "notes_de": "Kontaktiere den Support über das Online-Formular und fordere eine Löschung des Accounts an.",
+        "domains": [
+            "outdooractive.com"
+        ]
+    },
+
+    {
+        "name": "Outlook",
+        "url": "https://account.live.com/CloseAccount.aspx",
+        "difficulty": "easy",
+        "domains": [
+            "live.com"
+        ]
+    },
+
+    {
+        "name": "Overcast.fm",
+        "url": "https://overcast.fm/account",
+        "difficulty": "impossible",
+        "domains": [
+            "overcast.fm"
+        ]
+    },
+
+    {
+        "name": "Overleaf",
+        "url": "https://www.overleaf.com/user/settings",
+        "difficulty": "easy",
+        "notes": "Select 'Delete your account' at the bottom of the account settings page.",
+        "email": "privacy@overleaf.com",
+        "domains": [
+            "overleaf.com"
+        ]
+    },
+
+    {
+        "name": "Overstock",
+        "url": "https://help.overstock.com/help/s/article/Customer-Care-Contact-Information",
+        "difficulty": "hard",
+        "notes": "You must contact support directly and ask them to invalidate your account.  However, your transaction data may not be deleted from their records.",
+        "notes_fr": "Vous devez contactez le support directement pour leur demander d'invalider votre compte. Cependant, vos donnéés des transcations ne peuvent pas être supprimées.",
+        "domains": [
+            "overstock.com"
+        ]
+    },
+
+    {
+        "name": "Pandora",
+        "url": "https://www.pandora.com/settings/info",
+        "difficulty": "easy",
+        "notes": "Scroll down to delete my account and click it, click delete account, type in your password, then hit submit. If you have Pandora Plus or Premium, cancel your subscription, wait for it to expire, then delete.",
+        "domains": [
+            "pandora.com"
+        ]
+    },
+
+    {
+        "name": "Pantheon",
+        "url": "https://dashboard.pantheon.io/#account/delete/Delete",
+        "difficulty": "easy",
+        "notes": "In order to delete an account, you first have to delete all active Sites, or transfer the ownership.",
+        "notes_de": "Um den Account löschen zu können, müssen Sie zunächst alle aktiven Webseiten löschen, oder diese an jemand anderen übertragen.",
+        "domains": [
+            "pantheon.io"
+        ]
+    },
+
+    {
+        "name": "Paper by FiftyThree",
+        "url": "https://paper.fiftythree.com/settings",
+        "difficulty": "medium",
+        "notes": "Login to your account, go to settings, underneath 'Request account deletion' click 'submitting a request'. Enter your e-mail address and click 'Delete account'. Might take some days until the account gets deleted.",
+        "domains": [
+            "fiftythree.com"
+        ]
+    },
+
+    {
+        "name": "Parcello",
+        "url": "https://www.parcello.org/settings",
+        "difficulty": "easy",
+        "notes": "Go to settings, click 'Delete account' underneath 'Miscellaneous'. Confirm this process in the modal. Works within the app as well.",
+        "notes_de": "Einstellungen öffnen → Auf 'Account löschen' unter 'Sonstiges' klicken → Mit 'Ja, Löschen!' bestätigen. Geht auch über die App.",
+        "domains": [
+            "parcello.org"
+        ]
+    },
+
+    {
+        "name": "Parkmobile",
+        "url": "https://parkmobile.zendesk.com/hc/en-us/articles/203299300-How-do-I-cancel-my-account-",
+        "difficulty": "hard",
+        "email": "helpdesk@parkmobileglobal.com",
+        "notes": "To cancel your account, send an e-mail message request to the Parkmobile Help Desk at helpdesk@parkmobileglobal.com and include your name, mobile number, license plate number, and/or the last 4 digits of the card we have on file for you. After the Help Desk cancels your account, you will receive a confirmation e-mail message.",
+        "domains": [
+            "parkmobile.us",
+            "parkmobile.com",
+            "parkmobile.zendesk.com"
+        ]
+    },
+
+    {
+        "name": "Passdock",
+        "url": "https://api.passdock.com/users/edit",
+        "difficulty": "easy",
+        "notes": "Select 'Delete account' at the bottom of your account info page.",
+        "notes_de": "Klicke 'Account löschen' unten auf der Account-Info-Seite.",
+        "domains": [
+            "passdock.com",
+            "api.passdock.com"
+        ]
+    },
+
+    {
+        "name": "Pastebin",
+        "url": "http://pastebin.com/delete_account",
+        "difficulty": "easy",
+        "notes": "Password is required for deletion. Pastes will be removed and the username cannot be used again. No Recovery after deletion.",
+        "domains": [
+            "pastebin.com"
+        ]
+    },
+
+    {
+        "name": "Path",
+        "url": "https://path.com",
+        "difficulty": "medium",
+        "notes": "You cannot delete your account from the website. Open the iOS/Android app, go to settings → about → disable account → delete account.",
+        "notes_fr": "Vous ne pouvez pas supprimer votre compte su site web. Ouvrez l'appli iOS/Androis, allez dans les parametres → about → disable account → delete account.",
+        "notes_it": "Non puoi cancellare il tuou account. Apri l'app iOS/Android, vai su go to settings → about → disable account → delete account.",
+        "notes_pt_br": "Você não pode deletar sua conta do site. Abra o aplicativo iOS/Android, vá em settings → about → disable account → delete account.",
+        "notes_cat": "No podrà esborrar el seu compte de la web. Obri l'aplicació d'iOS/Android, vagi a settings → about → disable account → delete account.",
+        "notes_es": "No podrás borrar tu cuenta de la web. Abre la aplicación de iOS/Android, ve a settings → about → disable account → delete account.",
+        "domains": [
+            "path.com"
+        ]
+    },
+
+    {
+        "name": "Patrick Krempf Reminder",
+        "url": "http://reminder.patrickkempf.de/manage.php?do=delaccount",
+        "difficulty": "easy",
+        "domains": [
+            "patrickkempf.de"
+        ]
+    },
+
+    {
+        "name": "PayPal",
+        "url": "https://www.paypal.com/us/cgi-bin/webscr?cmd=_close-account",
+        "difficulty": "impossible",
+        "notes": "Log in. Click 'Profile' near the top of the page. Click 'My settings'. Click 'Close Account' in the 'Account type' section and follow the steps listed. Your account is never deleted though.",
+        "domains": [
+            "paypal.com"
+        ]
+    },
+
+    {
+        "name": "PaySera",
+        "url": "https://bank.paysera.com/l.php?tmpl_into=middle&tmpl_name=m_helpdesk_ask_your_question",
+        "difficulty": "hard",
+        "notes": "Quote from the support staff: If you want to delete your Paysera account completely, please write us an email (support@paysera.com) with a request and indicate why you want to delete your account. This email has to be sent from the email address that you use to log in to your Paysera account. Please be informed that if you delete your account, you will not be able to create a new account in the future. Paysera account is free of charge and we recommend not to delete it, but close the account, and you will be able to activate it in the future yourself by logging in to your Paysera account.",
+        "notes_de": "Um den Account komplett zu löschen muss von der für die Registrierung verwendeten E-Mail-Adresse eine E-Mail an support@paysera.com in Englisch geschrieben werden. Hier dann darum bitten, dass der Account komplett gelöscht werden soll. Laut Support kann dann in Zukunft kein neuer Account angelegt werden.",
+        "email": "support@paysera.com",
+        "domains": [
+            "paysera.com"
+        ]
+    },
+
+    {
+        "name": "PCPartPicker",
+        "url": "http://pcpartpicker.com/",
+        "difficulty": "easy",
+        "notes": "Click the delete account on your account preferences.",
+        "domains": [
+            "pcpartpicker.com"
+        ]
+    },
+
+    {
+        "name": "Peak",
+        "url": "http://www.peak.net/",
+        "difficulty": "hard",
+        "notes": "You must send an e-mail to support@peak.net requesting deletion. You will then receive a response from support asking for feedback and to confirm the deletion. The next e-mail you receive from support will notify you that your account has been deleted.",
+        "notes_fr": "Il faut que vous demandez la suppression de votre compte dans un e-mail que vous envoyez à support@peak.net. Vous recevrez une réponse qui demande à la fois vos impressions de l'appli et une confirmation de la suppression. L'e-mail prochain que vous recevrez vous notifiera la suppression de votre compte.",
+        "email": "support@peak.net",
+        "domains": [
+            "www.peak.net"
+        ]
+    },
+
+    {
+        "name": "Penflip",
+        "url": "https://www.penflip.com/profile/account",
+        "difficulty": "easy",
+        "notes": "You only need to click on 'Delete Account' on your account site.",
+        "notes_de": "Auf der Account Seite auf 'Delete Account' klicken.",
+        "domains": [
+            "penflip.com"
+        ]
+    },
+
+    {
+        "name": "Penzu",
+        "url": "https://penzu.com/app/account/delete",
+        "difficulty": "easy",
+        "notes": "Click on 'Delete Penzu Account'. Confirm the deletion through the link sent to your email address.",
+        "domains": [
+            "penzu.com"
+        ]
+    },
+
+    {
+        "name": "The Perfect Shave",
+        "url": "https://www.perfect-shave.de/einstellungen",
+        "difficulty": "easy",
+        "notes": "Click on 'Konto löschen' and then on 'Mein Konto jetzt unwiederruflich löschen'",
+        "notes_de": "Klicke auf 'Konto löschen' und dann auf 'Mein Konto jetzt unwiederruflich löschen",
+        "domains": [
+            "perfect-shave.de"
+        ]
+    },
+
+    {
+        "name": "Personal Capital",
+        "url": "https://home.personalcapital.com/page/login/app#/settings",
+        "difficulty": "easy",
+        "notes": "Click 'DELETE USER ACCOUNT' at the bottom of the settings page.",
+        "domains": [
+            "personalcapital.com"
+        ]
+    },
+
+    {
+        "name": "Personello Germany",
+        "url": "http://de.personello.com/mypersonello/index/feedback",
+        "difficulty": "hard",
+        "notes": "It is necessary to contact the support, for example through 'Mein Konto' -> 'Meinung abgeben'.",
+        "notes_de": "Es ist nötig den Support zu kontaktieren oder über das Webinterface seine Meinung abzugeben unter 'Mein Konto' -> 'Meinung abgeben'"
+    },
+
+    {
+        "name": "Philips Hue",
+        "url": "https://account.meethue.com/account",
+        "difficulty": "easy",
+        "notes": "Click 'Delete Account' on your account page.",
+        "notes_de": "Klicke auf 'Konto löschen' in den Kontoeinstellungen.",
+        "domains": [
+            "meethue.com",
+            "account.meethue.com"
+        ]
+    },
+
+    {
+        "name": "PhishTank",
+        "url": "https://www.phishtank.com/",
+        "difficulty": "impossible",
+        "domains": [
+            "phishtank.com"
+        ]
+    },
+
+    {
+        "name": "Photobucket",
+        "url": "http://s113.photobucket.com/settings/status#",
+        "difficulty": "easy"
+    },
+
+    {
+        "name": "PHP Classes",
+        "url": "http://www.phpclasses.org/faq/#delete-account",
+        "difficulty": "impossible",
+        "notes": "They refuse to delete accounts from the site."
+    },
+
+    {
+        "name": "Picasa",
+        "url": "http://picasaweb.google.com/",
+        "difficulty": "impossible",
+        "notes": "You can't delete your Google Account for Picasa Web Albums without deleting your entire Google Account.",
+        "notes_fr": "Vous ne pouvez pas supprimer votre compte Picassa sans supprimer votre compte Google.",
+        "notes_it": "Non puoi eliminare il tuo account Picasa Web Albums senza eliminare l'intero Account Google.",
+        "notes_pt_br": "Você não pode deletar sua conta Picasa sem deletar toda sua Conta Google.",
+        "notes_cat": "No pot esborrar el seu compte a Picasa sense esborrar el seu compte de Google.",
+        "notes_es": "No puedes borrar tu cuenta de Picasa sin borrar toda la cuenta de Google.",
+        "notes_pl": "Nie ma możliwosći usunięcia konta w usłudze Picasa Web Albums bez usuwania całego konta Google.",
+        "domains": [
+            "picasaweb.google.com",
+            "picasa.google.com"
+        ]
+    },
+
+    {
+        "name": "Pinboard",
+        "url": "https://pinboard.in/faq/#close_account",
+        "difficulty": "hard",
+        "notes": "Send us an e-mail from the address that you have registered - we take care of it.",
+        "email": "support@pinboard.in",
+        "domains": [
+            "pinboard.in"
+        ]
+    },
+
+    {
+        "name": "Pingdom",
+        "url": "https://my.pingdom.com/account/cancel/confirm",
+        "difficulty": "easy",
+        "domains": [
+            "pingdom.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Pinterest",
+        "url": "https://pinterest.com/settings/account-settings/",
+        "difficulty": "medium",
+        "notes": "On the Account Settings, click 'Delete Account', state reason and click 'Next', then 'Send email'. You need to check the e-mail and confirm the deletion.",
+        "domains": [
+            "pinterest.com"
+        ]
+    },
+
+    {
+        "name": "PivotalTracker",
+        "url": "https://www.pivotaltracker.com/",
+        "email": "tracker@pivotal.io",
+        "notes": "You can delete your account using the website, but it is only fully deleted after e-mailing",
+        "difficulty": "medium",
+        "domains": [
+            "pivotaltracker.com"
+        ]
+    },
+
+    {
+        "name": "Pixabay",
+        "url": "https://pixabay.com/de/accounts/settings/",
+        "difficulty": "easy",
+        "notes": "In your account setting choose 'Delete account'.",
+        "notes_de": "Wähle 'Konto Löschen' in den Kontoeinstellungen.",
+        "domains": [
+            "pixabay.com"
+        ]
+    },
+
+    {
+        "name": "Pixlr",
+        "url": "https://pixlr.com/user/settings/",
+        "difficulty": "easy",
+        "notes": "Click on 'Remove account'.",
+        "domains": [
+            "pixlr.com"
+        ]
+    },
+
+    {
+        "name": "Pixum",
+        "url": "https://int.pixum.com/service/delete-account",
+        "difficulty": "hard",
+        "notes": "Contact support via email and request your account to be deleted.",
+        "notes_de": "Schreibe dem Support per E-Mail und bitte um eine Löschung des Accounts",
+        "email": "service@pixum.com"
+    },
+
+    {
+        "name": "PlantSnap",
+        "url": "https://www.plantsnap.com/support-center/get-in-touch/",
+        "difficulty": "medium",
+        "notes": "To delete your account, open the app on your mobile device and click the \"More\" option button. Then click your profile name, from there you will be able to delete your account. If you require additional help, use the contact form provided on their website.",
+        "domains": [
+            "plantsnap.com"
+        ]
+    },
+
+    {
+        "name": "Player FM",
+        "url": "https://player.fm/will-miss-you",
+        "difficulty": "easy",
+        "notes": "In upper right, click the settings button and select \"Help/FAQ\". Select option \"How do I delete my account and leave Player FM?\" - link will be below. Type \"delete\" in the box and click the button to finalize.",
+        "domains": [
+            "player.fm"
+        ]
+    },
+
+    {
+        "name": "PlayPosit",
+        "difficulty": "easy",
+        "notes": "Click your username in the upper right and select Profile, then Delete Account",
+        "domains": [
+            "playposit.com"
+        ]
+    },
+
+    {
+        "name": "PlayStation Network",
+        "url": "https://support.us.playstation.com/app/contact_options",
+        "difficulty": "impossible",
+        "notes": "It is not possible to delete your PlayStation Network account.  The best you can do is delete any personal information that you have stored on their website.",
+        "notes_fr": "Il n'est pas possible de supprimer votre compte PSN. Le meilleur que vous pouvez faire est de supprimer toutes vos informations enregistrées dans le site.",
+        "domains": [
+            "playstation.com"
+        ]
+    },
+
+    {
+        "name": "Plenty of Fish",
+        "url": "http://www.pof.com/deleteaccount.aspx",
+        "difficulty": "easy",
+        "notes": "Fill out the deletion form",
+        "notes_fr": "Completez le formulaire de suppression",
+        "notes_it": "Completa il form per l'eliminazione.",
+        "notes_pt_br": "Preencha o formulário de remoção",
+        "notes_cat": "Completi el formulari d'eliminació del compte",
+        "notes_es": "Completa el formulario de eliminación de la cuenta",
+        "domains": [
+            "pof.com"
+        ]
+    },
+
+    {
+        "name": "Plex.tv",
+        "url": "https://plex.tv/users/edit",
+        "difficulty": "easy",
+        "notes": "Under 'Danger Zone', click 'Delete your account'.",
+        "domains": [
+            "plex.tv"
+        ]
+    },
+
+    {
+        "name": "Pocket",
+        "url": "http://getpocket.com/account_deletion/",
+        "difficulty": "easy",
+        "domains": [
+            "getpocket.com"
+        ]
+    },
+
+    {
+        "name": "Pocket Casts",
+        "url": "https://support.pocketcasts.com/",
+        "difficulty": "hard",
+        "notes": "You must request account deletion via email. If the web player was purchased, access to it will be lost as well.",
+        "email": "support@shiftyjelly.com"
+    },
+
+    {
+        "name": "Pocoyo Club",
+        "url": "https://www.pocoyo.com/en/club/account-cancellation",
+        "difficulty": "easy",
+        "domains": [
+            "pocoyo.com"
+        ]
+    },
+
+    {
+        "name": "Podio",
+        "url": "https://podio.com/settings/account",
+        "difficulty": "easy",
+        "notes": "Log in to your account, press the delete button and type the phrase asked.",
+        "notes_fr": "Connectez-vous, appuyez le bouton « delete », et tapez la phrase demandée.",
+        "domains": [
+            "podio.com"
+        ]
+    },
+
+    {
+        "name": "Points.com",
+        "url": "http://questions.points.com/entries/20026692-How-do-I-cancel-my-account-",
+        "difficulty": "hard",
+        "notes": "Must contact support through Contanct form or online chat.",
+        "notes_fr": "Il faut contacter le support via le formulaire de contact ou le tchat en ligne.",
+        "domains": [
+            "points.com"
+        ]
+    },
+
+    {
+        "name": "pon",
+        "url": "https://my.ponlist.de/de/legal",
+        "difficulty": "easy",
+        "notes": "Open the app → Open Settings → Click on your Account's information → Initiate deletion",
+        "notes_de": "App öffnen → Einstellungen öffnen → Auf das eigene Profil klicken → Benutzerkonto schließen",
+        "domains": [
+            "ponlist.de"
+        ]
+    },
+
+    {
+        "name": "Porkbun",
+        "url": "https://porkbun.com/account",
+        "difficulty": "easy",
+        "notes": "Log into your account -> Click the link -> Click the Delete Account button and follow instructions.",
+        "notes_fr": "Connectez-vous -> Appuyez le lien -> Cliquez sur le bouton Delete Account et suivez les instructions.",
+        "domains": [
+            "porkbun.com"
+        ]
+    },
+
+    {
+        "name": "Postcrossing",
+        "url": "http://www.postcrossing.com/removal",
+        "difficulty": "easy",
+        "notes": "Log into your account -> Click the link (data fully deleted, not possible to revert this).",
+        "notes_fr": "Connectez-vous -> Appuyez le lien (toutes les données sont supprimées définitivement).",
+        "notes_it": "Entra nel tuo account -> Clicca il link (informazioni completamente eliminate, operazione non reversibile).",
+        "notes_pt_br": "Faça login em sua conta -> Clique no link (dados totalmente apagados, não é possível reverter).",
+        "notes_cat": "Entri al seu compte -> Cliqui a l'enllaç (les dades s'eliminen permanentment, no es pot revertir).",
+        "notes_es": "Entra en tu cuenta -> Haz clic en el enlace (los datos se eliminan permanentmente, no es posible de deshacerlo).",
+        "domains": [
+            "postcrossing.com"
+        ]
+    },
+
+    {
+        "name": "Postman",
+        "url": "https://app.getpostman.com/dashboard/profile",
+        "difficulty": "easy",
+        "notes": "Log into your account, then click the 'Delete Account' button on your profile page.",
+        "domains": [
+            "getpostman.com"
+        ]
+    },
+
+    {
+        "name": "Premera",
+        "url": "https://www.premera.com/",
+        "email": "support@premera.com",
+        "difficulty": "hard",
+        "notes": "Email Premera's support team to request account deletion.",
+        "domains": [
+            "premera.com"
+        ]
+    },
+
+    {
+        "name": "Premiumize.me",
+        "url": "https://www.premiumize.me/deleteaccount",
+        "difficulty": "easy",
+        "notes": "Log into your account -> Click the link -> Click on Send verification code -> Paste the code you got on your email and click Delete Account.",
+        "domains": [
+            "premiumize.me"
+        ]
+    },
+
+    {
+        "name": "Prey",
+        "url": "https://panel.preyproject.com/settings/account",
+        "difficulty": "easy",
+        "notes": "Log into your account -> Click 'Need to close your account?' near the bottom of the page -> Confirm deletion",
+        "notes_fr": "Connectez-vous -> Cliquez sur « Need to close your account? » au bas de la page -> Confirmez la suppression de votre compte",
+        "domains": [
+            "preyproject.com"
+        ]
+    },
+
+    {
+        "name": "Prezi",
+        "url": "https://prezi.com/profile/delete_user_account/",
+        "difficulty": "easy",
+        "notes": "Log into your account -> Click the link -> Enter your password and click on Delete Account.",
+        "notes_fr": "Connectez-vous -> Cliquez sur le lien -> Entrez votre mot de passe et cliquez sur « Delete Account ».",
+        "domains": [
+            "prezi.com"
+        ]
+    },
+
+    {
+        "name": "ProductHunt",
+        "url": "https://www.producthunt.com/my/settings/edit",
+        "difficulty": "easy",
+        "notes": "Go to the account setting, click 'Continue' under 'Delete my Account' and follow from there.",
+        "domains": [
+            "producthunt.com"
+        ]
+    },
+
+    {
+        "name": "Prosper",
+        "url": "https://www.prosper.com/secure/account/borrower/close_account.aspx",
+        "difficulty": "easy",
+        "notes": "Log into your account -> Click the link -> Click on Close My Account Now.",
+        "domains": [
+            "prosper.com"
+        ]
+    },
+
+    {
+        "name": "Proto.io",
+        "url": "https://support.proto.io/hc/en-us/articles/222733628-Dashboard-basics-Billing-Settings",
+        "difficulty": "easy",
+        "notes": "You can either close your account temporary or delete it permanently. Log into your account -> Click Settings -> Manage Subscription -> NEED TO CLOSE YOUR ACCOUNT? click Yes, Close Account",
+        "domains": [
+            "proto.io"
+        ]
+    },
+
+    {
+        "name": "ProtonMail",
+        "url": "https://mail.protonmail.com/account",
+        "difficulty": "easy",
+        "notes": "Log into your account -> Click Settings -> Scroll Down to the Delete My Account Button -> Type why you are leaving, password, and 2 Factor Authentication code if enabled -> Click Delete",
+        "domains": [
+            "protonmail.com"
+        ]
+    },
+
+    {
+        "name": "Prott",
+        "url": "https://prottapp.com/app/#/users/edit/general",
+        "difficulty": "easy",
+        "notes": "Log into your account -> Click Settings -> in General tab scroll down and find 'Click here if you want to cancel your account' -> Choose why you are leaving and click 'Continue' -> Click 'Yes Cancel My Account'",
+        "domains": [
+            "prottapp.com"
+        ]
+    },
+
+    {
+        "name": "Public Lab",
+        "url": "https://publiclab.org/questions/niklasjordan/03-25-2019/how-can-i-delete-a-user-account",
+        "difficulty": "impossible",
+        "notes": "It is currently not possible to delete an account on Public Lab.",
+        "domains": [
+            "publiclab.org"
+        ]
+    },
+
+    {
+        "name": "Pushover",
+        "url": "https://pushover.net/settings/delete_account",
+        "difficulty": "easy",
+        "domains": [
+            "pushover.net"
+        ]
+    },
+
+    {
+        "name": "Put.io",
+        "url": "https://put.io/payment/billing",
+        "difficulty": "easy",
+        "notes": "Click Destroy my account completely, then click Delete everything.",
+        "domains": [
+            "put.io"
+        ]
+    },
+
+    {
+        "name": "Quip",
+        "url": "https://www.quipsupport.com/entries/25079898-How-do-I-delete-my-account-",
+        "difficulty": "hard",
+        "notes": "Email support@quip.com and ask them to delete your account.",
+        "email": "support@quip.com",
+        "domains": [
+            "quip.com"
+        ]
+    },
+
+    {
+        "name": "Quizlet",
+        "url": "https://quizlet.com/delete-account",
+        "difficulty": "easy",
+        "domains": [
+            "quizlet.com"
+        ]
+    },
+
+    {
+        "name": "Quora",
+        "url": "http://www.quora.com/Quora-product/How-do-I-delete-my-Quora-account",
+        "difficulty": "easy",
+        "notes": "Log in, go to 'Settings', 'Privacy', and then 'Delete Account'.",
+        "domains": [
+            "quora.com"
+        ]
+    },
+
+    {
+        "name": "radio.fr",
+        "url": "http://www.radio.fr/#%2Fkonto_loeschen.jsf",
+        "difficulty": "easy",
+        "notes": "Login, go to profile page, it's in tab 'my data' and click 'delete my account'.",
+        "notes_fr": "Connectez-vous, allez à la page du profil, c'est dans l'onglet 'mes données' et cliquez sur 'supprimer mon compte.'",
+        "domains": [
+            "radio.fr"
+        ]
+    },
+
+    {
+        "name": "Raindrop.io",
+        "url": "https://raindrop.io/app/#/settings/profile",
+        "difficulty": "hard",
+        "notes": "To delete your account, you need to send an e-mail to info@raindrop.io",
+        "email": "info@raindrop.io",
+        "domains": [
+            "raindrop.io"
+        ]
+    },
+
+    {
+        "name": "Rainforest QA",
+        "url": "https://app.rainforestqa.com/settings",
+        "difficulty": "easy",
+        "notes": "Login, go to the settings page and click 'I want to delete my account'.",
+        "notes_fr": "Connectez-vous, allez dans les parametres et cliquez sur « I want to delete my account ».",
+        "notes_it": "Entra, recati nella pagina impostazioni e clicca 'Voglio eliminare il mio account'.",
+        "notes_pt_br": "Faça login, vá na página de configurações e clique 'I want to delete my account'.",
+        "notes_cat": "Entri al seu compte, vagi a la pàgina de configuració i cliqui a 'I want to delete my account'.",
+        "notes_es": "Entra en tu cuenta, ve a la página de configuración y pulsa 'I want to delete my account'.",
+        "domains": [
+            "rainforestqa.com"
+        ]
+    },
+
+    {
+        "name": "RateYourMusic",
+        "url": "http://rateyourmusic.com/account/delete",
+        "difficulty": "impossible",
+        "notes": "After deleteing the account, it will be deactivated for 30 days before being deleted permanently. Messages, forum posts, and contributions stay on the site even after your account is deleted.",
+        "domains": [
+            "rateyourmusic.com"
+        ]
+    },
+
+    {
+        "name": "Razer",
+        "url": "https://razer-id.razerzone.com/account/delete",
+        "difficulty": "easy",
+        "notes": "An account is required to access the warranty and product registration section of the website. Despite being on a different subdomain, this affects the normal Razerzone.com website and the assorted store as well.",
+        "domains": [
+            "razerzone.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Readability",
+        "url": "https://www.readability.com/account/delete",
+        "difficulty": "impossible",
+        "notes": "You can't delete your account, but you can deactivate it.",
+        "notes_fr": "Vous ne pouvez pas supprimer votre compte, mais vous pouvez le désactiver.",
+        "notes_it": "Non puoi eliminare il tuo account ma puoi disattivarlo.",
+        "notes_pt_br": "Você não pode deletar sua conta, mas você pode desativá-la.",
+        "notes_cat": "No podrà esborrar el seu compte, pero es podrà desactivar.",
+        "notes_es": "No podrás borrar tu cuenta, pero se podrá desactivar.",
+        "notes_pl": "Nie możesz usunąć swojego konta, ale możesz je deaktywować.",
+        "domains": [
+            "readability.com"
+        ]
+    },
+
+    {
+        "name": "Readernaut",
+        "url": "https://readernaut.com",
+        "difficulty": "easy",
+        "notes": "Go to your profile page, and use the 'Delete Your Account' button.",
+        "domains": [
+            "readernaut.com"
+        ]
+    },
+
+    {
+        "name": "ReadyForZero",
+        "url": "https://www.readyforzero.com/user/settings#readyforzero-account",
+        "difficulty": "easy",
+        "domains": [
+            "readyforzero.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Reddit",
+        "url": "https://ssl.reddit.com/prefs/delete/",
+        "difficulty": "easy",
+        "notes": "Increase your productivity by over 5 times with this one trick they don't want you to know about!",
+        "notes_it": "Incrementa la tua produttività di oltre 5 volte con questi consigli che loro non vogliono farti sapere!",
+        "notes_pt_br": "Aumente sua produtividade em 5 vezes com este truque que eles não querem que você saiba!",
+        "notes_cat": "Augmenti la seva productivitat fins a 5 vegades amb aquest truc que ningú en vol sentir a parlar!",
+        "notes_es": "Aumente tu productividad hasta 5 veces con este truco del que nadie quiere oír hablar!",
+        "domains": [
+            "reddit.com"
+        ]
+    },
+
+    {
+        "name": "Redditgifts",
+        "url": "http://redditgifts.com/privacy/",
+        "difficulty": "hard",
+        "notes": "If you decide you would like to delete your account you must email us at support@redditgifts.com. You must email us from the email address associated with your account and provide your reddit username.",
+        "notes_it": "Per eliminare il tuo account invia un'e-mail a support@redditgifts.com. Invia l'e-mail dall'indirizzo associato al tuo account ed inserisci il tuo username reddit.",
+        "notes_pt_br": "Caso você decida apagar sua conta você deve enviar um e-mail para support@redditgifts.com. O e-mail deve ser enviado pelo e-mail associado a sua conta e você deve especificar seu usuário reddit.",
+        "notes_cat": "Si decideix desactivar el seu compte haurà de posarse en contacte amb support@redditgifts.com. Haurà d'enviar l'e-mail i nom de l'usuari de Reddit associat al compte de la web.",
+        "notes_es": "Si decide desactivar tu cuenta tendrás que ponerte en contacto con support@redditgifts.com. Deberás enviar el e-mail y nombre de usuario de Reddit asociado a la cuenta de la web.",
+        "email": "support@redditgifts.com",
+        "email_body": "My reddit username is XXXXXX",
+        "domains": [
+            "redditgifts.com"
+        ]
+    },
+
+    {
+        "name": "RedPen.io",
+        "url": "https://redpen.io/account",
+        "difficulty": "hard",
+        "notes": "You would need to email the team by clicking feedback to have your account removed.",
+        "domains": [
+            "redpen.io"
+        ]
+    },
+
+    {
+        "name": "Remember The Milk",
+        "url": "https://www.rememberthemilk.com/login/delete.rtm",
+        "difficulty": "easy",
+        "domains": [
+            "rememberthemilk.com"
+        ]
+    },
+
+    {
+        "name": "Replay Poker",
+        "url": "https://www.replaypoker.com/settings/deactivate",
+        "difficulty": "easy",
+        "notes": "Please enter a reason for deactivating your account and then click 'Deactivate' after you're finished.",
+        "domains": [
+            "replaypoker.com"
+        ]
+    },
+
+    {
+        "name": "RescueTime",
+        "url": "https://www.rescuetime.com/settings",
+        "difficulty": "easy",
+        "notes": "Use the 'Delete your account' link in the lower right-hand corner.",
+        "domains": [
+            "rescuetime.com"
+        ]
+    },
+
+    {
+        "name": "Retrospring",
+        "url": "https://retrospring.net/settings/account",
+        "difficulty": "easy",
+        "notes": "Use the Delete button at the bottom of the page.",
+        "domains": [
+            "retrospring.net"
+        ]
+    },
+
+    {
+        "name": "Rideindego",
+        "url": "https://www.rideindego.com/faq/#how-do-i-cancel-my-pass",
+        "difficulty": "impossible",
+        "notes": "You can only cancel the auto-renewal feature. I called them and asked to cancel my account and be removed from their mailing list and they told me my account was already not renewing and there was nothing else they could do.",
+        "domains": [
+            "rideindego.com"
+        ]
+    },
+
+    {
+        "name": "Riffle",
+        "url": "https://riffle.uservoice.com/knowledgebase/articles/244346-delete-your-account",
+        "difficulty": "easy",
+        "notes": "On your profile page, click 'Edit Profile' and use the 'Cancel account' button.",
+        "domains": [
+            "riffle.com"
+        ]
+    },
+
+    {
+        "name": "Roblox",
+        "url": "https://en.help.roblox.com/hc/en-us/articles/203313050-How-Do-I-Delete-My-Account-",
+        "difficulty": "impossible",
+        "notes": "Not possible. 'We currently do not have a feature for players to delete their accounts. If you no longer wish to play on your account, it will remain inactive until you're ready to play again.'",
+        "domains": [
+            "www.roblox.com"
+        ]
+    },
+
+    {
+        "name": "Roll20",
+        "url": "https://app.roll20.net/account/",
+        "difficulty": "easy",
+        "notes": "On the account page, scroll down to the \"Danger Zone\" and click on the \"Delete My Account\" button. After that, you will have to type \"DELETE\" in the pop-up box.",
+        "domains": [
+            "roll20.net"
+        ]
+    },
+
+    {
+        "name": "Rotten Tomatoes",
+        "url": "http://rottentomatoes.com/user/account/cancel",
+        "difficulty": "easy",
+        "domains": [
+            "rottentomatoes.com"
+        ]
+    },
+
+    {
+        "name": "Rovio",
+        "url": "https://account.rovio.com/",
+        "difficulty": "easy",
+        "notes": "Bottom link 'Delete Account'",
+        "notes_it": "Link sul fondo 'Delete Account'.",
+        "notes_pt_br": "Link no final 'Delete Account'",
+        "notes_cat": "Enllaç al final: 'Delete Account'",
+        "notes_es": "Enlace al final: 'Delete Account'",
+        "domains": [
+            "rovio.com"
+        ]
+    },
+
+    {
+        "name": "Runescape",
+        "url": "http://services.runescape.com/m=rswiki/en/Account_Help",
+        "difficulty": "hard",
+        "notes": "Under 5. Account Settings > A. Account Management > V. Account Deletion. You must mail or fax an affidavit to the Runescape office along with a copy of your legal identification",
+        "domains": [
+            "runescape.com"
+        ]
+    },
+
+    {
+        "name": "RunKeeper",
+        "url": "https://runkeeper.com/delete-account?confirm",
+        "difficulty": "easy",
+        "notes": "Enter your password, select a reason for deletion, complete the captcha, press the delete button and then confirm it in the dialog.",
+        "notes_it": "Inserire la password, selezionare un motivo per la cancellazione, completare il captcha, premere il pulsante Elimina e quindi confermare nella finestra di dialogo.",
+        "notes_pt_br": "Digite sua senha, selecione um motivo para a exclusão, preencha o captcha, pressione o botão delete e confirme-o na caixa de diálogo.",
+        "notes_cat": "Introduïu la vostra contrasenya, seleccioneu un motiu d'eliminació, completeu el captcha, premeu el botó Suprimeix i després confirmeu-lo al diàleg.",
+        "notes_es": "Ingrese su contraseña, seleccione un motivo para la eliminación, complete el captcha, presione el botón Eliminar y luego confírmelo en el cuadro de diálogo.",
+        "domains": [
+            "runkeeper.com"
+        ]
+    },
+
+    {
+        "name": "Runtastic",
+        "url": "https://help.runtastic.com/hc/en-us/articles/200370082-Delete-Account-Cancel-Membership",
+        "difficulty": "easy",
+        "notes": "To delete your account go to Runtastic.com & log in, click on the arrow on the right side of your user name, click on \"Settings\", click on \"Login Data\" on the left hand side, click on \"Delete my account\" at the bottom",
+        "domains": [
+            "runtastic.com"
+        ]
+    },
+
+    {
+        "name": "Scaleway",
+        "url": "https://cloud.scaleway.com/#/account",
+        "difficulty": "easy",
+        "notes": "On the top right of the page, click 'Delete my account'.",
+        "domains": [
+            "scaleway.com"
+        ]
+    },
+
+    {
+        "name": "ScanMyServer",
+        "url": "https://scanmyserver.com/?suspend=1",
+        "difficulty": "easy",
+        "notes": "Login to your account and follow 'Account Suspension' instructions.",
+        "notes_fr": "Connectez vous et suivez les instructions de suspension du compte.",
+        "notes_it": "Entra nel tuo account e segui le istruzioni 'Account Suspension'.",
+        "notes_pt_br": "Faça login e siga as instruções de 'Account Suspension'.",
+        "notes_cat": "Entri al seu compte i segueixi les instruccions a 'Account Suspension'.",
+        "notes_es": "Entra en tu cuenta y sigue las instrucciones en 'Account Suspension'.",
+        "domains": [
+            "scanmyserver.com"
+        ]
+    },
+
+    {
+        "name": "Scribd",
+        "url": "http://www.scribd.com/account_settings/preferences",
+        "difficulty": "easy",
+        "domains": [
+            "scribd.com"
+        ]
+    },
+
+    {
+        "name": "Scriptogr.am",
+        "url": "http://scriptogr.am/dashboard/#settings",
+        "difficulty": "easy",
+        "notes": "Click the link 'Delete your account' at the bottom. Note: On your dropbox, the content of this site will not be removed. If needed, you can delete the folder 'Apps/scriptogram' manually.",
+        "notes_it": "Clicca il link 'Delete your account' sul fondo. Nota: Su dropbox il contenuto di questo sito non verrà eliminato. Se necessario, devi eliminare la cartella 'Apps/scriptogram' manualmente",
+        "notes_pt_br": "Clique no link 'Delete your account' no final da página. Nota: No seu dropbox, o conteúdo deste site não será removido. Caso necessário, você pode remover a pastas 'Apps/scriptogram' manualmente.",
+        "notes_cat": "Cliqui a l'enllaç 'Delete your account' al final de la pàgina. Nota: Al teu Dropbox, el contingut d'aquest servei a Dropbox no serà esborrat. Si ho necessita, pot esborrar la carpeta 'Apps/scriptogram' de forma manual.",
+        "notes_es": "Haz clic en el enlace 'Delete your account' al final de la página. Nota: En tu Dropbox, el contenido de este servicio en Dropbox no será borrado. Si lo necessita, puede borrar la carpeta 'Apps/scriptogram' de forma manual.",
+        "domains": [
+            "scriptogr.am"
+        ]
+    },
+
+    {
+        "name": "Sedo",
+        "url": "https://sedo-us1.custhelp.com/app/answers/detail/a_id/350/~/how-can-i-close-my-account",
+        "difficulty": "hard",
+        "domains": [
+            "sedo.com"
+        ]
+    },
+
+    {
+        "name": "ShareLaTeX",
+        "url": "https://www.sharelatex.com/user/settings",
+        "difficulty": "easy",
+        "notes": "Click the \"Delete your account\" at the bottom of the settings page and type \"DELETE\" in the popup box.",
+        "domains": [
+            "sharelatex.com"
+        ]
+    },
+
+    {
+        "name": "Shopee",
+        "url": "https://www.sharelatex.com/user/settings",
+        "difficulty": "medium",
+        "notes": "Tap Saya (me)>Akun Saya (My account)>Ajukan Penghapusan akun (Submit Account removal/Submit Account Deletion).",
+        "domains": [
+            "shopee.com"
+        ]
+    },
+
+    {
+        "name": "Shopify",
+        "url": "http://shopify.com/admin/settings/account",
+        "difficulty": "easy",
+        "notes": "Select 'Please cancel my account'. Choose a reason then select 'close my shopify store'.",
+        "notes_fr": "Selectionnez supprimer mon compte. Choisissez la raison et cliquez 'close my shopify store'",
+        "notes_it": "Seleziona 'Please cancel my account'. Seleziona un motivo e seleziona 'close my shopify store'.",
+        "notes_pt_br": "Selecione 'Please cancel my account'. Escolha um motivo e selecione 'close my shopify store'.",
+        "notes_cat": "Seleccioni 'Please cancel my account'. Esculli un motiu i seleccioni 'close my shopify store'.",
+        "notes_es": "Selecciona 'Please cancel my account'. Selecciona un motivo y pulsa 'close my shopify store'.",
+        "domains": [
+            "shopify.com"
+        ]
+    },
+
+    {
+        "name": "showRSS",
+        "url": "http://showrss.info/",
+        "difficulty": "impossible",
+        "domains": [
+            "showrss.info"
+        ]
+    },
+
+    {
+        "name": "Shpock",
+        "url": "https://en.shpock.com/",
+        "difficulty": "hard",
+        "notes": "Requires e-mailing support to delete the account.",
+        "email": "support@shpock.com",
+        "domains": [
+            "shpock.com"
+        ]
+    },
+
+    {
+        "name": "Shutterfly",
+        "url": "http://www.shutterfly.com/about/contact_details.jsp",
+        "difficulty": "hard",
+        "notes": "Contact customers services by email or live chat and request deletion.",
+        "notes_fr": "Contactez le service clients par e-mail our par le tchat en ligne et demandez la suppression de votre compte.",
+        "notes_it": "Contatta il servizio clienti via email o via chat e richiedi la cancellazione.",
+        "notes_pt_br": "Contate a assistência ao cliente por e-mail ou chat ao vivo e peça a remoção.",
+        "notes_cat": "Contacti amb l'assistència al client per e-mail o chat i demani la supressió del compte.",
+        "notes_es": "Contacta con la asistencia al cliente por e-mail o chat y pide la supresión de la cuenta.",
+        "email": "customerservice@cs.shutterfly.com",
+        "domains": [
+            "shutterfly.com"
+        ]
+    },
+
+    {
+        "name": "Shutterstock",
+        "url": "http://submit.shutterstock.com/privacy.mhtml",
+        "difficulty": "hard",
+        "notes": "If you wish to delete your account or request that we no longer use your information to provide you services contact us at Support@Shutterstock.com.",
+        "domains": [
+            "shutterstock.com"
+        ]
+    },
+
+    {
+        "name": "SigFig",
+        "url": "https://support.sigfig.com/hc/en-us/articles/202586434-How-do-I-completely-delete-my-account-",
+        "difficulty": "hard",
+        "notes": "Contact customer service by email and request deletion.",
+        "email": "support@sigfig.com",
+        "domains": [
+            "sigfig.com"
+        ]
+    },
+
+    {
+        "name": "Simple Machines",
+        "url": "http://www.simplemachines.org/community/index.php?action=profile;area=deleteaccount",
+        "difficulty": "hard",
+        "notes": "Enter your password to have your account marked for deletion by an administrator or moderator. You can do this for any other Simple Machines forums if the forum administrator allows.",
+        "domains": [
+            "simplemachines.org"
+        ]
+    },
+
+    {
+        "name": "Simplenote",
+        "url": "https://app.simplenote.com/settings",
+        "difficulty": "easy",
+        "notes": "Login to your account, go to account settings and click 'Delete Account'. Confirm by ticking the box, entering your password and click 'Delete Account'.",
+        "domains": [
+            "simplenote.com"
+        ]
+    },
+
+    {
+        "name": "Skillshare",
+        "url": "http://www.skillshare.com/settings/account",
+        "difficulty": "easy",
+        "notes": "Login to your profile, click on 'Account Settings', click on 'Deactivate Your Account', and confirm by clicking on 'Deactivate Account'.",
+        "domains": [
+            "skillshare.com"
+        ]
+    },
+
+    {
+        "name": "Skoob",
+        "url": "http://www.skoob.com.br/usuario/excluir/",
+        "difficulty": "easy",
+        "domains": [
+            "skoob.com.br"
+        ]
+    },
+
+    {
+        "name": "Skype",
+        "meta": "popular",
+        "url": "https://support.skype.com/en/faq/FA142/can-i-delete-my-skype-account",
+        "difficulty": "hard",
+        "notes": "Contact customer services on chat. You’ll need to know whether you bought services from Skype, you’ll need to verify your signup email address.",
+        "notes_fr": "Contactez le service clients. Il vous faudra les noms de 5 de vos contacts, le mois de la création de votre compte, et l'adresse e-mail du compte.",
+        "notes_it": "Contatta il servizio clienti. Devi conoscere 5 contatti dalla tua lista contatti, il mese di creazione dell'account e la email con cui ti sei registrato.",
+        "notes_pt_br": "Contate a assistência ao cliente. Você precisará saber 5 contatos da sua lista de contatos, o mês em que sua conta foi criada, e seu e-mail de cadastro.",
+        "notes_cat": "Contacti amb l'assistència al client. Haurà de coneixer 5 contactes de la seva llista, el mes que va ser creat el compte i el e-mail associat.",
+        "notes_es": "Contacta con la asistencia al cliente. Deberás conocer 5 contactos de su lista, el mes que la cuenta fue creada y el e-mail asociado.",
+        "domains": [
+            "skype.com"
+        ]
+    },
+
+    {
+        "name": "Slack",
+        "url": "https://my.slack.com/account/settings",
+        "difficulty": "easy",
+        "notes": "If you are the Slack team's primary owner you will need to either delete the team or transfer its ownership before deleting your account",
+        "domains": [
+            "slack.com"
+        ]
+    },
+
+    {
+        "name": "Slashdot",
+        "url": "http://slashdot.org/faq/#accounts3",
+        "difficulty": "impossible",
+        "domains": [
+            "slashdot.org"
+        ]
+    },
+
+    {
+        "name": "Slideshare",
+        "url": "https://www.linkedin.com/help/slideshare/answer/53671?query=delete%20account",
+        "difficulty": "easy",
+        "notes": "Sign in to SlideShare, move your cursor over your photo in the top right and select Account Settings, click the Change Password tab on the left, click Delete Account, click 'Yes, delete my account', enter your password and select applicable reasons for deleting this account, then click Delete Account. Note: If you created your SlideShare account through LinkedIn, you'll have to close your LinkedIn account.",
+        "domains": [
+            "slideshare.com"
+        ]
+    },
+
+    {
+        "name": "SlimTimer",
+        "url": "http://slimtimer.com/",
+        "difficulty": "hard",
+        "notes": "Email request required."
+    },
+
+    {
+        "name": "SmartRecruiters",
+        "url": "https://help.smartrecruiters.com/Getting_Started/User_settings/How_do_I_close_my_user_account%3F",
+        "difficulty": "impossible",
+        "notes": "You can deactivate your user account, but you cannot delete it.",
+        "domains": [
+            "smartrecruiters.com"
+        ]
+    },
+
+    {
+        "name": "Smashcast",
+        "url": "https://www.smashcast.tv",
+        "difficulty": "easy",
+        "notes": "Access your user settings page, click the \"Delete Account...\" link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.",
+        "domains": [
+            "smashcast.tv"
+        ]
+    },
+
+    {
+        "name": "Snapchat",
+        "url": "http://www.snapchat.com/a/delete_account",
+        "difficulty": "easy",
+        "notes": "Enter username and password and click 'Delete'.",
+        "notes_fr": "Entrez votre pseudo et votre mot de passe et cliquez sur supprimer.",
+        "notes_it": "Inserisci username e password e clicca 'Delete'.",
+        "notes_pt_br": "Digite seu usuário e senha e clique em 'Delete'.",
+        "notes_cat": "Entri el seu nom d'usuari i contrasenya i faci clic a 'Delete'.",
+        "notes_es": "Entra tu nombre de usuario y contraseña y haz clic en 'Delete'.",
+        "domains": [
+            "snapchat.com"
+        ]
+    },
+
+    {
+        "name": "Social Blade",
+        "url": "https://support.socialblade.com/",
+        "difficulty": "impossible",
+        "notes": "You can't delete your account. Customer support will also not delete it upon request.",
+        "notes_de": "Man kann seinen Account nicht löschen. Der Kundenservice löscht ihn auch auf Anfrage nicht.",
+        "domains": [
+            "socialblade.com"
+        ]
+    },
+
+    {
+        "name": "SoloLearn",
+        "url": "https://www.sololearn.com/",
+        "difficulty": "hard",
+        "notes": "E-mail requesting a full deletion. It takes 30 days for it to be irreversible.",
+        "email": "info@sololearn.com",
+        "email_subject": "Delete Account",
+        "email_body": "I want to permanently delete my account from SoloLearn",
+        "domains": [
+            "sololearn.com"
+        ]
+    },
+
+    {
+        "name": "Songkick",
+        "url": "http://www.songkick.com/settings/account-settings",
+        "difficulty": "easy",
+        "domains": [
+            "songkick.com"
+        ]
+    },
+
+    {
+        "name": "Sonico",
+        "url": "http://www.sonico.com/tyc.php",
+        "difficulty": "hard",
+        "notes": "Send a request to legal@sonico.com and request deletion.",
+        "notes_fr": "Envoyez une demande de suppression à legal@sonico.com .",
+        "notes_it": "Invia la richiesta a legal@sonico.com",
+        "notes_pt_br": "Envie um pedido para legal@sonico.com e peça a remoção.",
+        "notes_cat": "Enviï una petició per esborrar el seu compte a legal@sonico.com.",
+        "notes_es": "Envía una petición para borrar tu cuenta a legal@sonico.com.",
+        "email": "legal@sonico.com",
+        "domains": [
+            "sonico.com"
+        ]
+    },
+
+    {
+        "name": "SoundCloud",
+        "url": "http://soundcloud.com/settings/account#delete-user",
+        "difficulty": "easy",
+        "domains": [
+            "soundcloud.com"
+        ]
+    },
+
+    {
+        "name": "soup.io",
+        "url": "http://www.soup.io/about",
+        "difficulty": "hard",
+        "notes": "Put 'delete me' in the description box on your profile and mail team@soup.io with your soup URL and request a deletion",
+        "notes_de": "Füge 'delete me' in die Beschreibungsbox auf deinem Profil ein und sende eine E-Mail an team@soup.io, die deine soup-URL und eine Löschaufforderung beinhalten.",
+        "notes_fr": "Insère 'delete me' à la place pour la description à ton profil et envoie un e-mail à team@soup.io avec ton soup URL et une demande de suppression.",
+        "email": "team@soup.io",
+        "domains": [
+            "www.soup.io"
+        ]
+    },
+
+    {
+        "name": "SourceForge",
+        "url": "https://sourceforge.net/auth/disable/",
+        "difficulty": "medium",
+        "notes": "Data created by the user such as posts and tickets will remain and be attributed to the account, even if deleted. The username will not become available.",
+        "notes_fr": "Les données crées par l'utilisateur resteront, même après la suppression du compte. Le pseudo ne devient pas disponbile.",
+        "notes_it": "I dati creati dall'utente come post e ticket rimarranno attribuiti all'account, anche se cancellato. L'username non sarà più disponibile.",
+        "notes_pt_br": "Dados criads pelo usuário como posts e tickets se manterão atribuídos à conta, mesmo que deletada. O usuário não se tornará disponível.",
+        "notes_cat": "Les dades creades per l'usuari, com els posts i tickets es mantindran atribuits al compte, inclús si es eliminada. El nom d'usuari no estarà disponible.",
+        "notes_es": "Los datos creados por el usuario, como los posts y tiquets se mantendrán atribuidos a la cuenta, incluso si es eliminada. El nombre de usuario no estará disponible.",
+        "domains": [
+            "sourceforge.net"
+        ]
+    },
+
+    {
+        "name": "Speaker Deck",
+        "url": "https://speakerdeck.com/account",
+        "difficulty": "easy",
+        "notes": "Scroll to the bottom of page and click on the 'Delete my account and all of my presentations'.",
+        "domains": [
+            "speakerdeck.com"
+        ]
+    },
+
+    {
+        "name": "SpigotMC",
+        "url": "https://www.spigotmc.org/threads/how-can-i-delete-my-account.298730",
+        "difficulty": "impossible",
+        "notes": "You can't delete your account you can only deactivate your account. Go for this to your profile and click the report button on your profile and write delete me and wait.",
+        "notes_de": "Du kannst deinen Account nicht komplett löschen sondern nur deaktivieren. Gehe dazu auf dein Profil und klicke den Reportbutton auf deinem Profil und schreibe delete me",
+        "domains": [
+            "spigotmc.org"
+        ]
+    },
+
+    {
+        "name": "Splitwise",
+        "url": "https://secure.splitwise.com/account/settings",
+        "difficulty": "easy",
+        "domains": [
+            "splitwise.com"
+        ]
+    },
+
+    {
+        "name": "Spotify",
+        "url": "http://support.spotify.com/close-account",
+        "difficulty": "hard",
+        "notes": "1. Cancel your subscription at https://www.spotify.com/us/account/subscription/ 2. Public playlists will be anonymised, delete any playlists you want. 3. Go to the provided link, Account -> I want to close my account permanently and reserve 20min of your time to chat with them.",
+        "domains": [
+            "spotify.com"
+        ]
+    },
+
+    {
+        "name": "Square Cash",
+        "url": "https://cash.me/login?return_to=support",
+        "difficulty": "hard",
+        "notes": "Login into the support page and email customer support asking to delete your account.",
+        "domains": [
+            "cash.me"
+        ]
+    },
+
+    {
+        "name": "Stack Overflow / Stack Exchange Accounts",
+        "url": "http://stackoverflow.com/help/deleting-account",
+        "difficulty": "hard",
+        "notes": "If you haven’t posted on the site, it’s just one click. If you have voted or posted, please contact the Stack Exchange Team: Visit the contact form and select ‘I need to delete my user profile’. After you contact us, the team will reach out with further instructions.",
+        "notes_fr": "Si vous n'avez pas posté, il ne faut qu'un clic. Sinon, remplacez votre bio par « please delete me » puis contactez le support du site.",
+        "notes_it": "Se non hai effettuato alcuna azione sul sito, basta un click. Altrimenti, edita il tuo 'About me' biografia in 'please delete me' quindi contatta il servizio clienti.",
+        "notes_pt_br": "Se você não postou no site, apenas um clique é necessário. Caso contrário, edite a sua 'About Me' biografia e escreva 'please delete me' e então contate o suporte.",
+        "notes_cat": "Si mai ha publicat al lloc només és un clic. En cas contrari, editi la seva biografia a 'About Me' i escrigui 'please delete me' a continuació contacti amb atenció al client.",
+        "notes_es": "Si nunca has publicado en el sitio sólo es un clic. Si no, edita tu biografía en 'About Me' y escribe 'please delete me', luego contacta con atención al cliente.",
+        "domains": [
+            "stackoverflow.com"
+        ]
+    },
+
+    {
+        "name": "Starbucks",
+        "url": "http://customerservice.starbucks.com/app/contact/ask_starbucks_website/",
+        "difficulty": "impossible",
+        "notes": "They will not delete your account but upon request they can “scramble all of your information so that you don’t receive emails and none of your information is available to [them] for potential fraud”.",
+        "notes_it": "Non elimineranno il tuo account ma su richiesta potranno cancellare tutte le tue informazioni.",
+        "notes_pt_br": "Eles não irão deletar sua conta mas mediante pedido eles podem “bagunçar todas suas informações para que você não receba e-mails e nenhuma informação sua esteja disponível a [eles] potenciais fraudes”.",
+        "notes_cat": "No poden esborrar el compte, pero si ho demanes poden “esborrar tota la seva informació per tal de no rebre e-mails i cap de les teves informacions estigui disponibl a [ells] per potencials accions fraudulentes.”.",
+        "notes_es": "No pueden borrar la cuenta, pero si lo pides pueden «borrar toda su información para no recibir e-mails y ninguna de tus informaciones estén disponibles para [ellos] potenciales acciones fraudulentas»",
+        "domains": [
+            "starbucks.com"
+        ]
+    },
+
+    {
+        "name": "Startnext",
+        "url": "https://www.startnext.com/help/FAQ.html#q74",
+        "difficulty": "easy",
+        "notes": "Go to your profile settings, scroll down, and click the 'Delete profile' link. It may be possible that your account cannot be deleted for a number of reasons, such as: you have a project in the starting, funding, or end phase; you have an active partner page; you supported a project that is still in the funding phase and we have not yet received your payment or your payment has not been returned to you.",
+        "domains": [
+            "startnext.com"
+        ]
+    },
+
+    {
+        "name": "StatusCake",
+        "difficulty": "easy",
+        "url": "https://www.statuscake.com/App/User.php",
+        "notes": "Under 'Account' scroll down and click the red button 'Remove Account'",
+        "domains": [
+            "statuscake.com"
+        ]
+    },
+
+    {
+        "name": "StayFriends.de",
+        "url": "http://www.stayfriends.de/j/ViewController?action=accountSettings&delEnabled=true",
+        "difficulty": "easy",
+        "notes": "The deletion of your entry can not be undone. All your profile data, contacts, messages and pictures will be permanently removed. Your classmates and contacts can no longer StayFriends contact you.",
+        "notes_it": "La cancellazione non può essere annullata. Tutti i tuoi dati, contatti messaggi e foto verrano eliminati permanentemente.",
+        "notes_de": "Die Löschung Ihres Eintrages kann nicht rückgängig gemacht werden. Alle Ihre Profildaten, Kontakte Nachrichten und Bilder werden unwiderruflich entfernt. Ihre Mitschüler und Kontakte können nicht mehr über StayFriends Kontakt zu Ihnen aufnehmen.",
+        "notes_cat": "L'eliminació no pot ser anulada. Totes les dades del teu perfil, contactes, missatges i imatges seran eliminades permanentment. Ningú es podrà posar en contacte amb tu.",
+        "notes_es": "La eliminación no puede ser anulada. Todos los datos de tu perfil, contactos, mensajes e imágenes serán eliminadas permanentemente. Nadie podrá ponerse en contacto contigo.",
+        "domains": [
+            "stayfriends.de"
+        ]
+    },
+
+    {
+        "name": "Steam",
+        "url": "https://help.steampowered.com/en/wizard/HelpDeleteAccount",
+        "difficulty": "hard",
+        "notes": "First you must verify ownership of the account, then Steam Support will respond to confirm your identification. After it is confirmed your account will be locked and then deleted in 30 days. You can cancel the deletion by contacting Steam Support during the 30 days.",
+        "domains": [
+            "steampowered.com"
+        ]
+    },
+
+    {
+        "name": "StepMap",
+        "url": "http://www.stepmap.de/profil.php",
+        "difficulty": "hard",
+        "notes": "To delete your StepMap account, let us know by sending an e-mail with info@stepmap.de and enter your username. The sender address must be your e-mail address that you have subscribed to at StepMap.",
+        "notes_de": "Um Deinen StepMap-Account zu löschen, teile uns dies bitte per E-Mail an info@stepmap.de mit und nenne uns Deinen Benutzernamen. Die Absenderadresse muss Deine E-Mail-Adresse sein, mit der Du Dich bei StepMap angemeldet hast.",
+        "email": "info@stepmap.de",
+        "domains": [
+            "stepmap.de"
+        ]
+    },
+
+    {
+        "name": "Stereomood",
+        "url": "http://www.stereomood.com/users/account",
+        "difficulty": "easy",
+        "domains": [
+            "stereomood.com"
+        ]
+    },
+
+    {
+        "name": "Storenvy",
+        "url": "http://www.storenvy.com/account",
+        "difficulty": "easy",
+        "notes": "Log in, then navigate to 'Account Settings' > 'Profile'. Scroll to the bottom and click 'Delete my Storenvy store & account'. Click 'OK' when prompted to confirm.",
+        "domains": [
+            "storenvy.com"
+        ]
+    },
+
+    {
+        "name": "Storify",
+        "url": "http://storify.com/settings#account",
+        "difficulty": "easy",
+        "notes": "Just click the 'Delete account' button in red",
+        "domains": [
+            "storify.com"
+        ]
+    },
+
+    {
+        "name": "Strava",
+        "url": "https://www.strava.com/athlete/delete_your_account",
+        "difficulty": "medium",
+        "notes": "Account deletion is irreversible: Your account and data will be permanently deleted, and you will be removed from all clubs, heatmaps, challenges and leaderboards. Some data you created for the community, like public segments or routes, may remain on Strava.",
+        "domains": [
+            "strava.com"
+        ]
+    },
+
+    {
+        "name": "Streamable",
+        "url": "https://support.streamable.com/contact-us",
+        "difficulty": "hard",
+        "notes": "You have to contact support in order to delete your account.",
+        "domains": [
+            "streamable.com"
+        ]
+    },
+
+    {
+        "name": "Stripe",
+        "url": "https://dashboard.stripe.com/account/data",
+        "difficulty": "easy",
+        "notes": "Account owners only, not team members can delete the account. Balances and pending invoices all need to be resolved before the account is permanently closed. Cannot be reversed.",
+        "meta": "popular",
+        "domains": [
+            "stripe.com"
+        ]
+    },
+
+    {
+        "name": "StumbleUpon",
+        "url": "https://www.stumbleupon.com/settings/delete-account",
+        "difficulty": "easy",
+        "notes": "You can reactivate within 14 days. After that the account is deleted.",
+        "notes_fr": "Vous pouvez réactiver pour 14 jours. Après le compte est supprimé.",
+        "notes_it": "Puoi riattivare il tuo account entro 14 giorni. Dopodichè sarà cancellato.",
+        "notes_pt_br": "Você pode reativar em até 14 dias. Após este prazo sua conta é deletada.",
+        "notes_cat": "Pot reactivar-la en un termini de 14 dies. Desprès d'aquest temps el compte serà esborrat.",
+        "notes_es": "Puedes reactivarla en un plazo de 14 días. Después de este fecha la cuenta será borrada.",
+        "domains": [
+            "stumbleupon.com"
+        ]
+    },
+
+    {
+        "name": "SuperBiiz",
+        "url": "https://www.superbiiz.com/contact.php",
+        "difficulty": "hard",
+        "notes": "You have to email them and request for your account to be deleted.",
+        "email": "support@superbiiz.com",
+        "domains": [
+            "superbiiz.com"
+        ]
+    },
+
+    {
+        "name": "SurveyMonkey",
+        "url": "https://www.surveymonkey.com/user/account/",
+        "difficulty": "easy",
+        "notes":"Scroll to the bottom of the page and click 'Permanently delete account'. After reviewing the information, click all checkboxes and enter your password. Click 'Yes, delete this account' to confirm.The account and questionnaire data will be definitively excluded within 90 days.",
+        "domains": [
+            "surveymonkey.com"
+        ]
+    },
+
+    {
+        "name": "Svtle",
+        "url": "https://svbtle.com/settings/account",
+        "difficulty": "easy",
+        "notes": "Click the 'Delete Account' link. After 30 days the data is irreversible to retrieve.",
+        "domains": [
+            "svbtle.com"
+        ]
+    },
+
+    {
+        "name": "Swagbucks",
+        "url": "http://www.swagbucks.com/account/settings#tab=account",
+        "difficulty": "easy",
+        "notes": "Use the 'Cancel My Account' link on your Account Settings page. Requires email confirmation.",
+        "domains": [
+            "swagbucks.com"
+        ]
+    },
+
+    {
+        "name": "Tablondeanuncios.com",
+        "url": "https://www.tablondeanuncios.com/mis-anuncios/",
+        "difficulty": "easy",
+        "notes": "Login to your account, go to Opciones, click Eliminar cuenta. Confirm by clicking I want to delete my account. Then, your account and your classified ads will be deleted.",
+        "notes_es": "Entra en tu cuenta, ve a 'Opciones', haz clic en 'Eliminar cuenta'. Haz clic en la pantalla de confirmación. Entonces, se borrará tu cuenta y todos los anuncios publicados.",
+        "domains": [
+            "tablondeanuncios.com"
+        ]
+    },
+
+    {
+        "name": "Tagged",
+        "url": "http://www.tagged.com/account_cancel.html",
+        "difficulty": "easy",
+        "notes": "You can reactivate at any time by logging in to your account.",
+        "domains": [
+            "tagged.com"
+        ]
+    },
+
+    {
+        "name": "Taiga",
+        "url": "https://tree.taiga.io/user-settings/user-profile",
+        "difficulty": "easy",
+        "notes": "Log in to your user account, go to 'User Settings' and select 'Delete Taiga account' below the save button. Confirm and done.",
+        "notes_de": "Nach dem Einloggen im Menü zu 'User Settings' gehen und dort 'Delete Taiga account' unter dem 'Save' Button auswählen. Bestätigen, fertig.",
+        "domains": [
+            "taiga.io",
+            "tree.taiga.io"
+        ]
+    },
+
+    {
+        "name": "Tango",
+        "url": "http://support.tango.me/entries/23534011-How-do-I-delete-my-Tango-account-",
+        "difficulty": "hard",
+        "notes": "In order to delete your account, you have to fill out the form.",
+        "domains": [
+            "tango.me"
+        ]
+    },
+
+    {
+        "name": "TargetProcess",
+        "url": "https://www.targetprocess.com/",
+        "email": "support@targetprocess.com",
+        "notes": "You need to e-mail them to ask for the deletion to be processed.",
+        "difficulty": "hard",
+        "domains": [
+            "targetprocess.com"
+        ]
+    },
+
+    {
+        "name": "Teachoo",
+        "url": "https://www.teachoo.com/contact/",
+        "difficulty": "hard",
+        "notes": "You must contact teachoo to remove your account.",
+        "domains": [
+            "teachoo.com"
+        ]
+    },
+
+    {
+        "name": "TeamViewer",
+        "url": "https://login.teamviewer.com/",
+        "difficulty": "easy",
+        "notes": "Edit profile (menu item at the top right corner of the page) →  Delete account",
+        "notes_it": "Modifica profilo (menu nell'angolo superiore destro della pagina) →  Delete account",
+        "notes_pt_br": "Edit profile (menu no canto do topo à direita da página) →  Delete account",
+        "notes_cat": "Edit profile (menú situat a la cantonada superior esquerra) →  Delete account",
+        "notes_es": "Edit profile (menú situado en la esquina superior izquierda) →  Delete account",
+        "domains": [
+            "teamviewer.com"
+        ]
+    },
+
+    {
+        "name": "Technorati",
+        "url": "http://technorati.com",
+        "difficulty": "impossible",
+        "notes": "It's not possible to remove your account, but you can remove your blogs.",
+        "notes_pt_br": "Não é possível remover sua conta, mas você pode remover seus blogs.",
+        "domains": [
+            "technorati.com"
+        ]
+    },
+
+    {
+        "name": "TED",
+        "url": "https://support.ted.com/customer/en/portal/articles/2581933-deleting-an-account",
+        "difficulty": "hard",
+        "notes": "Contact the TED support team <a href=\"http://support.ted.com/customer/portal/emails/new\">via their online contact form</a> for account deletion requests",
+        "domains": [
+            "ted.com"
+        ]
+    },
+
+    {
+        "name": "Telegram",
+        "url": "https://telegram.org/deactivate",
+        "difficulty": "easy",
+        "notes": "Open deactivation page. Enter your phone number and one time password sent to your Telegram account. Delete your account then.",
+        "domains": [
+            "telegram.org"
+        ]
+    },
+
+    {
+        "name": "Things",
+        "url": "https://support.culturedcode.com/customer/en/portal/articles/2803591-deleting-your-account-data",
+        "difficulty": "easy",
+        "notes": "In the Things app go to Preferences -> Things Cloud and select Edit Account. Then select 'Delete Account'.",
+        "notes_de": "Der Account kann über die Things Einstellungen -> Things Cloud bei 'Account bearbeiten' über 'Account löschen' gelöscht werden.",
+        "domains": [
+            "culturedcode.com"
+        ]
+    },
+
+    {
+        "name": "Threema",
+        "url": "https://myid.threema.ch/revoke",
+        "difficulty": "easy",
+        "notes": "In the app, go to your ID and select 'Delete ID' at the bottom. Alternatively go to <a href=\"https://myid.threema.ch/revoke\">https://myid.threema.ch/unlink</a> and remove your ID with your revocation password. If you do not have one, you can only unlink your phone number and mail under <a href=\"https://myid.threema.ch/unlink\">https://myid.threema.ch/unlink</a>.",
+        "notes_de": "Gehe in der App zu deiner ID und wähle 'ID löschen' am unteren Rand aus. Alternativ kannst du zu <a href=\"https://myid.threema.ch/revoke\">https://myid.threema.ch/unlink</a> gehen und dort deine ID mit deinem Widerrufspassword löschen. Wenn du dies nicht hast, kannst du nur deine Telefonnummer und E-Mail-Adresse unter <a href=\"https://myid.threema.ch/unlink\">https://myid.threema.ch/unlink</a> von der ID entfernen.",
+        "domains": [
+            "threema.ch"
+        ]
+    },
+
+    {
+        "name": "Ticketmaster",
+        "url": "http://help.ticketmaster.com/contact-us/",
+        "difficulty": "hard",
+        "notes": "You must submit a request to close your account via the form.",
+        "notes_it": "Devi inviare una richiesta attraverso il form per chiudere il tuo account.",
+        "notes_pt_br": "Você deve enviar um pedido para fechar sua conta pelo formulário.",
+        "notes_cat": "Haurà de sol·licitar que esborrin el seu compte via formulari.",
+        "notes_es": "Deberás solicitar que borren tu cuenta vía formulario.",
+        "domains": [
+            "ticketmaster.com"
+        ]
+    },
+
+    {
+        "name": "TikTok",
+        "difficulty": "medium",
+        "notes": "Tap account (with people depicton, on the bottom right edge)>Menu (on top right edge)>Privacy and Settings>Privacy and Safety>Delete Account>Next>Continue>Delete Account.",
+        "domains": [
+            "tiktok.com"
+        ]
+    },
+
+    {
+        "name": "TinyDeal",
+        "url": "http://help.tinydeal.com/contact-us",
+        "difficulty": "impossible",
+        "notes": "You will most likely be told that it's impossible to delete your account when contacting customer service.",
+        "domains": [
+            "tinydeal.com"
+        ]
+    },
+
+    {
+        "name": "Todoist",
+        "url": "https://www.todoist.com/settings",
+        "difficulty": "easy",
+        "notes": "At the bottom of the page is a delete account buttom, after clicking on it, you will need to re-enter your password.",
+        "domains": [
+            "todoist.com"
+        ]
+    },
+
+    {
+        "name": "Tokopedia",
+        "difficulty": "impossible",
+        "domains": [
+            "tokopedia.com"
+        ]
+    },
+
+    {
+        "name": "Topcoder",
+        "url": "https://www.topcoder.com/",
+        "difficulty": "impossible",
+        "notes": "You can't delete your account, but you can contact them via email to deactivate it.",
+        "email": "support@topcoder.com",
+        "domains": [
+            "topcoder.com"
+        ]
+    },
+
+    {
+        "name": "Topface",
+        "url": "http://topface.com/delete-profile/",
+        "difficulty": "easy",
+        "domains": [
+            "topface.com"
+        ]
+    },
+
+    {
+        "name": "Tor Project",
+        "url": "https://trac.torproject.org/",
+        "difficulty": "impossible",
+        "notes": "You can create an account with your email address only. But you cannot change, close, or delete your account",
+        "domains": [
+            "trac.torproject.org"
+        ]
+    },
+
+    {
+        "name": "The Tracktor",
+        "url": "https://thetracktor.com/account/close",
+        "difficulty": "easy",
+        "notes": "Login to your account first. Confirm by ticking 'Close my account' and click 'Close Account'.",
+        "domains": [
+            "thetracktor.com"
+        ]
+    },
+
+    {
+        "name": "Trakt",
+        "url": "http://trakt.tv/settings/data",
+        "difficulty": "easy",
+        "domains": [
+            "trakt.tv"
+        ]
+    },
+
+    {
+        "name": "TransferXL",
+        "url": "https://transferxl.com/profile",
+        "difficulty": "easy",
+        "notes": "Click on \"Delete your account\" at the bottom of the page.",
+        "domains": [
+            "transferxl.com"
+        ]
+    },
+
+    {
+        "name": "Transifex",
+        "url": "https://docs.transifex.com/account/deactivating-your-account",
+        "difficulty": "easy",
+        "notes": "In the main navigation, click on your profile image in the top right corner; from the dropdown menu, select User Settings; scroll to the bottom of the page and click Deactivate my account; confirm you want to delete your account by clicking Deactivate my account in the popup.",
+        "domains": [
+            "transifex.com"
+        ]
+    },
+
+    {
+        "name": "TrashMail",
+        "url": "https://trashmail.com/?lang=en&cmd=manager",
+        "difficulty": "easy",
+        "notes": "In top navigation bar, click on 'Account', then select 'Delete account'.",
+        "domains": [
+            "trashmail.com"
+        ]
+    },
+
+    {
+        "name": "Trello",
+        "url": "https://trello.com/your/account",
+        "difficulty": "easy",
+        "notes": "Select 'Delete your account?' option to delete your account",
+        "notes_fr": "Selectionnez 'Supprimer mon compte?' pour le supprimer.",
+        "notes_it": "Seleziona 'Eliminare il tuo account?' per eliminare il tuo account.",
+        "notes_pt_br": "Selecione a opção 'Delete your account?' para deletar sua conta",
+        "notes_cat": "Seleccioni l'opció 'Delete your account?' per esborrar el seu compte",
+        "notes_es": "Selecciona la opción 'Delete your account?' para borrar tu cuenta ",
+        "domains": [
+            "trello.com"
+        ]
+    },
+
+    {
+        "name": "Trillian",
+        "url": "http://www.trillian.im/account/#delete",
+        "difficulty": "easy",
+        "notes": "Select the option to delete your account and enter your username, password and the code which will be send to your mailaddress.",
+        "notes_nl": "Selecteer de optie om uw account te verwijderen en vul de gebruikersnaam, wachtwoord en de code in die wordt verstuurd naar uw mailadres.",
+        "domains": [
+            "trillian.im"
+        ]
+    },
+
+    {
+        "name": "TripAdvisor",
+        "url": "https://www.tripadvisorsupport.com/hc/en-us/articles/200615117",
+        "difficulty": "easy",
+        "domains": [
+            "tripadvisor.com"
+        ]
+    },
+
+    {
+        "name": "TripIt",
+        "url": "https://www.tripit.com/account/delete",
+        "difficulty": "easy",
+        "domains": [
+            "tripit.com"
+        ]
+    },
+
+    {
+        "name": "Troll and Toad",
+        "url": "https://www.trollandtoad.com/contact.php",
+        "difficulty": "hard",
+        "notes": "You must contact customer support using their 'Contact Us' form, and provide your account's e-mail address. The account will be deleted once a support staff member processes it.",
+        "domains": [
+            "www.trollandtoad.com"
+        ]
+    },
+
+    {
+        "name": "Tumblr",
+        "url": "http://www.tumblr.com/account/delete",
+        "difficulty": "easy",
+        "domains": [
+            "tumblr.com"
+        ]
+    },
+
+    {
+        "name": "Twenty20",
+        "url": "https://www.twenty20.com/delete-account?t20p=settings.index",
+        "difficulty": "easy",
+        "domains": [
+            "twenty20.com"
+        ]
+    },
+
+    {
+        "name": "Twitch",
+        "url": "https://www.twitch.tv/user/delete-account",
+        "difficulty": "easy",
+        "domains": [
+            "twitch.tv"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Twitter",
+        "url": "https://twitter.com/settings/accounts/confirm_deactivation",
+        "difficulty": "easy",
+        "notes": "Your account is deactivated before being deleted. After 30 days of remaining deactivated it will then be deleted.",
+        "notes_fr": "Votre compte est désactivé avant qu'il est supprimé. Il est seulement après 30 jours d'être désactivé qu'un compte est supprimé définitivement.",
+        "notes_it": "Il tuo account verrà 'disabilitato' prima di venir rimosso. Se dopo 30 giorni è ancora disattivato esso verrà eliminato.",
+        "domains": [
+            "twitter.com"
+        ]
+    },
+
+    {
+        "name": "Twoo",
+        "url": "http://www.twoo.com/settings/delete/",
+        "difficulty": "easy",
+        "domains": [
+            "www.twoo.com"
+        ]
+    },
+
+    {
+        "name": "Typeform",
+        "url": "https://www.typeform.com/help/submit-ticket/",
+        "notes": "To delete your account and data you need to contact Support.",
+        "difficulty": "hard",
+        "domains": [
+            "typeform.com"
+        ]
+    },
+
+    {
+        "name": "TypePad",
+        "url": "https://www.typepad.com/secure/account/cancel-account",
+        "difficulty": "easy",
+        "domains": [
+            "typepad.com"
+        ]
+    },
+
+    {
+        "name": "Uber",
+        "url": "https://help.uber.com/h/24010fe7-7a67-4ee5-9938-c734000b144a",
+        "notes": "Requires 'reason' to be filled out, and takes a few days to process. Once processed, you must click on the account deletion link which is sent via email.",
+        "difficulty": "hard",
+        "domains": [
+            "uber.com"
+        ]
+    },
+
+    {
+        "name": "Ubuntu One",
+        "url": "https://login.ubuntu.com/+faq#can-i-delete-my-ubuntu-one-account",
+        "difficulty": "hard",
+        "notes": "Yes and no, it depends on which type(s) of accounts, and you will need to delete the accounts in the correct order. All accounts are tied to Ubuntu One's Single Sign-On (login.ubuntu.com), so that is the account you should close last. Everything else, such as Launchpad.net, cloud file storage, AskUbuntu, and other accounts should be closed first if possible. This is especially important if you have any paid services attached, to make sure you won't be billed for anything after closing the accounts. The last step is to delete your Single Sign-On (SSO) account. SSO accounts must be deleted manually by the Ubuntu One staff.",
+        "notes_it": "Si e no, dipende dal tipo/i di account, e dovrai eliminare gli account nel giusto order. Tutti gli account sono collegati a Ubuntu One's Single Sign-On (login.ubuntu.com), quindi questo sarà l'ultimo account da chiudere. Tutto il resto, come Launchpad.net, cloud file storage, AskUbuntu e gli altri account devono essere chiusi prima, se possibile. Questo è importante soprattutto se hai qualche servizio a pagamento collegato, per essere sicuro di non ricevere richieste di pagamento dopo la chiusura degli account. L'ultimo passo è eliminare il tuo Single Sign-On (SSO) account. Questo deve essere eliminato manualmente dallo staff di Ubuntu One.",
+        "notes_pt_br": "Sim e não, depende do(s) tipo(s) de conta(s), e você precisará deletar a(s) conta(s) na ordem correta. Todas as contas estão ligadas ao Single Sign-on (login.ubuntu.com) do Ubuntu One, então esta é a conta que você deve fechar por último. De resto, como Launchpad.net, armazenamento de arquivos na nuvem, AskUbuntu, e outras contas devem ser fechadas primeiro se possível. Isto é muito importante se você tem algum serviço pago ligado, para ter certeza que você não será cobrado por qualquer coisa após fechar suas contas. O último passo é fechar sua conta Single Sign-On (SSO). Contas SSO devem ser deletadas manualmente pela equipe do Ubuntu One.",
+        "notes_cat": "Si i no, depén del tipo(s) de compte(s), i l'haurà d'eliminar en l'ordre correcte.  Tots els comptes estan relacionats amb l'inici de sessió únic (login.ubuntu.com) Ubuntu One, aleshores aquesta és l'ultim compte que has de tancar . A més,   l'enmagatzematge d'arxius en el núvo Launchpad.net, AskUbuntu i altres comptes s'han de tancar abans si és possible. Això és molt important si té algun servei de pagament, per assegurar-se que no se li cobrarà res després de tancar els seus comptes. L'últim pas és tancar el compte de Single Sign-On (SSO). Comptes d'SSO han de ser eliminats manualment pel personal d'Ubuntu One.",
+        "notes_es": "Sí y no, depende del tipo(s) de cuenta(s), y la(s) deberás eliminar en el orden correcto. Todas las cuentas están relacionados con el inicio de sesión único (login.ubuntu.com) Ubuntu One, entonces esta es la última cuenta que tienes que cerrar. Además, el almacenamiento de archivos en la nube Launchpad.net, AskUbuntu y otras cuentas se deberán cerrarán antes si es posible. Esto es muy importante si tienes algún servicio de pago, para asegurarte de que no te le cobrarás nada después de cerrar tus cuentas. el último paso es cerrar la cuenta de Single Sign-On (SSO). Las cuentas de SSO deben ser eliminadas a mano por el personal de Ubuntu One ",
+        "domains": [
+            "one.ubuntu.com"
+        ]
+    },
+
+    {
+        "name": "Udacity",
+        "url": "http://forums.udacity.com/answer_link/100044663/",
+        "difficulty": "impossible",
+        "notes": "A Udacity employee recommends that you stop using the account, which means there's currently no way of deleting the account.",
+        "notes_fr": "Udacity recommande à arrêter votre usage du compte, qui veut dire qu'il n'y a pas de façon de supprimer le compte en ce moment.",
+        "notes_it": "Un impiegato di Udacity consiglia di smettere di usare l'account, il che significa che non ci sono modi differenti per eliminare l'account.",
+        "notes_pt_br": "Um empregado Udacity recomenda que você pare de usar a conta, o que significa que não há como deletar sua conta atualmente.",
+        "notes_cat": "Un treballador d'Udacity recomana que pari d'utilitzar el compte, això vol dir que no hi ha cap manera d'esborrar el compte de moment.",
+        "notes_es": "Un empleado de Udacity recomienda que pares de utilizar la cuenta, es decir que no hay ninguna manera de borrar la cuenta de momento.",
+        "domains": [
+            "udacity.com"
+        ]
+    },
+
+    {
+        "name": "Udemy",
+        "url": "https://www.udemy.com/user/edit-danger-zone/",
+        "difficulty": "medium",
+        "notes": "In order to delete your account, you need to first unsubscribe from all of your courses.",
+        "notes_it": "Per eliminare il tuo account devi prima dis-iscriverti da tutti i tuoi corsi.",
+        "notes_pt_br": "Para deletar sua conta, você precisa se desinscrever de todos os seus cursos.",
+        "notes_cat": "Per esborrar el seu compte, haurà de deixar d'estar subscrit a tots els cursos.",
+        "notes_es": "Para borrar tu cuenta, primera deberás cancelar las suscripciones a todos los cursos.",
+        "domains": [
+            "udemy.com"
+        ]
+    },
+
+    {
+        "name": "Uncubed",
+        "url": "https://uncubed.com/learn/users/edit",
+        "difficulty": "hard",
+        "notes": "You can deactivate your account from 'Settings', but must contact them via email to terminate your account",
+        "email": "team@uncubed.com",
+        "domains": [
+            "uncubed.com"
+        ]
+    },
+
+    {
+        "name": "Unfuddle Ten",
+        "url": "https://unfuddle.io/app",
+        "difficulty": "hard",
+        "notes": "Send an email with the subject 'Delete my account', it is the only way.",
+        "email": "support@unfuddle.com",
+        "domains": [
+            "unfuddle.io"
+        ]
+    },
+
+    {
+        "name": "United Domains",
+        "url": "https://www.united-domains.de/support/kontakt-formular/close//",
+        "difficulty": "hard",
+        "notes": "Contact Support and request to delete your account.",
+        "notes_de": "Kontaktiere den Support und fordere eine Löschung des Accounts an.",
+        "email": "support@united-domains.de",
+        "domains": [
+            "united-domains.de"
+        ]
+    },
+
+    {
+        "name": "Unity ID",
+        "url": "https://support.unity3d.com/hc/en-us/articles/209059926",
+        "difficulty": "impossible",
+        "notes": "It is not possible for users to delete their own Unity ID accounts, instead users must contact Unity to disable accounts. Requires that the request come from the email linked to the account.",
+        "domains": [
+            "unity3d.com"
+        ]
+    },
+
+    {
+        "name": "Unroll.me",
+        "url": "https://unroll.me/user/settings",
+        "difficulty": "easy",
+        "notes": "Click 'Delete my account' at the bottom of the user settings page.",
+        "domains": [
+            "unroll.me"
+        ]
+    },
+
+    {
+        "name": "UPS",
+        "url": "https://www.ups.com/myups/deletereg",
+        "difficulty": "easy",
+        "domains": [
+            "ups.com"
+        ]
+    },
+
+    {
+        "name": "Usersnap",
+        "url": "https://usersnap.com/contact",
+        "difficulty": "hard",
+        "notes": "Send an email with the subject 'Delete my account'",
+        "email": "help@usersnap.com",
+        "domains": [
+            "usersnap.com"
+        ]
+    },
+
+    {
+        "name": "Ustream",
+        "url": "http://www.ustream.tv/dashboard/account/preferences",
+        "difficulty": "easy",
+        "notes": "Scroll down to the bottom of the 'Account Settings' page and click 'Delete Account'",
+        "notes_fr": "Tout en bas de la page il y a 'Parametre du compte' cliquez 'Supprimer mon compte'.",
+        "notes_it": "Scrolla fino al fondo della pagina 'Impostazioni Accountì e clicca 'Elimina Account'",
+        "notes_pt_br": "Vá até o final da página 'Account Settings' e clique em 'Delete Account'",
+        "notes_cat": "Baixi fins al peu de la pàgina a 'Account Settings' i cliqui a 'Delete Account'",
+        "notes_es": "Desplázate hasta el pie de la página en 'Account Settings' y pulsa 'Delete Account",
+        "domains": [
+            "ustream.tv"
+        ]
+    },
+
+    {
+        "name": "Valleywag (Gawker Media)",
+        "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
+        "difficulty": "impossible",
+        "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
+        "notes_fr": "Vous pouvez arrêter votre usage du service à tout moment sans nous informer. Nous pouvons, cependant, guarder et continuer d'utiliser tous le contenu que vous avez téléchargé par le service.",
+        "notes_it": "Puoi in qualsiasi momento smettere di usare il servizio. Tuttavia noi possiamo comunque accedere a qualsiasi contenuto che hai inviato attraverso il servizio.",
+        "notes_pt_br": "Você pode parar de usar o serviço a qualquer momento. Nós, no entanto, iremos manter e usar qualquer conteúdo enviado por você através do serviço.",
+        "notes_cat": "Pot parar de fer servir el servei en qualsevol moment. Nosaltres, si més no mantindrém i continuarem utilitzant el contingut que ha enviat amb el servei.",
+        "notes_es": "«Puedes dejar de utilizar el servicio en cualquier momento. Nosotros, sin embargo continuaremos usando el contenido que has enviado.»",
+        "domains": [
+            "kinja.com"
+        ]
+    },
+
+    {
+        "name": "Velo Hero",
+        "url": "http://app.velohero.com/settings/terminate",
+        "difficulty": "easy",
+        "domains": [
+            "velohero.com"
+        ]
+    },
+
+    {
+        "name": "Verduca",
+        "url": "http://www.veduca.com.br",
+        "difficulty": "impossible",
+        "domains": [
+            "veduca.com.br"
+        ]
+    },
+
+    {
+        "name": "vgy.me",
+        "url": "https://vgy.me",
+        "difficulty": "impossible",
+        "notes": "Admin once stated in an email that there would be no need to delete an account.",
+        "domains": [
+            "vgy.me"
+        ]
+    },
+
+    {
+        "name": "Viadeo",
+        "url": "http://www.viadeo.com/settings/account/?ga_from=Fu:%2Fsettings%2Faccount%2F;Fb%3Amenu_box_right%3BFe%3AL1-account-settings%3B",
+        "difficulty": "easy",
+        "notes": "There's a button on the right, just under the menu.",
+        "notes_fr": "La bouton de suppression se trouve sur la droite sous le menu.",
+        "notes_it": "C'è un bottone sulla destra, proprio sotto il menu.",
+        "notes_pt_br": "Existe um botão à direita, logo abaixo do menu.",
+        "notes_cat": "Hi ha un botò a la dreta, just a sota del menu.",
+        "notes_es": "Hay un botón a la derecha, abajo del menú.",
+        "domains": [
+            "viadeo.com"
+        ]
+    },
+
+    {
+        "name": "Vidyard",
+        "url": "https://knowledge.vidyard.com",
+        "difficulty": "medium",
+        "notes": "Click \"Get Help\" and request an account deletion, entering your email into the request form.",
+        "domains": [
+            "vidyard.com"
+        ]
+    },
+
+    {
+        "name": "Vimeo",
+        "url": "https://vimeo.com/settings/goodbye/forever",
+        "difficulty": "easy",
+        "domains": [
+            "vimeo.com"
+        ]
+    },
+
+    {
+        "name": "Vine",
+        "url": "https://support.twitter.com/forms/vine",
+        "difficulty": "hard",
+        "notes": "The only way to delete your Vine account without deleting your Twitter account is to contact Twitter through their contact form.",
+        "notes_fr": "La seule façon de supprimer votre compte Vine sans supprimer votre compte Twitter, est de contacter Twitter directement.",
+        "notes_it": "L'unico modo per eliminare il tuo account Vine senza eliminare il tuo account Twitter è contattare Twitter attraverso il loro form contatti.",
+        "notes_pt_br": "A única maneira de deletar sua conta Vine sem deletar sua conta no Twitter é contatar o Twitter por meio do formulário de contato.",
+        "notes_cat": "L'unica manera d'esborrar el seu compte de Vine sense esborrar el compte de Twitter es contactar amb Twitter via el seu formulari de contacte.",
+        "notes_es": "La única manera de borrar tu cuenta de Vine sin borrar la cuenta de Twitter es contactar con Twitter vía su formulario de contacto.",
+        "domains": [
+            "vine.co"
+        ]
+    },
+
+    {
+        "name": "VK/ВКонтакте",
+        "url": "http://vk.com/settings?act=deactivate",
+        "difficulty": "easy",
+        "domains": [
+            "vk.com"
+        ]
+    },
+
+    {
+        "name": "Voat",
+        "url": "https://voat.co/Account/Delete",
+        "difficulty": "easy",
+        "domains": [
+            "voat.co"
+        ]
+    },
+
+    {
+        "name": "Voxer",
+        "url": "https://support.voxer.com/hc/en-us/articles/204330173-How-do-I-delete-my-Voxer-account-",
+        "difficulty": "medium",
+        "notes": "Account can only be deleted from Android or iOS app, not the Voxer website.",
+        "domains": [
+            "voxer.com"
+        ]
+    },
+
+    {
+        "name": "Walmart",
+        "url": "http://help.walmart.com/app/answers/detail/a_id/230/~/how-to-close-your-walmart.com-account",
+        "difficulty": "hard",
+        "notes": "Contact customer service to close your account.",
+        "domains": [
+            "walmart.com"
+        ]
+    },
+
+    {
+        "name": "WAYN",
+        "url": "http://www.wayn.com/wayn.html?wci=unregister",
+        "difficulty": "easy",
+        "domains": [
+            "wayn.com"
+        ]
+    },
+
+    {
+        "name": "Waze",
+        "url": "https://www.waze.com/dashboard/delete_account",
+        "difficulty": "easy",
+        "domains": [
+            "waze.com"
+        ]
+    },
+
+    {
+        "name": "We the People",
+        "url": "https://petitions.whitehouse.gov/",
+        "difficulty": "impossible",
+        "notes": "Site provides no user account management interface or account deletion options.",
+        "notes_fr": "Le site ne propose pas la suppression de compte.",
+        "notes_it": "Il sito non possiede nessuna interfaccia di gestione utente o possibilità di eliminare l'account",
+        "notes_pt_br": "O site não possui interface de gerenciamento da conta ou opções para remoção da conta.",
+        "notes_cat": "La web no té opcions d'usuari o per esborrar el compte.",
+        "notes_es": "El sitio no tiene opciones de configuración o para borrar la cuenta.",
+        "domains": [
+            "petitions.whitehouse.gov"
+        ]
+    },
+
+    {
+        "name": "Weather.com",
+        "url": "http://registration.weather.com/ursa/profile/unsubscribe",
+        "difficulty": "easy",
+        "notes": "Site uses the term \"unsubscribe\" to describe completely deleting an account.",
+        "domains": [
+            "weather.com"
+        ]
+    },
+
+    {
+        "name": "WEB.DE",
+        "url": "https://kundencenter.web.de/",
+        "difficulty": "easy",
+        "domains": [
+            "web.de"
+        ]
+    },
+
+    {
+        "name": "Weebly",
+        "url": "https://www.weebly.com/home/account/payment",
+        "difficulty": "easy",
+        "notes": "Click on 'Permanently delete your Weebly account'.",
+        "domains": [
+            "weebly.com"
+        ]
+    },
+
+    {
+        "name": "WeHeartIt",
+        "url": "http://weheartit.com/settings/delete",
+        "difficulty": "easy",
+        "domains": [
+            "weheartit.com"
+        ]
+    },
+
+    {
+        "name": "Western Union",
+        "url": "https://wucare.westernunion.com/s/article/How-do-I-delete-my-Western-Union-online-profile?language=en_US",
+        "email": "CustomerCare@westernunion.com",
+        "email_body": "My name is XXXXXX%0AMy registered phone number is XXXXXX%0AMy WU number is XXXXXX%0AI would like to delete my WU profile because XXXXXX",
+        "difficulty": "hard",
+        "notes": "To delete your profile, <a href=\"https://www.westernunion.com/us/en/contactus.html\">contact</a> Customer Care or send an email from the account you registered with containing your name, registered phone number, My WU number (if applicable), and reason for deleting your profile.",
+        "domains": [
+            "westernunion.ch",
+            "westernunion.com"
+        ]
+    },
+
+    {
+        "name": "WhatPulse",
+        "url": "http://whatpulse.org/my/#home",
+        "difficulty": "easy",
+        "notes": "When logged into the website, select \"My WhatPulse\" from the navigation bar, then click \"Unregister from WhatPulse\" towards the bottom of the page. This will permanently delete the account.",
+        "notes_es": "Logeados en el sitio web, seleccione \"Mi whatpulse\" de la barra de navegación, haga clic en \"Unregister from WhatPulse\" hacia la parte inferior de la página. Esto eliminará permanentemente la cuenta.",
+        "domains": [
+            "whatpulse.org"
+        ]
+    },
+
+    {
+        "name": "WhatsApp",
+        "url": "https://www.whatsapp.com/faq/search/?q=how%20do%20I%20delete%20my%20account?&p=desktop",
+        "difficulty": "medium",
+        "notes": "From the app: Settings → Account → Delete your account.",
+        "notes_fr": "Depuis l'app: Réglages -> Compte -> Supprimer mon compte.",
+        "notes_it": "Dall'applicazione: Impostazioni → Account → Elimina il tuo account.",
+        "notes_pt_br": "No aplicativo: Settings → Account → Delete your account.",
+        "notes_cat": "Des de l'aplicació: Settings → Account → Delete your account.",
+        "notes_es": "Desde la aplicación: Settings → Account → Delete your account.",
+        "notes_pl": "Z aplikacji: Ustawienia → Konto → Usuń konto.",
+        "domains": [
+            "whatsapp.com"
+        ]
+    },
+
+    {
+        "name": "Which?",
+        "url": "http://www.which.co.uk/terms-and-conditions/your-which-membership/",
+        "difficulty": "hard",
+        "email": "which@which.co.uk",
+        "email_body": "My membership number is XXXXXX",
+        "domains": [
+            "which.co.uk"
+        ],
+        "notes": "Require your membership number to be sent in the email. This can be found here <a href=\"https://www.which.co.uk/account/#/\">https://www.which.co.uk/account/#/</a>"
+    },
+
+    {
+        "name": "whistle.im",
+        "url": "http://whistle.im/browser#vcard",
+        "difficulty": "easy",
+        "notes": "Menu →  Edit vCard →  Account management →  Delete everything (cannot be undone)",
+        "notes_it": "Menu →  Modifica vCard →  Gestione Account →  Elimina tutto (non può essere annullato)",
+        "notes_cat": "Menu →  Edit vCard →  Account management →  Delete everything (no es pot tornar endarrera)",
+        "notes_es": "Menu →  Edit vCard →  Account management →  Delete everything (no se puede deshacerlo)",
+        "domains": [
+            "whistle.im"
+        ]
+    },
+
+    {
+        "name": "WhoSay.com",
+        "url": "http://www.whosay.com/settings",
+        "difficulty": "easy",
+        "notes": "Just click 'Deactivate'.",
+        "notes_fa": "فقط روی 'Deactivate' کلیک کنید.",
+        "notes_pl": "Po prostu kliknij 'Deactivate'.",
+        "domains": [
+            "whosay.com"
+        ]
+    },
+
+    {
+        "name": "Wikidot",
+        "url": "https://www.wikidot.com/account/settings",
+        "difficulty": "easy",
+        "notes": "Click on 'Delete account'. Confirm account deletion through the link sent to user email address.",
+        "domains": [
+            "wikidot.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Wikipedia",
+        "url": "https://en.wikipedia.org/wiki/Wikipedia:FAQ#How_do_I_change_my_username.2Fdelete_my_account.3F",
+        "difficulty": "impossible",
+        "notes": "'A username cannot be deleted.' However, they do have some suggestions.",
+        "notes_fr": "Vous ne pouvez pas supprimer votre compte.",
+        "notes_it": "'Un username non può essere eliminato.'. In ogni caso, ci sono alcuni consigli.",
+        "notes_pt_br": "'Um usuário não pode ser deletado.' Entretanto, eles possuem algumas sugestões.",
+        "notes_cat": "'No es poden esborrar els usuaris.' Però fan algunes suggerencies.",
+        "notes_es": "'No se pueden borrar los usuarios.' Pero hacen algunas sugerencias.",
+        "domains": [
+            "wikipedia.org"
+        ]
+    },
+
+    {
+        "name": "WishSimply",
+        "url": "https://wishsimply.com/profile/account-settings",
+        "difficulty": "easy",
+        "notes": "Enter your account password and click on 'DELETE ACCOUNT'.",
+        "domains": [
+            "WishSimply.com"
+        ]
+    },
+
+    {
+        "name": "Wix",
+        "url": "http://www.wix.com/support/html5/billing/premium-plans/faq/cancel-account-20",
+        "difficulty": "easy",
+        "notes": "Delete any built sites and subscriptions then follow the link to a deletion request form. Email is sent straight away with a link to confirm the deletion",
+        "domains": [
+            "wix.com"
+        ]
+    },
+
+    {
+        "name": "WolframAlpha.com",
+        "url": "http://www.wolframalpha.com/fbfaqs.html",
+        "difficulty": "hard",
+        "notes": "For the immediate future, send a message to WolframAlpha, and your Wolfram ID will be deleted manually.",
+        "email": "info@wolframalpha.com",
+        "domains": [
+            "wolframalpha.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "WordPress.com",
+        "url": "https://wordpress.com/me/account",
+        "difficulty": "easy",
+        "notes": "You can permanently close your WordPress.com account from your Account Settings screen by clicking on 'Close your account permanently'",
+        "domains": [
+            "wordpress.com"
+        ]
+    },
+
+    {
+        "name": "workupload",
+        "url": "https://workupload.com/contact",
+        "difficulty": "hard",
+        "notes": "Write a short mail using their web contact form.",
+        "domains": [
+            "workupload.com"
+        ]
+    },
+
+    {
+        "name": "Wunderlist",
+        "url": "https://www.wunderlist.com/#/preferences/account",
+        "difficulty": "easy",
+        "notes": "Click 'Delete Account' at the bottom of the account preferences panel.",
+        "notes_fr": "Cliquez 'Supprimer mon compte' en bas de la page.",
+        "notes_it": "Clicca 'Elimina Account' sul fondo della pagina delle impostazioni account.",
+        "notes_pt_br": "Clique em 'Delete Account' no final do painel de preferências da conta.",
+        "notes_cat": "Cliqui a 'Delete Account' al final del panell d'opcions del compte.",
+        "notes_es": "Haz clic en 'Delete Account' al final del panel de opciones de la cuenta.",
+        "domains": [
+            "wunderlist.com"
+        ]
+    },
+
+    {
+        "name": "XDA Developers",
+        "url": "https://www.xda-developers.com/gdpr-data/",
+        "difficulty": "hard",
+        "notes": "Click 'Data Deletion Request' and fill in the form. Make sure to specify if you want your posts deleted.",
+        "notes_fr": "Cliquez 'Data Deletion Request' et remplissez le formulaire. Assurez-vous de spécifier si vous voulez que vos posts soient supprimés",
+        "domains":[
+            "xda-developers.com"
+        ]
+    },
+
+    {
+        "name": "Xing",
+        "url": "https://www.xing.com/help/help-and-faqs-2/general-stuff-55/xing-memberships-153/general-stuff-803/canceling-free-basic-membership-185",
+        "difficulty": "easy",
+        "notes": "Select 'delete my profile' at the bottom of the page.",
+        "notes_fr": "Selectionnez 'Supprimer mon compte' en bas de la page.",
+        "notes_it": "Seleziona 'elimina il mio profilo' sul fondo della pagina.",
+        "notes_pt_br": "Selecione 'delete my profile' no final da página.",
+        "notes_cat": "Seleccioni 'delete my profile' al final de la pàgina.",
+        "notes_es": "Selecciona 'delete my profile' al final de la página.",
+        "domains": [
+            "xing.com"
+        ]
+    },
+
+    {
+        "name": "Yahoo!",
+        "meta": "popular",
+        "url": "https://edit.yahoo.com/config/delete_user",
+        "difficulty": "easy",
+        "domains": [
+            "yahoo.com"
+        ]
+    },
+
+    {
+        "name": "Yammer",
+        "url": "https://www.yammer.com/mozillians/account/display_options",
+        "difficulty": "easy",
+        "notes": "On the above URL, click the 'Delete your Yammer account' link in the top right and confirm.",
+        "domains": [
+            "yammer.com"
+        ]
+    },
+
+    {
+        "name": "Yandex",
+        "url": "https://passport.yandex.com/profile/delete?origin=passport_profile",
+        "difficulty": "easy",
+        "notes": "On the above URL, confirm the deletion by entering the CAPTCHA code. If backup email and/or phone added you will need to send a confirmation code and fill in the code(s). Press \"Delete account\" and confirm deletion in the dialog box.",
+        "domains": [
+            "yandex.com"
+        ]
+    },
+
+    {
+        "name": "Yelp",
+        "meta": "popular",
+        "url": "http://www.yelp.co.uk/contact?topic=support&subtopic=close",
+        "difficulty": "easy",
+        "domains": [
+            "yelp.co.uk"
+        ]
+    },
+
+    {
+        "name": "YNAB (You Need A Budget)",
+        "url": "https://app.youneedabudget.com/users/delete",
+        "difficulty": "easy",
+        "domains": [
+            "youneedabudget.com"
+        ]
+    },
+
+    {
+        "name": "YouTube",
+        "meta": "popular",
+        "url": "https://myaccount.google.com/deleteservices",
+        "difficulty": "easy",
+        "notes": "You can request your data copy before you delete YouTube account.",
+        "domains": [
+            "youtube.com"
+        ]
+    },
+
+    {
+        "name": "Yummly",
+        "url": "https://www.yummly.com/settings",
+        "difficulty": "easy",
+        "notes": "Select \"To delete your account, click here\" at the bottom of the page.",
+        "domains": [
+            "yummly.com"
+        ]
+    },
+
+    {
+        "name": "Zattoo",
+        "url": "https://zattoo.com/account/delete",
+        "difficulty": "easy",
+        "domains": [
+            "zattoo.com"
+        ]
+    },
+
+    {
+        "name": "Zazzle",
+        "url": "https://www.zazzle.com/about/ask",
+        "difficulty": "hard",
+        "notes": "To terminate your account, simply send a message via their web contact form to Customer Care that contains your username and the email address associated with your account.  Once you've done so, a member of our Support Team will disable your account and remove any products, both public and private, and disable your store (if applicable).  The account will be deleted fully when our system processes the next batch of account removals.",
+        "domains": [
+            "zazzle.com"
+        ]
+    },
+
+    {
+        "name": "Zeit",
+        "url": "https://zeit.co/account/plan",
+        "difficulty": "hard",
+        "notes": "You would need to email the team by clicking contact us to get your account closed.",
+        "email": "team@zeit.co",
+        "domains": [
+            "zeit.co"
+        ]
+    },
+
+    {
+        "name": "Zeit Online",
+        "url": "http://community.zeit.de/hilfe/meinen-account-loeschen",
+        "difficulty": "hard",
+        "notes": "Send an Email with the Username",
+        "email": "community@zeit.de",
+        "domains": [
+            "zeit.de"
+        ]
+    },
+
+    {
+        "name": "Zendesk",
+        "url": "https://support.zendesk.com/hc/en-us/articles/223774027-Canceling-your-Support-account",
+        "difficulty": "easy",
+        "notes": "Go to Admin->Settings->Subscription and click 'Yes, cancel my account'.",
+        "domains": [
+            "zendesk.com"
+        ]
+    },
+
+    {
+        "name": "Zenkit",
+        "url": "https://zenkit.com/profile",
+        "difficulty": "easy",
+        "notes": "Login to your account, go to profile, scroll down and click 'Delete Account'. Confirm by entering 'DELETEMYACCOUNT' and click 'Delete My Account'.",
+        "domains": [
+            "zenkit.com"
+        ]
+    },
+
+    {
+        "name": "Zoho",
+        "url": "https://accounts.zoho.com/u/h#setting/closeaccount",
+        "difficulty": "easy",
+        "domains": [
+            "zoho.com"
+        ]
+    },
+
+    {
+        "name": "Zynga",
+        "url": "https://zynga.com/privacy/faqs",
+        "difficulty": "hard",
+        "notes": "Place Delete My Account in the subject line and include your first name, last name, e-mail address and user ID number for the SNS from which you access our games (if applicable) in the body of the e-mail.",
+        "email": "privacy@zynga.com",
+        "email_subject": "Delete My Account",
+        "email_body": "My first and last name are XXXXXX XXXXXX, my e-mail address is XXXXXX, and my user ID number is XXXXXX",
+        "domains": [
+            "zynga.com"
+        ]
+    }
+]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7461,6 +7461,17 @@
     },
 
     {
+        "name": "Viva o Linux (VOL)",
+        "url": "http://vivaolinux.com.br/minhaConta.php",
+        "difficulty": "easy",
+        "notes": "Click at \"Excluir conta\", type your password and confirm your action by clicking \"Gravar\".",
+        "notes_pt_br": "Clique em \"Excluir conta\", digite sua senha e clique em \"Gravar\" para confirmar a exclusão da conta.",
+        "domains": [
+            "vivaolinux.com.br"
+        ]
+    },
+
+    {
         "name": "VK/ВКонтакте",
         "url": "http://vk.com/settings?act=deactivate",
         "difficulty": "easy",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4416,9 +4416,181 @@
     },
 
     {
+        "name": "Mercado Libre Argentina",
+        "url": "http://myaccount.mercadolibre.com.ar/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Libre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Libre account, your Mercado Pago account will be deleted too.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Libre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Libre, sua conta do Mercado Pago também será excluída.",
+        "domains": [
+            "mercadolibre.com.ar",
+            "mercadopago.com.ar"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Bolivia",
+        "url": "http://myaccount.mercadolibre.com.bo/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.com.bo"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Chile",
+        "url": "http://myaccount.mercadolibre.cl/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Libre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Libre account, your Mercado Pago account will be deleted too.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Libre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Libre, sua conta do Mercado Pago também será excluída.",
+        "domains": [
+            "mercadolibre.cl",
+            "mercadopago.cl"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Colombia",
+        "url": "http://myaccount.mercadolibre.com.co/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Libre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Libre account, your Mercado Pago account will be deleted too.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Libre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Libre, sua conta do Mercado Pago também será excluída.",
+        "domains": [
+            "mercadolibre.com.co",
+            "mercadopago.com.co"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Costa Rica",
+        "url": "http://myaccount.mercadolibre.co.cr/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.co.cr"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Ecuador",
+        "url": "http://myaccount.mercadolibre.com.ec/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.com.ec"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Guatemala",
+        "url": "http://myaccount.mercadolibre.com.gt/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.com.gt"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Honduras",
+        "url": "http://myaccount.mercadolibre.com.hn/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.com.hn"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre México",
+        "url": "http://myaccount.mercadolibre.com.mx/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Libre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Libre account, your Mercado Pago account will be deleted too.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Libre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Libre, sua conta do Mercado Pago também será excluída.",
+        "domains": [
+            "mercadolibre.com.mx",
+            "mercadopago.com.mx"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Nicaragua",
+        "url": "http://myaccount.mercadolibre.com.ni/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.com.ni"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Panamá",
+        "url": "http://myaccount.mercadolibre.com.pa/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.com.pa"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Paraguay",
+        "url": "http://myaccount.mercadolibre.com.py/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.com.py"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Perú",
+        "url": "http://myaccount.mercadolibre.com.pe/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Libre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Libre account, your Mercado Pago account will be deleted too.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Libre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Libre, sua conta do Mercado Pago também será excluída.",
+        "domains": [
+            "mercadolibre.com.pe",
+            "mercadopago.com.pe"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre República Dominicana",
+        "url": "http://myaccount.mercadolibre.com.do/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.com.do"
+        ]
+    },
+
+    {
+        "name": "Mercado Libre Salvador",
+        "url": "http://myaccount.mercadolibre.com.sv/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes.",
+        "domains": [
+            "mercadolibre.com.sv"
+        ]
+    },
+
+    {
         "name": "Mercado Libre Uruguay",
-        "url": "https://myaccount.mercadolibre.com.uy/cancelar-cuenta",
-        "difficulty": "easy",
+        "url": "http://myaccount.mercadolibre.com.uy/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Libre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Libre account, your Mercado Pago account will be deleted too.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Libre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Libre, sua conta do Mercado Pago também será excluída.",
         "domains": [
             "mercadolibre.com.uy",
             "mercadopago.com.uy"
@@ -4426,11 +4598,23 @@
     },
 
     {
+        "name": "Mercado Libre Venezuela",
+        "url": "http://myaccount.mercadolibre.com.ve/cancelar-cuenta",
+        "difficulty": "medium",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estoy de acuerdo\", and confirm your action by clinking \"Aceptar\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Libre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Libre account, your Mercado Pago account will be deleted too.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estoy de acuerdo\" e clique em \"Aceptar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Libre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Libre, sua conta do Mercado Pago também será excluída.",
+        "domains": [
+            "mercadolibre.com.ve",
+            "mercadopago.com.ve"
+        ]
+    },
+
+    {
         "name": "Mercado Livre Brasil",
         "url": "http://myaccount.mercadolivre.com.br/cancelar-conta",
         "difficulty": "medium",
-        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estou de acordo\", and confirm your action by clinking \"Aceito\".</br></br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Livre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Livre account, your Mercado Pago account will be deleted too.",
-        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estou de acordo\" e clique em \"Aceitar\".</br></br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Livre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Livre, sua conta do Mercado Pago também será excluída.",
+        "notes": "To cancel/delete your account, access the account deletion link specified above and log in to your account. In the options, select a reason why you want to cancel your account, click in the checkbox \"Estou de acordo\", and confirm your action by clinking \"Aceito\".<br><br><strong>Warning:</strong> You may cancel your account only if there is no limitation, partial and/or total blockage applied to it. You will also be unable to cancel your account if you have outstanding payments and/or purchases. Mercado Livre and Mercado Pago are services associated with the same type of account. If you choose to delete your Mercado Livre account, your Mercado Pago account will be deleted too.",
+        "notes_pt_br": "Para cancelar/excluir sua conta, acesse o link de exclusão especificado acima e faça login em sua conta. Nos opções de exclusão, selecione um motivo pelo qual você quer cancelar sua conta, marque a opção \"Estou de acordo\" e clique em \"Aceitar\".<br><br><strong>Aviso:</strong> Você poderá cancelar sua conta apenas se não houver nenhuma limitação, bloqueio parcial e/ou total aplicado aplicado à ela. Você também não poderá cancelar sua conta caso você tenha pagamentos e/ou compras pendentes. O Mercado Livre e o Mercado Pago são serviços associados ao mesmo tipo de conta, se você optar por excluir sua conta do Mercado Livre, sua conta do Mercado Pago também será excluída.",
         "domains": [
             "mercadolivre.com.br",
             "mercadopago.com.br",


### PR DESCRIPTION
<h3 align='center'>Changes</h3>

* **Updated:** `difficulty`, `notes` and `notes_pt_br` of the "Mercado Libre Uruguay" account deletion info
* **Added:** "Mercado Libre Argentina" account deletion info
* **Added:** "Mercado Libre Bolivia" account deletion info
* **Added:** "Mercado Libre Chile" account deletion info
* **Added:** "Mercado Libre Colombia" account deletion info
* **Added:** "Mercado Libre Costa Rica" account deletion info
* **Added:** "Mercado Libre Ecuador" account deletion info
* **Added:** "Mercado Libre Guatemala" account deletion info
* **Added:** "Mercado Libre Honduras" account deletion info
* **Added:** "Mercado Libre México" account deletion info
* **Added:** "Mercado Libre Nicaragua" account deletion info
* **Added:** "Mercado Libre Panamá" account deletion info
* **Added:** "Mercado Libre Paraguay" account deletion info
* **Added:** "Mercado Libre Perú" account deletion info
* **Added:** "Mercado Libre República Dominicana" account deletion info
* **Added:** "Mercado Libre Salvador" account deletion info
* **Added:** "Mercado Libre Uruguay" account deletion info
* **Added:** "Mercado Libre Venezuela" account deletion info
* **Added:** "Viva o Linux (VOL)" account deletion info

<h3 align='center'>Additional information</h3>

The "Mercado Pago" service isn't available in some countries. This is why domains associated with the "Mercado Pago" aren't present in some account deletion entries. In this case, only the domains related to "Mercado Libre" are present. 