### PR TITLE
Remove Linux Counter

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4035,13 +4035,6 @@
     },
 
     {
-        "name": "The Linux Counter Project",
-        "url": "https://linuxcounter.net/deleteaccount/profile.html",
-        "difficulty": "easy",
-        "notes": "Login -> Profile -> Delete account -> Yes"
-    },
-
-    {
         "name": "LiveJournal",
         "url": "http://www.livejournal.com/accountstatus.bml",
         "difficulty": "medium",


### PR DESCRIPTION
It ceased operating in [December, 2018](http://en.wikipedia.org/wiki/Linux_Counter) and stopped responding in [October 2019](https://travis-ci.org/jdm-contrib/jdm/builds/597252011)