### PR TITLE
Added Gfycat

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2720,6 +2720,17 @@
     },
 
     {
+        "name": "Gfycat",
+        "url": "https://gfycat.com/support",
+        "email": "support@sigfig.com",
+        "difficulty": "hard",
+        "notes": "You can't delete your account without contacting them. Send them an email from the address used to create the account"
+        "domains": [
+            "gfycat.com"
+        ]
+    },
+
+    {
         "name": "GHash.IO",
         "url": "https://support.cex.io/hc/en-us/articles/201516097-How-can-I-delete-my-account-from-CEX-IO-and-GHash-IO-",
         "email": "support@cex.io",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2722,9 +2722,9 @@
     {
         "name": "Gfycat",
         "url": "https://gfycat.com/support",
-        "email": "support@sigfig.com",
+        "email": "support@gfycat.com",
         "difficulty": "hard",
-        "notes": "You can't delete your account without contacting them. Send them an email from the address used to create the account"
+        "notes": "You can't delete your account without contacting them. Send them an email from the address used to create the account",
         "domains": [
             "gfycat.com"
         ]


### PR DESCRIPTION
I have not found a support page explaining how to delete an account, only reddit comments such as [this comment](https://www.reddit.com/r/gfycat/comments/bvxsal/how_do_you_delete_a_gfycat_account/eptawui/) going back several years.

The support page I added as url does not have any relevant info other than the support email.