### PR TITLE
Remove Gitorious

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2775,16 +2775,6 @@
     },
 
     {
-        "name": "Gitorious",
-        "url": "https://gitorious.org",
-        "difficulty": "impossible",
-        "notes": "Gitorious is now an archived, read-only copy of the prior code hosting website. Data cannot be altered on this mirror.",
-        "domains": [
-            "gitorious.org"
-        ]
-    },
-
-    {
         "name": "Gizmodo (Gawker Media)",
         "url": "http://legal.kinja.com/kinja-terms-of-use-90161644",
         "difficulty": "impossible",


### PR DESCRIPTION
As of Build [#968](https://travis-ci.org/jdm-contrib/jdm/builds/600362808), Gitorious seems to be offline. It has been just a read only website for some time, but they might have decided to shut it down.

Since it's owned by GitLab, which is fairly big, I'll give it a 2-3 day grace period to see if it comes back online, before merging.