### PR TITLE
Remove MyLife.com

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4854,15 +4854,6 @@
     },
 
     {
-        "name": "MyLife.com",
-        "url": "http://www.mylife.com/showDeleteAccount.do",
-        "difficulty": "easy",
-        "domains": [
-            "mylife.com"
-        ]
-    },
-
-    {
         "name": "MyScript",
         "url": "https://sso.myscript.com/v1/api/account/delete/request",
         "difficulty": "easy",


### PR DESCRIPTION
Has been consistently offline since build #974, on October 22.
[Twitter](https://twitter.com/mylifecom) shows no activity since 2016
[Facebook](https://www.facebook.com/MyLifeUS/) has a post from October 21, but none of the links to the company work.

I'll give it a couple days, then delete it.