### PR TITLE
Update Netflix and Geocaching to hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4267,13 +4267,14 @@
         "name": "Netflix",
         "url": "https://help.netflix.com/en/node/407",
         "difficulty": "impossible",
-        "notes": "Contact customer services. Even then they may not delete your account under the premise that you might want to rejoin and keep your history and recommendations.",
-        "notes_fr": "Contactez le service clients.",
+        "notes": "Cancel your membership, then contact support if you want immediate deletion. Otherwise your account will be conserved for 10 months.",
+        "notes_fr": "Annulez votre abonnement, puis contactez le support si vous souhaitez une suppression immédiate. Sinon, votre compte sera conservé pendant 10 mois."
         "notes_it": "Contatta il servizio clienti.",
         "notes_pt_br": "Contate a assistência ao cliente. Mesmo assim eles não deletarão sua conta sobre a premissa que talvez você queira retornar em manter seu histórico e recomendações.",
         "notes_cat": "Contacti amb el servei d'assistència al client. No s'eliminarà completament, sota la premisa de que potser voldràs reobrir el compte i mantindre l'historial i les notificacions.",
         "notes_es": "Contacta con el servicio de asistencia al cliente. No se eliminará completamente, bajo la suposición de que quizás querrás reabrir la cuenta y mantener el historial y las notificaciones.",
-        "domains": [
+        "email": "privacy@netflix.com",
+		"domains": [
             "netflix.com"
         ]
     },

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4271,7 +4271,6 @@
         "notes_fr": "Annulez votre abonnement, puis contactez le support si vous souhaitez une suppression immédiate. Sinon, votre compte sera conservé pendant 10 mois.",
         "notes_it": "Contatta il servizio clienti.",
         "notes_pt_br": "Contate a assistência ao cliente. Mesmo assim eles não deletarão sua conta sobre a premissa que talvez você queira retornar em manter seu histórico e recomendações.",
-        "notes_cat": "Contacti amb el servei d'assistència al client. No s'eliminarà completament, sota la premisa de que potser voldràs reobrir el compte i mantindre l'historial i les notificacions.",
         "email": "privacy@netflix.com",
         "domains": [
             "netflix.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4267,7 +4267,7 @@
         "name": "Netflix",
         "url": "https://help.netflix.com/en/node/407",
         "difficulty": "hard",
-        "notes": "Cancel your membership, then contact support if you want immediate deletion. Otherwise your account will be conserved for 10 months.",
+        "notes": "Cancel your membership, then contact support if you want immediate deletion, otherwise your account will be automatically deleted in 10 months.",
         "notes_fr": "Annulez votre abonnement, puis contactez le support si vous souhaitez une suppression immédiate. Sinon, votre compte sera conservé pendant 10 mois.",
         "notes_it": "Contatta il servizio clienti.",
         "notes_pt_br": "Contate a assistência ao cliente. Mesmo assim eles não deletarão sua conta sobre a premissa que talvez você queira retornar em manter seu histórico e recomendações.",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2463,7 +2463,7 @@
         "name": "Geocaching",
         "url": "http://support.groundspeak.com/index.php?pg=kb.page&id=102",
         "difficulty": "hard",
-        "notes": "To permanently delete your account, you must contact them as the option in your account settings will not delete your geocaching logs."
+        "notes": "To permanently delete your account, you must contact them as the option in your account settings will not delete your geocaching logs.",
         "domains": [
             "geocaching.com",
             "groundspeak.com"
@@ -4268,7 +4268,7 @@
         "url": "https://help.netflix.com/en/node/407",
         "difficulty": "hard",
         "notes": "Cancel your membership, then contact support if you want immediate deletion. Otherwise your account will be conserved for 10 months.",
-        "notes_fr": "Annulez votre abonnement, puis contactez le support si vous souhaitez une suppression immédiate. Sinon, votre compte sera conservé pendant 10 mois."
+        "notes_fr": "Annulez votre abonnement, puis contactez le support si vous souhaitez une suppression immédiate. Sinon, votre compte sera conservé pendant 10 mois.",
         "notes_it": "Contatta il servizio clienti.",
         "notes_pt_br": "Contate a assistência ao cliente. Mesmo assim eles não deletarão sua conta sobre a premissa que talvez você queira retornar em manter seu histórico e recomendações.",
         "notes_cat": "Contacti amb el servei d'assistència al client. No s'eliminarà completament, sota la premisa de que potser voldràs reobrir el compte i mantindre l'historial i les notificacions.",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4266,7 +4266,7 @@
         "meta": "popular",
         "name": "Netflix",
         "url": "https://help.netflix.com/en/node/407",
-        "difficulty": "impossible",
+        "difficulty": "hard",
         "notes": "Cancel your membership, then contact support if you want immediate deletion. Otherwise your account will be conserved for 10 months.",
         "notes_fr": "Annulez votre abonnement, puis contactez le support si vous souhaitez une suppression immédiate. Sinon, votre compte sera conservé pendant 10 mois."
         "notes_it": "Contatta il servizio clienti.",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2462,8 +2462,8 @@
     {
         "name": "Geocaching",
         "url": "http://support.groundspeak.com/index.php?pg=kb.page&id=102",
-        "difficulty": "impossible",
-        "notes": "Each member ID on Geocaching.com is a historical record in their system and cannot be deleted. Therefore, your account can only be disabled, not be deleted.",
+        "difficulty": "hard",
+        "notes": "To permanently delete your account, you must contact them as the option in your account settings will not delete your geocaching logs."
         "domains": [
             "geocaching.com",
             "groundspeak.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4270,7 +4270,6 @@
         "notes": "Cancel your membership, then contact support if you want immediate deletion, otherwise your account will be automatically deleted in 10 months.",
         "notes_fr": "Annulez votre abonnement, puis contactez le support si vous souhaitez une suppression immédiate. Sinon, votre compte sera conservé pendant 10 mois.",
         "notes_it": "Contatta il servizio clienti.",
-        "notes_pt_br": "Contate a assistência ao cliente. Mesmo assim eles não deletarão sua conta sobre a premissa que talvez você queira retornar em manter seu histórico e recomendações.",
         "email": "privacy@netflix.com",
         "domains": [
             "netflix.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4269,7 +4269,6 @@
         "difficulty": "hard",
         "notes": "Cancel your membership, then contact support if you want immediate deletion, otherwise your account will be automatically deleted in 10 months.",
         "notes_fr": "Annulez votre abonnement, puis contactez le support si vous souhaitez une suppression immédiate. Sinon, votre compte sera conservé pendant 10 mois.",
-        "notes_it": "Contatta il servizio clienti.",
         "email": "privacy@netflix.com",
         "domains": [
             "netflix.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4274,7 +4274,7 @@
         "notes_cat": "Contacti amb el servei d'assistència al client. No s'eliminarà completament, sota la premisa de que potser voldràs reobrir el compte i mantindre l'historial i les notificacions.",
         "notes_es": "Contacta con el servicio de asistencia al cliente. No se eliminará completamente, bajo la suposición de que quizás querrás reabrir la cuenta y mantener el historial y las notificaciones.",
         "email": "privacy@netflix.com",
-		"domains": [
+        "domains": [
             "netflix.com"
         ]
     },

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4272,7 +4272,6 @@
         "notes_it": "Contatta il servizio clienti.",
         "notes_pt_br": "Contate a assistência ao cliente. Mesmo assim eles não deletarão sua conta sobre a premissa que talvez você queira retornar em manter seu histórico e recomendações.",
         "notes_cat": "Contacti amb el servei d'assistència al client. No s'eliminarà completament, sota la premisa de que potser voldràs reobrir el compte i mantindre l'historial i les notificacions.",
-        "notes_es": "Contacta con el servicio de asistencia al cliente. No se eliminará completamente, bajo la suposición de que quizás querrás reabrir la cuenta y mantener el historial y las notificaciones.",
         "email": "privacy@netflix.com",
         "domains": [
             "netflix.com"


### PR DESCRIPTION
Update the following sites to hard:

- Netflix: The support page indicates that accounts are now automatically deleted 10 months after membership cancellation or upon request to support.
- Geocaching: The support page seems to indicate that by contacting support, it is possible to request permanent account deletion.