### PR TITLE
Update Typeform

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7205,9 +7205,9 @@
 
     {
         "name": "Typeform",
-        "url": "https://www.typeform.com/help/submit-ticket/",
-        "notes": "To delete your account and data you need to contact Support.",
-        "difficulty": "hard",
+        "url": "https://help.typeform.com/hc/en-us/articles/360029631211-The-right-to-be-forgotten",
+        "notes": "Follow the steps in the link: Login, then click 'My Account', scroll to the 'Danger Zone', click 'Delete my account' and confirm.",
+        "difficulty": "easy",
         "domains": [
             "typeform.com"
         ]


### PR DESCRIPTION
Closes #379 

While searching for the "Submit ticket" valid URL, I actually found out that it is now easy to delete ([source](https://help.typeform.com/hc/en-us/articles/360029631211-The-right-to-be-forgotten))