### PR TITLE
Fix OpenDNS Deletion process

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5216,12 +5216,9 @@
 
     {
         "name": "OpenDNS",
-        "url": "http://www.opendns.com/support/contact/",
+        "url": "https://dashboard.opendns.com/myaccount/deleteaccount",
         "difficulty": "easy",
-        "notes": "Seems to have a button to delete account when heading to open the ticket.",
-        "notes_pt_br": "Parece ter um botão para deletar a conta ao ir abrir o ticket.",
-        "notes_es": "Parece que tiene un botón para eliminar la cuenta en el camino donde se abre el billete.",
-        "email": "contact@opendns.com",
+        "notes": "You can delete the account by visiting the delete account page.",
         "domains": [
             "opendns.com"
         ]


### PR DESCRIPTION
There is an account deletion page for OpenDNS. This commit includes the direct link there.