### PR TITLE
Catch EOFError in website ping script

### DIFF
--- a/script/ping_websites.rb
+++ b/script/ping_websites.rb
@@ -52,6 +52,7 @@ rescue  Errno::ECONNRESET,
         Errno::ETIMEDOUT,
         Net::OpenTimeout,
         Net::ReadTimeout,
+        EOFError,
         SocketError => e
     # All categories where a site is most definitely non-operational
     puts "HTTP request failed to #{name}: #{e.inspect}"


### PR DESCRIPTION
This will prevent CI failures like this one:
https://travis-ci.org/jdm-contrib/jdm/builds/627660808