### PR TITLE
Remove Stereomood

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -6884,15 +6884,6 @@
     },
 
     {
-        "name": "Stereomood",
-        "url": "http://www.stereomood.com/",
-        "difficulty": "easy",
-        "domains": [
-            "stereomood.com"
-        ]
-    },
-
-    {
         "name": "Storenvy",
         "url": "http://www.storenvy.com/account",
         "difficulty": "easy",


### PR DESCRIPTION
The [latest builds](https://travis-ci.org/jdm-contrib/jdm/builds/638907045?utm_source=github_status&utm_medium=notification) on Travis started erroring out on Stereomood. It turns out that it seems like they haven't been run by their owners since 2015 ([1](https://medium.com/@stereomoodteam/the-last-song-for-stereomood-s-founders-b9c2b2ac0cf0), [2](https://www.facebook.com/photo.php?fbid=10207162736486323&set=o.50644269128&type=3&theater), [3](https://twitter.com/stereomood?lang=en)). Maybe just the domain was still up.

In any case, I'm removing it.
