### PR TITLE
Update kit.com to kit.co

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3960,13 +3960,13 @@
     },
 
     {
-        "name": "Kit.com",
-        "url": "https://kit.com/terms#contact",
+        "name": "Kit.co",
+        "url": "https://kit.co/terms#contact",
         "difficulty": "hard",
         "notes": "If you need to contact us for any reason, you can do so by emailing us.",
-        "email": "support@kit.com",
+        "email": "support@kit.co",
         "domains": [
-            "kit.com/"
+            "kit.co"
         ]
     },
 


### PR DESCRIPTION
Kit.com [started failing](https://travis-ci.org/jdm-contrib/jdm/builds/644746011?utm_source=github_status&utm_medium=notification) and I found out it's because they [switched their domain to kit.co](https://domainnamewire.com/2019/11/25/kit-com-is-losing-its-domain-name-switching-to-kit-co/)