### PR TITLE
Make validate_json script stricter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ The sites, urls and additional notes are stored in `_data/sites.json`. If you wa
 
 - `name`: The name of the service.
 - `url`: The url of the account-deletion page. If no such page exists, the url should be a contact or help page explaining the process of account deletion.
-- `difficulty`: This is an indicator used on the site to determine the difficulty of account deletion:
+- `difficulty`: This is an indicator used on the site to determine the difficulty of account deletion. Use one of:
     - `easy`: Sites with a simple process such as a 'delete account' button
     - `medium`: Sites that do allow account deletion but require you to perform additional steps
     - `hard`: Sites that require you to contact customer services or those that don't allow automatic or easy account deletion
@@ -13,7 +13,7 @@ The sites, urls and additional notes are stored in `_data/sites.json`. If you wa
 - `email`: *(optional)* If you have to send an email to a company to cancel your account, add the email address here. We'll do the rest.
 - `email_subject`: *(optional)* Set the subject for the email link. If unset, the default text is "Account Deletion Request".
 - `email_body`: *(optional)* Set the body for the email link. If unset, the default text is "Please delete my account, my username is XXXXXX".
-- `domains`: *(optional)* This is used by the [Chrome extension](https://github.com/jdm-contrib/justdelete.me-chrome-extension)
+- `domains`: This is used by the [Chrome extension](https://github.com/jdm-contrib/justdelete.me-chrome-extension)
 
 ## Contribution checklist
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2128,7 +2128,10 @@
     {
         "name": "DynDNS",
         "url": "https://account.dyn.com/profile/close.html",
-        "difficulty": "easy"
+        "difficulty": "easy",
+        "domains": [
+            "dyn.com"
+        ]
     },
 
     {
@@ -2217,7 +2220,10 @@
         "name": "Edpuzzle",
         "url": "https://edpuzzle.com",
         "difficulty": "hard",
-        "notes": "click on the contrat popup on the bottom of the screen and fill out the form, an admin will email asking for your username and will then delete it"
+        "notes": "click on the contrat popup on the bottom of the screen and fill out the form, an admin will email asking for your username and will then delete it",
+        "domains": [
+            "edpuzzle.com"
+        ]
     },
 
     {
@@ -2427,7 +2433,10 @@
         "url": "https://www.experiandirect.com/triplealert/Message.aspx?PageTypeID=FAQ&WT.svl=faq&SiteVersionID=473&SiteID=100173&sc=657900&bcd=",
         "difficulty": "hard",
         "notes": "You have to call or email them. They respond to email quickly, however, so it is not that painful.",
-        "email": "support@experiandirect.com"
+        "email": "support@experiandirect.com",
+        "domains": [
+            "experiandirect.com"
+        ]
     },
 
     {
@@ -2453,7 +2462,10 @@
         "url": "https://www.messenger.com",
         "difficulty": "impossible",
         "notes": "If you logged in with your Facebook account, you can just delete that account. If you registered using your phone number, there's no way to delete your account",
-        "notes_es": "Si iniciaste sesión con tu cuenta de Facebook, podés borrar esa cuenta. Si te registraste con tu número de celular, no hay forma de eliminar tu cuenta"
+        "notes_es": "Si iniciaste sesión con tu cuenta de Facebook, podés borrar esa cuenta. Si te registraste con tu número de celular, no hay forma de eliminar tu cuenta",
+        "domains": [
+            "messenger.com"
+        ]
     },
 
     {
@@ -2657,7 +2669,10 @@
         "notes_pt_br": "Para deletar sua conta, você deve postar nada por pelo menos três dias.",
         "notes_pl": "Aby usunąć swoje konto, nie możesz dodawać żadnych treści przez co najmniej trzy dni.",
         "notes_cat": "Per esborrar el seu compte no ha de pujar res en 3 dies.",
-        "notes_es": "Para borrar tu cuenta no debes subir nada por lo menos 3 días."
+        "notes_es": "Para borrar tu cuenta no debes subir nada por lo menos 3 días.",
+        "domains": [
+            "fotka.pl"
+        ]
     },
 
     {
@@ -3790,7 +3805,10 @@
         "url": "https://issuu.com/home/settings/billing",
         "difficulty": "easy",
         "notes": "Closing your account will delete your profile and all of your publications. There is no going back, so don't say we didn't warn you.",
-        "notes_fa": "با بستن حساب کاربریتان تمامی مجلات و اطلاعات شما حذف می‌شود. این اطلاعات غیز قابل بازگشت خواهند بود."
+        "notes_fa": "با بستن حساب کاربریتان تمامی مجلات و اطلاعات شما حذف می‌شود. این اطلاعات غیز قابل بازگشت خواهند بود.",
+        "domains": [
+            "issuu.com"
+        ]
     },
 
     {
@@ -4267,7 +4285,10 @@
         "name": "Linsensuppe",
         "url": "https://www.linsensuppe.de",
         "difficulty": "impossible",
-        "notes": "One cannot even change the password"
+        "notes": "One cannot even change the password",
+        "domains": [
+            "linsensuppe.de"
+        ]
     },
 
     {
@@ -5490,7 +5511,10 @@
         "url": "https://developers.openshift.com/en/account-overview.html#_how_do_i_delete_my_account",
         "difficulty": "impossible",
         "notes": "You can't delete your account including all data, only a ‘soft delete’ is possible where you can always re-enable your account.",
-        "notes_de": "Es ist nicht möglich das Konto mit allen Daten zu löschen, es ist nur ein 'weiches Löschen' möglich, bei dem es immer die Möglichkeit des Wieder-Aktivierens gibt."
+        "notes_de": "Es ist nicht möglich das Konto mit allen Daten zu löschen, es ist nur ein 'weiches Löschen' möglich, bei dem es immer die Möglichkeit des Wieder-Aktivierens gibt.",
+        "domains": [
+            "openshift.com"
+        ]
     },
 
     {
@@ -5794,14 +5818,20 @@
         "difficulty": "hard",
         "email": "support@photobucket.com",
         "notes": "To delete your account you will have to send an email to support@photobucket.com. Photobucket support will require some information for verification purposes. These include your username, email address, full name, dob, the postal code and country from where you registered your account and a description of a couple of pictures in your account. After your reply the staff will delete your account in 48 hours. According to Photobucket your old pictures cannot be recovered from deleted accounts as they will be completely erased from their servers.",
-        "notes_it": "Per eliminare il tuo account dovrai mandare una mail a support@photobucket.com. La mail deve essere scritta in inglese. Lo staff richiederàil vostro nome utente, indirizzo email, il nome completo, data di nascita, codice postale e paese dal quale avete registrato il vostro account e una descrizione di alcune immagini caricate. L'account verrà cancellato nel giro di 48 ore. Una volta eliminate le immagini non possono essere recuperate in quanto verranno cancellate dai loro servers."
+        "notes_it": "Per eliminare il tuo account dovrai mandare una mail a support@photobucket.com. La mail deve essere scritta in inglese. Lo staff richiederàil vostro nome utente, indirizzo email, il nome completo, data di nascita, codice postale e paese dal quale avete registrato il vostro account e una descrizione di alcune immagini caricate. L'account verrà cancellato nel giro di 48 ore. Una volta eliminate le immagini non possono essere recuperate in quanto verranno cancellate dai loro servers.",
+        "domains": [
+            "photobucket.com"
+        ]
     },
 
     {
         "name": "PHP Classes",
         "url": "http://www.phpclasses.org/faq/#delete-account",
         "difficulty": "impossible",
-        "notes": "They refuse to delete accounts from the site."
+        "notes": "They refuse to delete accounts from the site.",
+        "domains": [
+            "phpclasses.org"
+        ]
     },
 
     {
@@ -5912,7 +5942,10 @@
         "difficulty": "hard",
         "notes": "Contact support via email and request your account to be deleted.",
         "notes_de": "Schreibe dem Support per E-Mail und bitte um eine Löschung des Accounts",
-        "email": "service@pixum.com"
+        "email": "service@pixum.com",
+        "domains": [
+            "pixum.com"
+        ]
     },
 
     {
@@ -6008,7 +6041,10 @@
         "url": "https://support.pocketcasts.com/",
         "difficulty": "hard",
         "notes": "You must request account deletion via email. If the web player was purchased, access to it will be lost as well.",
-        "email": "support@shiftyjelly.com"
+        "email": "support@shiftyjelly.com",
+        "domains": [
+            "pocketcasts.com"
+        ]
     },
 
     {
@@ -6798,7 +6834,10 @@
         "name": "SlimTimer",
         "url": "http://slimtimer.com/",
         "difficulty": "hard",
-        "notes": "Email request required."
+        "notes": "Email request required.",
+        "domains": [
+            "slimtimer.com"
+        ]
     },
 
     {

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -15,7 +15,7 @@ module ExitCodes
     UNEXPECTED_DIFFICULTY = 7  # Unexpected value for 'difficulty' field
 end
 
-SupportedDifficulties = ["easy","medium","hard","impossible"]
+SupportedDifficulties = ["easy", "medium", "hard", "impossible"]
 
 def get_transformed_name(site_object)
     return site_object['name'].downcase.sub(/^the\s+/, '')
@@ -39,7 +39,9 @@ def validate_website_entry(key, i)
     difficulty = key['difficulty']
     unless SupportedDifficulties.include?(difficulty)
         STDERR.puts "Entry '#{key['name']}' has unexpected 'difficulty' field:"\
-                    "'#{difficulty}'.\n\t Use one of #{SupportedDifficulties}"
+                    "'#{difficulty}'.\n"\
+                    "Use one of the supported difficulty values:\n"\
+                    "\t#{SupportedDifficulties}"
         exit ExitCodes::UNEXPECTED_DIFFICULTY
     end
 end

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 # Validates JSON files in the _data directory
-# See ExitCodes for actual return value
 
 require 'json'
 

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -8,6 +8,13 @@
 
 require 'json'
 
+module ErrorCodes
+    SUCCESS = 0
+    PARSE_FAILED = 1
+    UNSORTED = 2
+    MISSING_URL = 3
+end
+
 def get_transformed_name(site_object)
     return site_object['name'].downcase.sub(/^the\s+/, '')
 end
@@ -36,7 +43,7 @@ json_files.each do |file|
             if File.basename(file) =~ /sites.json/
                 name = get_transformed_name(key)
                 prev_name = get_transformed_name(json[i - 1])
-                error_on_missing_field(key, 'url', 3)
+                error_on_missing_field(key, 'url', ErrorCodes::MISSING_URL)
             else
                 name = key
                 prev_name = json.keys[i - 1]
@@ -45,14 +52,14 @@ json_files.each do |file|
                 STDERR.puts 'Sorting error in ' + file
                 STDERR.puts 'Keys must be in alphanumeric order. ' + \
                             prev_name + ' needs to come after ' + name
-                exit 2
+                exit ErrorCodes::UNSORTED
             end
         end
     rescue JSON::ParserError => error
         STDERR.puts 'JSON parsing error encountered!'
         STDERR.puts error.backtrace.join("\n")
-        exit 1
+        exit ErrorCodes::PARSE_FAILED
     end
 end
 
-exit 0
+exit ErrorCodes::SUCCESS

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -38,8 +38,6 @@ json_files.each do |file|
         json = JSON.parse(File.read(file))
         # check for alphabetical ordering
         json.each_with_index do |(key, _), i|
-            next if i.zero?
-
             # sites.json is an array of objects; this would expand to:
             #   key = { ... }
             #   i = 0
@@ -54,7 +52,7 @@ json_files.each do |file|
                 name = key
                 prev_name = json.keys[i - 1]
             end
-            if prev_name > name
+            if i > 0 && prev_name > name
                 STDERR.puts 'Sorting error in ' + file
                 STDERR.puts 'Keys must be in alphanumeric order. ' + \
                             prev_name + ' needs to come after ' + name

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -20,9 +20,9 @@ def get_transformed_name(site_object)
     return site_object['name'].downcase.sub(/^the\s+/, '')
 end
 
-def error_on_missing_field(name, key, field, exit_code)
+def error_on_missing_field(key, field, exit_code)
     unless key.key?(field)
-        STDERR.puts "Entry: #{name} has no #{field}"
+        STDERR.puts "Entry: #{key['name']} has no #{field}"
         exit exit_code
     end
 end
@@ -32,14 +32,13 @@ def validate_website_entry(key, i)
         STDERR.puts "Entry: #{i} has no name"
         exit ExitCodes::MISSING_NAME
     end
-    name = key['name']
-    error_on_missing_field(name, key, 'url', ExitCodes::MISSING_URL)
-    error_on_missing_field(name, key, 'difficulty', ExitCodes::MISSING_DIFFICULTY)
-    error_on_missing_field(name, key, 'domains', ExitCodes::MISSING_DOMAINS)
+    error_on_missing_field(key, 'url', ExitCodes::MISSING_URL)
+    error_on_missing_field(key, 'difficulty', ExitCodes::MISSING_DIFFICULTY)
+    error_on_missing_field(key, 'domains', ExitCodes::MISSING_DOMAINS)
     difficulty = key['difficulty']
     supported_difficulties = ["easy","medium","hard","impossible"]
     unless supported_difficulties.include?(difficulty)
-        STDERR.puts "Entry: #{name} has unexpected difficulty: #{difficulty}. Use one of #{supported_difficulties}"
+        STDERR.puts "Entry: #{key['name']} has unexpected difficulty: #{difficulty}. Use one of #{supported_difficulties}"
         exit ExitCodes::UNEXPECTED_DIFFICULTY
     end
 end

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -23,14 +23,14 @@ end
 
 def error_on_missing_field(key, field, exit_code)
     unless key.key?(field)
-        STDERR.puts "Entry: #{key['name']} has no #{field}"
+        STDERR.puts "Entry '#{key['name']}' has no '#{field}' field"
         exit exit_code
     end
 end
 
 def validate_website_entry(key, i)
     unless key.key?('name')
-        STDERR.puts "Entry: #{i} has no name"
+        STDERR.puts "Entry #{i} has no 'name' field"
         exit ExitCodes::MISSING_NAME
     end
     error_on_missing_field(key, 'url', ExitCodes::MISSING_URL)
@@ -38,7 +38,8 @@ def validate_website_entry(key, i)
     error_on_missing_field(key, 'domains', ExitCodes::MISSING_DOMAINS)
     difficulty = key['difficulty']
     unless SupportedDifficulties.include?(difficulty)
-        STDERR.puts "Entry: #{key['name']} has unexpected difficulty: #{difficulty}. Use one of #{SupportedDifficulties}"
+        STDERR.puts "Entry '#{key['name']}' has unexpected 'difficulty' field:"\
+                    "'#{difficulty}'.\n\t Use one of #{SupportedDifficulties}"
         exit ExitCodes::UNEXPECTED_DIFFICULTY
     end
 end

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -9,6 +9,7 @@
 # Exits 'MISSING_DIFFICULTY' if any sites.json entries are missing the required 'difficulty' key
 # Exits 'MISSING_DOMAINS' if any sites.json entries are missing the required 'domains' key
 # Exits 'MISSING_NAME' if any sites.json entries are missing the required 'name' key
+# Exits 'UNEXPECTED_DIFFICULTY' if field contains unexpected value on 'difficulty' key
 
 require 'json'
 
@@ -20,6 +21,7 @@ module ErrorCodes
     MISSING_DIFFICULTY = 4
     MISSING_DOMAINS = 5
     MISSING_NAME = 6
+    UNEXPECTED_DIFFICULTY = 7
 end
 
 def get_transformed_name(site_object)
@@ -42,6 +44,12 @@ def validate_website_entry(key, i)
     error_on_missing_field(name, key, 'url', ErrorCodes::MISSING_URL)
     error_on_missing_field(name, key, 'difficulty', ErrorCodes::MISSING_DIFFICULTY)
     error_on_missing_field(name, key, 'domains', ErrorCodes::MISSING_DOMAINS)
+    difficulty = key['difficulty']
+    supported_difficulties = ["easy","medium","hard","impossible"]
+    unless supported_difficulties.include?(difficulty)
+        STDERR.puts "Entry: #{name} has unexpected difficulty: #{difficulty}. Use one of #{supported_difficulties}"
+        exit ErrorCodes::UNEXPECTED_DIFFICULTY
+    end
 end
 
 json_files = Dir.glob('_data/**/*').select { |f| File.file?(f) }

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -12,6 +12,15 @@ def get_transformed_name(site_object)
     return site_object['name'].downcase.sub(/^the\s+/, '')
 end
 
+def error_on_missing_field(key, field, exit_code)
+    name = get_transformed_name(key)
+    unless key.key?(field)
+        # Forces all sites.json entries to have the provided key
+        STDERR.puts "Entry: #{name} has no #{field}"
+        exit exit_code
+    end
+end
+
 json_files = Dir.glob('_data/**/*').select { |f| File.file?(f) }
 json_files.each do |file|
     begin
@@ -25,13 +34,9 @@ json_files.each do |file|
             #   i = 0
             # hence, the key variable holds the actual value
             if File.basename(file) =~ /sites.json/
-                unless key.key?('url')
-                    # Forces all sites.json entries to have a URL key
-                    STDERR.puts "Entry: #{name} has no URL"
-                    exit 3
-                end
                 name = get_transformed_name(key)
                 prev_name = get_transformed_name(json[i - 1])
+                error_on_missing_field(key, 'url', 3)
             else
                 name = key
                 prev_name = json.keys[i - 1]

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -1,13 +1,14 @@
 #!/usr/bin/env ruby
 
 # Validates JSON files in the _data directory
-# Exits 0 on success
-# Exits 1 upon JSON parsing errors
-# Exits 2 if a file's keys are not in alphanumeric order
-# Exits 3 if any sites.json entries are missing the required 'url' key
-# Exits 4 if any sites.json entries are missing the required 'difficulty' key
-# Exits 5 if any sites.json entries are missing the required 'domains' key
-# Exits 6 if any sites.json entries are missing the required 'name' key
+# See ErrorCodes for actual return value
+# Exits 'SUCCESS' on success
+# Exits 'PARSE_FAILED' upon JSON parsing errors
+# Exits 'UNSORTED' if a file's keys are not in alphanumeric order
+# Exits 'MISSING_URL' if any sites.json entries are missing the required 'url' key
+# Exits 'MISSING_DIFFICULTY' if any sites.json entries are missing the required 'difficulty' key
+# Exits 'MISSING_DOMAINS' if any sites.json entries are missing the required 'domains' key
+# Exits 'MISSING_NAME' if any sites.json entries are missing the required 'name' key
 
 require 'json'
 
@@ -27,7 +28,6 @@ end
 
 def error_on_missing_field(name, key, field, exit_code)
     unless key.key?(field)
-        # Forces all sites.json entries to have the provided key
         STDERR.puts "Entry: #{name} has no #{field}"
         exit exit_code
     end
@@ -35,7 +35,6 @@ end
 
 def validate_website_entry(key, i)
     unless key.key?('name')
-        # Forces all sites.json entries to have a name
         STDERR.puts "Entry: #{i} has no name"
         exit ErrorCodes::MISSING_NAME
     end

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -15,6 +15,8 @@ module ExitCodes
     UNEXPECTED_DIFFICULTY = 7  # Unexpected value for 'difficulty' field
 end
 
+SupportedDifficulties = ["easy","medium","hard","impossible"]
+
 def get_transformed_name(site_object)
     return site_object['name'].downcase.sub(/^the\s+/, '')
 end
@@ -35,9 +37,8 @@ def validate_website_entry(key, i)
     error_on_missing_field(key, 'difficulty', ExitCodes::MISSING_DIFFICULTY)
     error_on_missing_field(key, 'domains', ExitCodes::MISSING_DOMAINS)
     difficulty = key['difficulty']
-    supported_difficulties = ["easy","medium","hard","impossible"]
-    unless supported_difficulties.include?(difficulty)
-        STDERR.puts "Entry: #{key['name']} has unexpected difficulty: #{difficulty}. Use one of #{supported_difficulties}"
+    unless SupportedDifficulties.include?(difficulty)
+        STDERR.puts "Entry: #{key['name']} has unexpected difficulty: #{difficulty}. Use one of #{SupportedDifficulties}"
         exit ExitCodes::UNEXPECTED_DIFFICULTY
     end
 end

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Validates JSON files in the _data directory
-# See ErrorCodes for actual return value
+# See ExitCodes for actual return value
 # Exits 'SUCCESS' on success
 # Exits 'PARSE_FAILED' upon JSON parsing errors
 # Exits 'UNSORTED' if a file's keys are not in alphanumeric order
@@ -13,7 +13,7 @@
 
 require 'json'
 
-module ErrorCodes
+module ExitCodes
     SUCCESS = 0
     PARSE_FAILED = 1
     UNSORTED = 2
@@ -38,17 +38,17 @@ end
 def validate_website_entry(key, i)
     unless key.key?('name')
         STDERR.puts "Entry: #{i} has no name"
-        exit ErrorCodes::MISSING_NAME
+        exit ExitCodes::MISSING_NAME
     end
     name = key['name']
-    error_on_missing_field(name, key, 'url', ErrorCodes::MISSING_URL)
-    error_on_missing_field(name, key, 'difficulty', ErrorCodes::MISSING_DIFFICULTY)
-    error_on_missing_field(name, key, 'domains', ErrorCodes::MISSING_DOMAINS)
+    error_on_missing_field(name, key, 'url', ExitCodes::MISSING_URL)
+    error_on_missing_field(name, key, 'difficulty', ExitCodes::MISSING_DIFFICULTY)
+    error_on_missing_field(name, key, 'domains', ExitCodes::MISSING_DOMAINS)
     difficulty = key['difficulty']
     supported_difficulties = ["easy","medium","hard","impossible"]
     unless supported_difficulties.include?(difficulty)
         STDERR.puts "Entry: #{name} has unexpected difficulty: #{difficulty}. Use one of #{supported_difficulties}"
-        exit ErrorCodes::UNEXPECTED_DIFFICULTY
+        exit ExitCodes::UNEXPECTED_DIFFICULTY
     end
 end
 
@@ -74,14 +74,14 @@ json_files.each do |file|
                 STDERR.puts 'Sorting error in ' + file
                 STDERR.puts 'Keys must be in alphanumeric order. ' + \
                             prev_name + ' needs to come after ' + name
-                exit ErrorCodes::UNSORTED
+                exit ExitCodes::UNSORTED
             end
         end
     rescue JSON::ParserError => error
         STDERR.puts 'JSON parsing error encountered!'
         STDERR.puts error.backtrace.join("\n")
-        exit ErrorCodes::PARSE_FAILED
+        exit ExitCodes::PARSE_FAILED
     end
 end
 
-exit ErrorCodes::SUCCESS
+exit ExitCodes::SUCCESS

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -5,6 +5,8 @@
 # Exits 1 upon JSON parsing errors
 # Exits 2 if a file's keys are not in alphanumeric order
 # Exits 3 if any sites.json entries are missing the required 'url' key
+# Exits 4 if any sites.json entries are missing the required 'difficulty' key
+# Exits 5 if any sites.json entries are missing the required 'domains' key
 
 require 'json'
 
@@ -13,6 +15,8 @@ module ErrorCodes
     PARSE_FAILED = 1
     UNSORTED = 2
     MISSING_URL = 3
+    MISSING_DIFFICULTY = 4
+    MISSING_DOMAINS = 5
 end
 
 def get_transformed_name(site_object)
@@ -44,6 +48,8 @@ json_files.each do |file|
                 name = get_transformed_name(key)
                 prev_name = get_transformed_name(json[i - 1])
                 error_on_missing_field(key, 'url', ErrorCodes::MISSING_URL)
+                error_on_missing_field(key, 'difficulty', ErrorCodes::MISSING_DIFFICULTY)
+                error_on_missing_field(key, 'domains', ErrorCodes::MISSING_DOMAINS)
             else
                 name = key
                 prev_name = json.keys[i - 1]

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -2,26 +2,18 @@
 
 # Validates JSON files in the _data directory
 # See ExitCodes for actual return value
-# Exits 'SUCCESS' on success
-# Exits 'PARSE_FAILED' upon JSON parsing errors
-# Exits 'UNSORTED' if a file's keys are not in alphanumeric order
-# Exits 'MISSING_URL' if any sites.json entries are missing the required 'url' key
-# Exits 'MISSING_DIFFICULTY' if any sites.json entries are missing the required 'difficulty' key
-# Exits 'MISSING_DOMAINS' if any sites.json entries are missing the required 'domains' key
-# Exits 'MISSING_NAME' if any sites.json entries are missing the required 'name' key
-# Exits 'UNEXPECTED_DIFFICULTY' if field contains unexpected value on 'difficulty' key
 
 require 'json'
 
 module ExitCodes
     SUCCESS = 0
-    PARSE_FAILED = 1
-    UNSORTED = 2
-    MISSING_URL = 3
-    MISSING_DIFFICULTY = 4
-    MISSING_DOMAINS = 5
-    MISSING_NAME = 6
-    UNEXPECTED_DIFFICULTY = 7
+    PARSE_FAILED = 1           # JSON parse errors
+    UNSORTED = 2               # data keys are not in alphanumeric order
+    MISSING_URL = 3            # Entry missing the required 'url' field
+    MISSING_DIFFICULTY = 4     # Entry missing the required 'difficulty' field
+    MISSING_DOMAINS = 5        # Entry missing the required 'domains' field
+    MISSING_NAME = 6           # Entry missing the required 'name' field
+    UNEXPECTED_DIFFICULTY = 7  # Unexpected value for 'difficulty' field
 end
 
 def get_transformed_name(site_object)


### PR DESCRIPTION
This PR introduces lots of changes to `validate_json.rb`:
- Enumerated `ErrorCodes` for each exit code it uses.
- Enforce that `difficulty` and `domains` are always filled.
- Enforce that `difficulty` is always one of `easy`, `medium`, `hard`, `impossible`

It also fixes:
- `validate_json.rb` not linting first entry
- Several entries not having any `domains` filled