### PR TITLE
Speed up Travis CI and improve error reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
+os: linux
+dist: bionic
 language: ruby
 rvm:
 - 2.6.5
-
-# Assume bundler is being used, therefore
-# the `install` step will run `bundle install` by default.
-script: ./script/cibuild
+cache: bundler
 
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
-sudo: false
+jobs:
+  include:
+    - stage: Run Tests
+      script: ./script/run_jekyll.sh
+      name: "Run jekyll"
+    - script: ./script/validate_json.rb
+      name: "Validate JSON"
+    - script: ./script/ping_websites.rb
+      name: "Ping websites"
+    - script: ./script/check_files_formatting.sh
+      name: "Check Files Formatting"

--- a/script/check_files_formatting.sh
+++ b/script/check_files_formatting.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e # halt script on error
+
+# Validate all files adhere to .editorconfig
+# Exclude files which should not be checked against .editorconfig
+# (eg. images, LICENSE, system-generated files, and library files)
+mapfile -t editorconfigargs < <(
+    find . \
+        -type 'f' \
+        ! -name '*.png' \
+        ! -name '*.ico' \
+        ! -name 'LICENSE' \
+        ! -name 'Gemfile.lock' \
+        ! -path './assets/*/libs/*' \
+        ! -path './.bundle/*' \
+        ! -path './.git/*' \
+        ! -path './_site/*' \
+        ! -path './vendor/*' \
+)
+npx @htmlacademy/editorconfig-cli "${editorconfigargs[@]}"

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,28 +1,12 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
-# Build site, validate HTML
-bundle exec jekyll build
-bundle exec htmlproofer ./_site --checks-to-ignore 'LinkCheck'
+# Run jekyll
+./script/run_jekyll.sh
 
 # Validate JSON
 ./script/validate_json.rb
 ./script/ping_websites.rb
 
-# Validate all files adhere to .editorconfig
-# Exclude files which should not be checked against .editorconfig
-# (eg. images, LICENSE, system-generated files, and library files)
-mapfile -t editorconfigargs < <(
-    find . \
-        -type 'f' \
-        ! -name '*.png' \
-        ! -name '*.ico' \
-        ! -name 'LICENSE' \
-        ! -name 'Gemfile.lock' \
-        ! -path './assets/*/libs/*' \
-        ! -path './.bundle/*' \
-        ! -path './.git/*' \
-        ! -path './_site/*' \
-        ! -path './vendor/*' \
-)
-npx @htmlacademy/editorconfig-cli "${editorconfigargs[@]}"
+# Check if files are properly formatted
+./script/check_files_formatting.sh

--- a/script/run_jekyll.sh
+++ b/script/run_jekyll.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e # halt script on error
+
+# Build site, validate HTML
+bundle exec jekyll build
+bundle exec htmlproofer ./_site --checks-to-ignore 'LinkCheck'


### PR DESCRIPTION
~This is a workflow that will eventually replace Travis, so that we get GH's native CI capabilities and thus have faster (maybe?) and cleaner or more accessible results.~

Turns out we can do a lot better on Travis than in GH actions flow, so instead I just opted to continue using it.
- We now use `bundler` cache, which completely eliminates our need to install everything from scratch.
- I've separated each step in the `cibuild` script into a different script which it calls. `cibuild` is still there for developers on offline use.
- The step above allows us to run all of the linting steps in parallel. Each step takes roughly 1min, this means that the job can finish in 1min (best case scenario) vs 4min in the past. It also makes it more clear to the authors of the PRs which of the steps is failing while also providing output on almost everything that needs to be fixed at once.

There are probably more things we can do, but I think this is a good step forward.