### PR TITLE
Remove entry for 'Klout'

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4104,22 +4104,6 @@
     },
 
     {
-        "name": "Klout",
-        "url": "http://klout.com/#/edit-settings/optout",
-        "difficulty": "medium",
-        "notes": "It can take up to 180 days for all your data to be removed from the system.",
-        "notes_fr": "La suppression totale de votre compte peut prendre 180 jours.",
-        "notes_it": "La cancellazione dei dati dal sistema può richiedere fino a 180 giorni.",
-        "notes_de": "Es kann bis zu 180 Tage dauern, bis all deine Daten aus dem System entfernt sind",
-        "notes_pt_br": "Pode levar até 180 dias para que todos os seus dados sejam removidos do sistema.",
-        "notes_cat": "Trigaran aproximadament 180 dies per eliminar les teves dades del sistema .",
-        "notes_es": "Tardarán aproximadamente 180 días para eliminar tus datos del sistema.",
-        "domains": [
-            "klout.com"
-        ]
-    },
-
-    {
         "name": "Koingo Software",
         "url": "https://www.koingosw.com/account/delete.php",
         "difficulty": "medium",


### PR DESCRIPTION
Failed to respond on job [#685031436][1]

[Wikipedia states][2] that it closed on May 25, 2018

[1]: https://travis-ci.org/github/jdm-contrib/jdm/jobs/685031436
[2]: https://en.wikipedia.org/wiki/Klout