### PR TITLE
Update the procedure to delete an /e/ account in ecloud.global

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2,11 +2,11 @@
     {
         "name": "/e/",
         "url": "https://doc.e.foundation/create-an-ecloud-account#how-can-i-delete-my-e-account-eemail",
-        "difficulty": "hard",
-        "notes": "Send an email from the /e/ID (&lt;yourmail&gt;@e.email) you want to delete. Optionally, you can describe the reason for the exclusion.",
-        "email": "contact@e.email",
+        "difficulty": "easy",
+        "notes": "Profile > settings > delete account > confirm",
         "domains": [
-            "e.foundation"
+            "e.foundation",
+            "ecloud.global"
         ]
     },
 


### PR DESCRIPTION
Hi, 

We recently implemented self-service account deletion for all ecloud.global users.

It can be seen with screenshots at the same URL we documented the previous procedure based on email.

This is the step previous to deletion (some style improvements needed 😛 ):
<img width="833" alt="Screenshot 2020-05-19 at 13 09 47" src="https://user-images.githubusercontent.com/1090103/82319519-0720e680-99d2-11ea-9537-0f4b1ef13532.png">

We no longer accept the email based flow. Besides, it was filling our community forum with random "Please delete my account, my username is XXXXXX" messages from users who don't even have an account there. I don't know if users willingly sent those messages or if there is some automated tool that is firing unsubscribe requests for all sites declared in JDM.

We are using an [open source plugin for Nextcloud](https://framagit.org/framasoft/nextcloud/drop_account), to which we're contributing.

