### PR TITLE
Remove Cheddar App

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1259,15 +1259,6 @@
     },
 
     {
-        "name": "Cheddar",
-        "url": "https://cheddarapp.com/account",
-        "difficulty": "easy",
-        "domains": [
-            "cheddarapp.com"
-        ]
-    },
-
-    {
         "name": "Chegg",
         "url": "https://www.chegg.com/contactus",
         "difficulty": "hard",


### PR DESCRIPTION
- [Their website](https://cheddarapp.com/account) doesn't load anymore
- The ping has been failing from [Travis #1421](https://travis-ci.org/github/jdm-contrib/jdm/jobs/688558269) to [Travis #1442](https://travis-ci.org/github/jdm-contrib/jdm/jobs/692861023)
- [Twitter](https://twitter.com/cheddarapp?lang=en) is inactive since July 3, 2019
- [Wayback Machine shows](https://web.archive.org/web/20180626035424/https://cheddarapp.com/changelog) latest change was on 2017