### PR TITLE
Remove Foodspotting

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2699,15 +2699,6 @@
     },
 
     {
-        "name": "Foodspotting",
-        "url": "http://www.foodspotting.com/settings",
-        "difficulty": "medium",
-        "notes": "Account can only be disabled, not deleted.",
-        "domains": [
-            "foodspotting.com"
-        ]
-    },
-    {
         "name": "Forvo",
         "url": "https://forvo.com/account-delete/",
         "difficulty": "easy",


### PR DESCRIPTION
According to their [Twitter](https://twitter.com/foodspotting?lang=en), it's been discontinued since May, 2018

![image](https://user-images.githubusercontent.com/6443427/83328197-a7d79780-a257-11ea-8b4a-7a24a384fafd.png)

Ping has started failing on [Travis #1441](https://travis-ci.org/github/jdm-contrib/jdm/jobs/692860984)