### PR TITLE
Fix #536: Add details on translation keys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,14 @@ The sites, urls and additional notes are stored in `_data/sites.json`. If you wa
 
 ## Translation
 
-If you want to translate the site:
+If you want to help on the translation of the site, you can read [translation reference](TRANSLATION_REFERENCE.md) to see what each of the keys is describing or translating.
+
+### Modify an existing Translation
+
+Look for the `CODE.json` file in the `_data/trans/` directory where `CODE` is your [short country code](https://en.wikipedia.org/wiki/Country_code)
+
+
+### Add a new translation
 
 1. Create a new `CODE.json` file in the `_data/trans/` directory where `CODE` is your [short country code](https://en.wikipedia.org/wiki/Country_code)
 2. Copy the contents of `en.json` to your new file

--- a/TRANSLATION_REFERENCE.md
+++ b/TRANSLATION_REFERENCE.md
@@ -1,0 +1,48 @@
+# Translation Reference
+
+This is a reference guide for translating, so that one can see where each key fits in the website.
+
+## Header
+
+- `title`: Website title and tagline
+- `name`: Language name
+- `tagline`: The slogan of the website
+- `about`: Button that skips to the end of the page until the credits
+- `extension`: Button that takes to the chrome extension
+- `fork`: Button to go to the GitHub repository
+- `twitter`: Button to tweet about JDM
+
+## Body
+
+- `popular`: Button to filter by popular websites
+- `difficulty`: Button to filter by a chosen difficulty
+- `reset`: Button to reset filtering
+- `noresults`: Description used when the filtering conditions lead to no results
+- `noresultshelp`: Description of hyperlink that takes to the JDM repository
+- `difficulty_easy`: Word for "easy" difficulty
+- `difficulty_medium`: Word for "medium" difficulty
+- `difficulty_hard`: Word for "hard" difficulty
+- `difficulty_impossible`: Word for "impossible" difficulty
+- `sendmail`: Text for hyperlink that opens up the new mail to be composed
+- `showinfo`: Text for button that shows notes of an entry
+- `hideinfo`: Text for button that hides notes of an entry
+- `noinfo`: Text shown when entry has no notes
+
+## Footer
+
+- `whatisthis`: Title of the section with the explanation about the website
+- `whatisthis[1-3]`: Phrase that describes the website, pieced together as "`whatisthis1` `whatisthis2` `whatisthis3`". `whatisthis2` is the "dark patterns" hyperlink text
+- `whatisthis4`: Second paragraph explaining the website
+- `forkproject`: Text for the hyperlink that takes to the JDM GitHub webpage
+- `guide`: Title for the section explaining how difficulties work
+- `guideexplanations`: Sentence introducing the guide
+- `guideeasy`: Short sentence explaining what "easy" means
+- `guidemedium`: Short sentence explaining what "medium" means
+- `guidehard`: Short sentence explaining what "hard" means
+- `guideimpossible`: Short sentence explaining what "impossible" means
+- `extension`: Title for the section explaining about the chrome extensions
+- `extensionguide`: Sentence introducing the extension section
+- `extensionp[1-2]` + `mikerogers`: First paragraph about the extension with credits to author. It's pieced together as "`extensionp1` `mikerogers` `extensionp2`"
+- `extensionp3`: Explains what the Chrome extension does
+- `extensionp[4-6]`: Last paragraph showing how to install the extension. It is written as "`extensionp4` + `extensionp5` + `extensionp6`" where `extensionp5` is the text for the hyperlink of the Chrome Web Store.
+- `footercredits`: Text to introduce creators


### PR DESCRIPTION
- Disambiguate when the translation already exists
- Add a document explaining how each of the translatable strings is used, to help translators find their way around without having to understand the HTML