### PR TITLE
Fall back to RVM 2.6.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os: linux
 dist: bionic
 language: ruby
 rvm:
-- 2.7.1
+- 2.6.6
 cache: bundler
 
 env:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ validated using a mixture of Ruby and Node.js packages and scripts.
 
 **Dependencies:**
 
-- [Ruby](https://www.ruby-lang.org) (>=2.7.1)
+- [Ruby](https://www.ruby-lang.org) (>=2.6.6)
 - [Node.js](https://nodejs.org)
 
 **Installation**


### PR DESCRIPTION
`nokogiri` still can't handle Ruby 2.7