### PR TITLE
Fix #554: initial character sorting skipps first letter

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -50,7 +50,7 @@ $(function(){
         var term = $(this).text().toLowerCase();
 
         hideFilteredSites(function() {
-            var text = $(this).find(".site-header").text().trim().toLowerCase().substr(1,1);
+            var text = $(this).find(".site-header").text().trim().toLowerCase().substr(0,1);
             return !~text.indexOf(term);
         });
     });


### PR DESCRIPTION
We were really getting the second letter and I don't know for how long this has been a bug hahaha