### PR TITLE
Remove Lumi

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4469,15 +4469,6 @@
     },
 
     {
-        "name": "Lumi",
-        "url": "https://lumi.do/account/privacy/delete/user",
-        "difficulty": "easy",
-        "domains": [
-            "lumi.do"
-        ]
-    },
-
-    {
         "name": "Lumosity",
         "url": "https://www.lumosity.com/app/v4/settings/account_deletion/new",
         "difficulty": "easy",


### PR DESCRIPTION
Started failing around Travis' job 1551: https://travis-ci.org/github/jdm-contrib/jdm/jobs/704749746

Twitter is inactive since 2015, wayback machine can't provide a rendering so I can see when it started to fail, but I'm removing it anyway