### PR TITLE
Update PassDock

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5968,8 +5968,8 @@
     },
 
     {
-        "name": "Passdock",
-        "url": "https://api.passdock.com/users/edit",
+        "name": "PassDock",
+        "url": "https://api.passdock.net/users/edit",
         "difficulty": "easy",
         "notes": "Select 'Delete account' at the bottom of your account info page.",
         "notes_de": "Klicke 'Account löschen' unten auf der Account-Info-Seite.",


### PR DESCRIPTION
Seems like it moved to the `.net` domain as the [last functioning archive][1] has the exact same appearance as the `.net` version

[1]: https://web.archive.org/web/20181229054638/http://passdock.com/