### PR TITLE
Remove Beam

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -742,17 +742,6 @@
     },
 
     {
-        "name": "Beam",
-        "url": "https://beam.pro/legal/privacy",
-        "difficulty": "hard",
-        "notes": "Remove all personal information from your account, then request deletion by emailing customer services.",
-        "email": "support@beam.pro",
-        "domains": [
-            "beam.pro"
-        ]
-    },
-
-    {
         "name": "Beamly",
         "url": "http://au.beamly.com/account/delete",
         "difficulty": "easy",


### PR DESCRIPTION
According to the [wayback machine](https://web.archive.org/web/20171201195748/https://beam.pro/), Beam has been redirecting to mixer for a while and [Mixer](https://mixer.com/) has shut down as of July 22nd: 
![image](https://user-images.githubusercontent.com/6443427/88460082-13ad3980-ce70-11ea-8b56-e9fd3258d4ca.png)

(Found out while investigating [this job](https://travis-ci.org/github/jdm-contrib/jdm/jobs/711707331))
