### PR TITLE
Remove Whistle.im

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -8532,19 +8532,6 @@
     },
 
     {
-        "name": "whistle.im",
-        "url": "http://whistle.im",
-        "difficulty": "easy",
-        "notes": "Menu →  Edit vCard →  Account management →  Delete everything (cannot be undone)",
-        "notes_it": "Menu →  Modifica vCard →  Gestione Account →  Elimina tutto (non può essere annullato)",
-        "notes_cat": "Menu →  Edit vCard →  Account management →  Delete everything (no es pot tornar endarrera)",
-        "notes_es": "Menu →  Edit vCard →  Account management →  Delete everything (no se puede deshacerlo)",
-        "domains": [
-            "whistle.im"
-        ]
-    },
-
-    {
         "name": "WhoSay.com",
         "url": "http://www.whosay.com/settings",
         "difficulty": "easy",


### PR DESCRIPTION
- The website is offline
- I can't seem to find any digital presence from them anymore
- The links to their social media on the internet archive don't work
- The app has vanished from Play store

All of this leads me to believe that it's gone, so I'm removing it.