### PR TITLE
Remove Desktoppr

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1847,15 +1847,6 @@
     },
 
     {
-        "name": "Desktoppr",
-        "url": "https://www.desktoppr.co/settings",
-        "difficulty": "easy",
-        "domains": [
-            "desktoppr.co"
-        ]
-    },
-
-    {
         "name": "DEV",
         "url": "https://dev.to/settings/account",
         "difficulty": "easy",


### PR DESCRIPTION
Their [latest tweet](https://twitter.com/desktopprapp?lang=en) is from 2015 and is selling the website. Don't know why it took so long to pop-up on the script, maybe someone bought and gave up