### PR TITLE
Update Wix

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -8967,9 +8967,9 @@
 
     {
         "name": "Wix",
-        "url": "https://support.wix.com/en/article/gdpr-permanently-deleting-your-wix-account",
-        "difficulty": "medium",
-        "notes": "Delete any built sites and subscriptions then follow the link to a deletion request form. Email is sent straight away with a link to confirm the deletion",
+        "url": "https://www.wix.com/close-account/index.html",
+        "difficulty": "easy",
+        "notes": "Delete any built sites and subscriptions then follow the link to a deletion request button.",
         "domains": [
             "wix.com"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -8969,7 +8969,7 @@
         "name": "Wix",
         "url": "https://www.wix.com/close-account/index.html",
         "difficulty": "easy",
-        "notes": "Delete any built sites and subscriptions then follow the link to a deletion request button.",
+        "notes": "Delete any built sites and subscriptions then follow the link to an account deletion button.",
         "domains": [
             "wix.com"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -8967,9 +8967,9 @@
 
     {
         "name": "Wix",
-        "url": "https://www.wix.com/close-account/index.html",
-        "difficulty": "easy",
-        "notes": "Delete any built sites and subscriptions then follow the link to an account deletion button.",
+        "url": "https://www.wix.com/account/support/permanent-delete",
+        "difficulty": "medium",
+        "notes": "Delete any built sites and subscriptions then follow the link to an account deletion form.",
         "domains": [
             "wix.com"
         ]


### PR DESCRIPTION
Old link was broken. Just used new link to delete, as per [their support article](https://support.wix.com/en/article/closing-your-wix-account?referral=MAD_account_settings_delete_account).