### PR TITLE
It's actually impossible to delete a change.org account

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1340,7 +1340,8 @@
     {
         "name": "Change.org",
         "url": "https://www.change.org/account_settings/disable_account",
-        "difficulty": "easy",
+        "difficulty": "impossible",
+        "notes": "There is only an option to disable your account. There is no way to request deletion.",
         "domains": [
             "change.org"
         ]


### PR DESCRIPTION
Unfortunately disabling your account does not delete it. Ever. Not even after a period of inactivity. If you ever show up on change.org again they will reactivate your account for you to use.