### PR TITLE
Remove SlimTimer

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7619,16 +7619,6 @@
     },
 
     {
-        "name": "SlimTimer",
-        "url": "http://slimtimer.com",
-        "difficulty": "hard",
-        "notes": "Email request required.",
-        "domains": [
-            "slimtimer.com"
-        ]
-    },
-
-    {
         "name": "SmartRecruiters",
         "url": "https://help.smartrecruiters.com/Getting_Started/User_settings/How_do_I_close_my_user_account%3F",
         "difficulty": "impossible",


### PR DESCRIPTION
Service has shut down on Jan 1, 2020
https://slimtimer.wordpress.com/2019/11/17/slimtimer-shutting-down-on-dec-15-2019/