### PR TITLE
/ Remove BBC iD

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -815,15 +815,6 @@
     },
 
     {
-        "name": "BBC iD",
-        "url": "https://ssl.bbc.co.uk/id/settings/delete",
-        "difficulty": "easy",
-        "domains": [
-            "bbc.co.uk"
-        ]
-    },
-
-    {
         "name": "Be Welcome",
         "url": "https://www.bewelcome.org/deleteprofile",
         "difficulty": "easy",


### PR DESCRIPTION
Seems like BBC iD is not working at all anymore, even the base link returns 404. This might have been merged into "BBC Account", but I can't confirm.

Wayback machine link points to something with a huge deprecation notice: https://web.archive.org/web/20200123100702/http://www.bbc.co.uk/frameworks/id/gettingstarted