### PR TITLE
Remove Smashcast

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -13,7 +13,7 @@
     {
         "name": "000Webhost",
         "url": "https://000webhost.com/members/profile",
-        "difficulty": "easy",
+        "difficulty": "easy",s
         "notes": "Go to \"Profile > Delete My Account\" and select why you are deleting your account.",
         "notes_pt_br": "Vá para \"Profile > Delete My Account\" e selecione um motivo pelo qual você está excluindo sua conta.",
         "domains": [
@@ -7864,16 +7864,6 @@
         "notes": "You can deactivate your user account, but you cannot delete it.",
         "domains": [
             "smartrecruiters.com"
-        ]
-    },
-
-    {
-        "name": "Smashcast",
-        "url": "https://www.smashcast.tv",
-        "difficulty": "easy",
-        "notes": "Access your user settings page, click the \"Delete Account...\" link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.",
-        "domains": [
-            "smashcast.tv"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -13,7 +13,7 @@
     {
         "name": "000Webhost",
         "url": "https://000webhost.com/members/profile",
-        "difficulty": "easy",s
+        "difficulty": "easy",
         "notes": "Go to \"Profile > Delete My Account\" and select why you are deleting your account.",
         "notes_pt_br": "Vá para \"Profile > Delete My Account\" e selecione um motivo pelo qual você está excluindo sua conta.",
         "domains": [


### PR DESCRIPTION
This is failing to respond on the ping script. According to [Wikipedia](https://en.wikipedia.org/wiki/Smashcast) it was shutdown on november 2020:

> According to the Wayback Machine, smashcast.tv last successfully loaded on November 16th, 2020, and failed to load on all attempts after November 28th, 2020.