### PR TITLE
Update HumbleBundle

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4136,9 +4136,9 @@
 
     {
         "name": "Humble Bundle",
-        "url": "https://www.humblebundle.com",
-        "difficulty": "impossible",
-        "notes": "You must <a href=\"https://support.humblebundle.com/hc/en-us/requests/new\">contact Humble Bundle via their online contact form</a> to request account deletion and provide three or more transaction IDs from previous orders. They only deactivate your account though and state you can get back at any time.",
+        "url": "https://dsar.humblebundle.com",
+        "difficulty": "medium",
+        "notes": "You must submit a Data Subject Request at their <a href=\"https://dsar.humblebundle.com/\">DSAR Privacy Portal</a> to request account deletion.",
         "domains": [
             "humblebundle.com"
         ]


### PR DESCRIPTION
Updated HumbleBundle info. You can delete the Humblebundle account using their DSAR Privacy Portal.