### PR TITLE
Add Keeper Security

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4915,6 +4915,18 @@
     },
 
     {
+        "name": "Keeper",
+        "url": "https://www.keepersecurity.com/privacypolicy.html?t=v#:~:text=You%20may%20deactivate%20your%20Keeper%20Security%20account%20and%20delete%20your%20personally%20identifiable%20information%20at%20any%20time%20by%20contacting%20us%20at%20support%40keepersecurity.com%20clearly%20indicating%20that%20you%20wish%20to%20deactivate%20and%20delete%20such%20information.",
+        "email": "support@keepersecurity.com",
+        "difficulty": "hard",
+        "notes": "You may deactivate your Keeper Security account and delete your personally identifiable information at any time by contacting their support at support@keepersecurity.com clearly indicating that you wish to delete your account.",
+        "domains": [
+            "keeper.io",
+            "keepersecurity.com"
+        ]
+    },
+
+    {
         "name": "Keybase.io",
         "url": "https://keybase.io/account/delete_me",
         "difficulty": "easy",


### PR DESCRIPTION
Since there are no anchors to the section about account deletion, I've used a feature available for chromium-based browsers. Visiting [the URL](https://www.keepersecurity.com/privacypolicy.html?t=v#:~:text=You%20may%20deactivate%20your%20Keeper%20Security%20account%20and%20delete%20your%20personally%20identifiable%20information%20at%20any%20time%20by%20contacting%20us%20at%20support%40keepersecurity.com%20clearly%20indicating%20that%20you%20wish%20to%20deactivate%20and%20delete%20such%20information.) will highlight the part about requesting account deletion. In other browsers, you'll simply just land on the top of the page, as normal.

![image](https://user-images.githubusercontent.com/2188806/106597489-c7e1f800-6556-11eb-92f7-df784ac84fd8.png)


