### PR TITLE
Remove Desk.com

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2221,18 +2221,6 @@
     },
 
     {
-        "name": "Desk.com",
-        "url": "https://desk.com",
-        "difficulty": "hard",
-        "email": "support@desk.com",
-        "notes": "Required to send e-mail, but it is quickly responded.",
-        "notes_tr": "E-posta göndermeniz gerekir, ancak hızlıca cevaplanıyorlar.",
-        "domains": [
-            "desk.com"
-        ]
-    },
-
-    {
         "name": "DEV",
         "url": "https://dev.to/settings/account",
         "difficulty": "easy",


### PR DESCRIPTION
Desk.com is now part of salesforce and doesn't have its own website

According to [this article](https://help-desk-migration.com/desk-com-soon-to-close-why-alternatives-and-how-to-migrate/) and its [twitter](https://twitter.com/desk) it has closed since march 2020.