### PR TITLE
Update kik URL to delete/deactivation page

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4990,7 +4990,7 @@
 
     {
         "name": "Kik",
-        "url": "https://help.kik.com/hc/en-us/articles/115006077428-Deactivate-your-account",
+        "url": "https://ws.kik.com/delete",
         "difficulty": "impossible",
         "notes": "You can only deactivate your account. There appears to be no way to permanently delete your account or data.",
         "notes_tr": "Yalnızca hesabınızı devre dışı bırakabilirsiniz. Hesabınızı veya verilerinizi kalıcı olarak silmenin bir yolu yok gibi görünüyor.",


### PR DESCRIPTION
The previous URL no longer works, and this one takes the user directly to the account deactivation page. As far as I can tell, the notes are still applicable.