### PR TITLE
Reddit: Add info for GDPR-enabled accounts.

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7947,8 +7947,19 @@
         "name": "Reddit",
         "url": "https://ssl.reddit.com/prefs/delete/",
         "difficulty": "hard",
-        "notes": "You cannot delete your Reddit account; you can only deactivate it. Content posted to Reddit (posts and comments) must be deleted individually. If you are an EU citizen, <a href=\"mailto:eurepresentative@reddit.com\">you may request deletion of your personal data via email</a>.",
+        "notes": "You cannot delete your Reddit account; you can only deactivate it. Content posted to Reddit (posts and comments) must be deleted individually beforehand. If you are an EU citizen, see the 'Reddit (GDPR) entry on JustDeleteMe.",
         "notes_tr": "Reddit hesabınızı silemezsiniz; sadece devre dışı bırakabilirsiniz. Reddit'e gönderilen içerik (gönderiler ve yorumlar) tek tek silinmelidir. AB vatandaşı iseniz, kişisel verilerinizin e-posta yoluyla silinmesini talep edebilirsiniz.",
+        "domains": [
+            "reddit.com"
+        ]
+    },
+
+    {
+        "meta": "popular",
+        "name": "Reddit (GDPR)",
+        "url": "https://www.reddit.com/message/compose?to=%2Fr%2Freddit.com&subject=GDPR / CCPA - u/[please enter your username here]&message=I am requesting deletion of my account and relate information under GDPR.",
+        "difficulty": "hard",
+        "notes": "Content posted to Reddit (posts and comments) must be deleted individually beforehand. As an EU citizen, do not use the normal deactivation process. Send a message with the provided link instead.",
         "domains": [
             "reddit.com"
         ]


### PR DESCRIPTION
After mailing eurepresentative@reddit.com, you get a generic response:
![image](https://user-images.githubusercontent.com/38327267/112157869-89280000-8bdf-11eb-95ea-e877d452ff98.png)

The link is generic, mailto:-like, what prefills some fields on sending a message to reddit, so why not give it to the user right away.

Since Reddit only claims to comply with actual GDPR-backed requests, I'd say it's better to make a separate entry for it.