### PR TITLE
GitHub link points to delete section

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3713,7 +3713,7 @@
 
     {
         "name": "GitHub",
-        "url": "https://github.com/settings/admin",
+        "url": "https://github.com/settings/admin#:~:text=Delete%20account",
         "difficulty": "easy",
         "notes": "Click on 'Delete account' near the bottom of the page and follow the instructions. Some user content will continue to exist anonymously on the website.",
         "notes_tr": "Sayfanın altındaki \"Hesabı Sil\" tuşuna tıklayın ve yönergeleri takip edin. Bazı kullanıcı içerikleri web sitesinde anonim olarak bulunmaya devam edecek.",


### PR DESCRIPTION
Using Text Fragments in URL can point the link directly to desired section on a page and highlights the text.
Example for the proposed change:
<img width="1034" alt="Screenshot 2021-04-14 at 12 53 48" src="https://user-images.githubusercontent.com/263021/114699627-d69c1680-9d20-11eb-9091-fd7d5d835192.png">


More info about Text Fragments: https://web.dev/text-fragments/