### PR TITLE
Add Glyph / Trion Worlds / Gamigo

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3951,6 +3951,17 @@
     },
 
     {
+        "name": "Glyph / Trion Worlds / Gamigo",
+        "url": "https://support.gamigo.com/hc/en-us/articles/204884188-How-do-I-delete-my-Glyph-account-",
+        "difficulty": "hard",
+        "notes": "Open a support ticket as detailed on the linked page. Alternatively, as specified in the gamigo US Inc. privacy policy, you can email dataprotection-us-inc@gamigo.com to request your data erasure pursuant to Art. 17 GDPR",
+        "domains": [
+            "trionworlds.com",
+            "gamigo.com"
+        ]
+    },
+
+    {
         "name": "Gmail",
         "url": "https://myaccount.google.com/deleteservices",
         "difficulty": "medium",


### PR DESCRIPTION
An interesting one, unclear if these are seperate accounts or one under
different names, but the support form provides a way to request deletion
of both.

Included the GDPR approach as it's significantly easier for those who can use it.