### PR TITLE
Add Target

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -9717,6 +9717,16 @@
     },
 
     {
+        "name": "Target",
+        "url": "https://contactus.target.com/",
+        "notes": "Target cannot delete your account, but they can disable it with the option to reenable later. The best you can do is to remove all personal information from the account, then contact Target to disable it. You may also wish to change the account's email to a temporary email address, and then forget this address when your Target account is disabled. Log in, scroll to the bottom, select 'Help' > 'Contact Us' > 'Target.com Order Experience'. This will allow you to chat, email, or call a customer service representative. Tell the rep you wish to disable your account.",
+        "difficulty": "impossible",
+        "domains": [
+            "target.com"
+        ]
+    },
+
+    {
         "name": "TargetProcess",
         "url": "https://www.targetprocess.com",
         "email": "support@targetprocess.com",


### PR DESCRIPTION
Added information on how to disable/sanitize a Target.com account. These account cannot be deleted, but they can be closed almost immediately after talking with a support rep.

I don't know that my note about using a temporary email address is strictly necessary. However, since a potential snooper with someone's Target account email address and full name can just call Target and reenable the account, later to obtain the password etc., someone might find this advice useful.