### PR TITLE
Add account deletion instructions for LeetCode

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5511,11 +5511,10 @@
     },
 
     {
-        "name": "Leetcode",
-        "url": "https://leetcode.com",
-        "difficulty": "impossible",
-        "notes": "You can't delete your account, though you can create a new session to reset your progress",
-        "notes_tr": "Hesabınızı silemezsiniz, ancak ilerlemenizi sıfırlamak için yeni bir oturum oluşturabilirsiniz",
+        "name": "LeetCode",
+        "url": "https://support.leetcode.com/hc/en-us/requests/new",
+        "difficulty": "hard",
+        "notes": "Go to the URL to submit an account deletion request. Include the USERNAME and EMAIL ADDRESS associated with your account. When you receive email confirmation, your account credentials will no longer work.",
         "domains": [
             "leetcode.com"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5514,7 +5514,7 @@
         "name": "LeetCode",
         "url": "https://support.leetcode.com/hc/en-us/requests/new",
         "difficulty": "hard",
-        "notes": "Go to the URL to submit an account deletion request. Include the USERNAME and EMAIL ADDRESS associated with your account. When you receive email confirmation, your account credentials will no longer work.",
+        "notes": "Log in to your LeetCode account, go to the URL to submit an account deletion request. Include in your request the USERNAME and EMAIL ADDRESS associated with your account. When you receive email confirmation, your account credentials will no longer work.",
         "domains": [
             "leetcode.com"
         ]


### PR DESCRIPTION
This took a while to find.

LeetCode's [Privacy Policy](https://leetcode.com/privacy/) is unhelpful, and their relevant [support article](https://support.leetcode.com/hc/en-us/articles/360014821014-How-can-I-delete-my-account-) does not specify how to "submit a request to [LeetCode's] support team." After some research, I found the link to their Support Request form in [a comment](https://leetcode.com/discuss/feedback/803485/How-to-permanently-delete-leetcode-account/665594) on [a LeetCode Discuss forum post](https://leetcode.com/discuss/feedback/803485/How-to-permanently-delete-leetcode-account). After that, following the instructions in the aforementioned support article actually worked!

I don't know how to translate these notes into Turkish, nor exactly what that URL looks like, but since the new notes are very different from the original I opted to remove the Turkish translation.