### PR TITLE
Vuforia Chalk

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10778,12 +10778,9 @@
 
     {
         "name": "Vuforia Chalk",
-        "url": "https://support.ptc.com/help/vuforia/chalk_app_center/#page/Vuforia_Chalk_Admin_Center%2Fcommon%2Fget_help.html%23",
+        "url": "https://www.ptc.com/en/contact-us",
         "difficulty": "hard",
-        "notes": "Business Account users must contact their company administrator. Peronal account users must send an email to Vuforia Support to request account deletion.",
-        "email": "vuforia-support@ptc.com",
-        "email_subject": "Account Deletion Request",
-        "email_body": "Hello, I have a Chalk account for personal use. I would like my information deleted and my account closed, please. My account email address is <EMAIL_ADDRESS>. Thank you.",
+        "notes": "Business Account users must contact their company administrator. Peronal account users must contact PTC to request account deletion. Go to the URL, enter your personal information as associated with your Chalk account, and request account deletion.",
         "domains": [
             "ptc.com",
             "vuforia.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10783,7 +10783,7 @@
         "notes": "Business Account users must contact their company administrator. Peronal account users must send an email to Vuforia Support to request account deletion.",
         "email": "vuforia-support@ptc.com",
         "email_subject": "Account Deletion Request",
-        "email_body": "Hello, I have a Chalk account for personal use. I would like my information deleted and my account closed, please. My account email address is <EMAIL_ADDRESS>.",
+        "email_body": "Hello, I have a Chalk account for personal use. I would like my information deleted and my account closed, please. My account email address is <EMAIL_ADDRESS>. Thank you.",
         "domains": [
             "ptc.com",
             "vuforia.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10780,7 +10780,7 @@
         "name": "Vuforia Chalk",
         "url": "https://support.ptc.com/help/vuforia/chalk_app_center/#page/Vuforia_Chalk_Admin_Center%2Fcommon%2Fget_help.html%23",
         "difficulty": "hard",
-        "notes": "Business Account users must contact their company administrator. Peronal account users must contact PTC to request account deletion. The email address provided at the URL does not exist. Call 1-877-275-4782, press 2 for Support Services, 9 for an operator, and ask them to delete your account. They should pass your information to the Vuforia team to delete your account.",
+        "notes": "Business Account users must contact their company administrator. Peronal account users must contact PTC by phone to request account deletion. (The email address provided at the URL does not exist.) Call 1-877-275-4782, press 2 for Support Services, 9 for an operator, and ask them to delete your account. They should pass your information to the Vuforia team to delete your account. After about two weeks, your login credentials should no longer work in the Chalk app.",
         "domains": [
             "ptc.com",
             "vuforia.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10777,6 +10777,20 @@
     },
 
     {
+        "name": "Vuforia Chalk",
+        "url": "https://support.ptc.com/help/vuforia/chalk_app_center/#page/Vuforia_Chalk_Admin_Center%2Fcommon%2Fget_help.html%23",
+        "difficulty": "hard",
+        "notes": "Business Account users must contact their company administrator. Peronal account users must send an email to Vuforia Support to request account deletion.",
+        "email": "vuforia-support@ptc.com",
+        "email_subject": "Account Deletion Request",
+        "email_body": "Hello, I have a Chalk account for personal use. I would like my information deleted and my account closed, please. My account email address is <EMAIL_ADDRESS>.",
+        "domains": [
+            "ptc.com",
+            "vuforia.com"
+        ]
+    },
+
+    {
         "name": "Walmart",
         "url": "https://help.walmart.com/app/answers/detail/a_id/230/~/how-to-close-your-walmart.com-account",
         "difficulty": "hard",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10778,9 +10778,9 @@
 
     {
         "name": "Vuforia Chalk",
-        "url": "https://www.ptc.com/en/contact-us",
+        "url": "https://support.ptc.com/help/vuforia/chalk_app_center/#page/Vuforia_Chalk_Admin_Center%2Fcommon%2Fget_help.html%23",
         "difficulty": "hard",
-        "notes": "Business Account users must contact their company administrator. Peronal account users must contact PTC to request account deletion. Go to the URL, enter your personal information as associated with your Chalk account, and request account deletion.",
+        "notes": "Business Account users must contact their company administrator. Peronal account users must contact PTC to request account deletion. The email address provided at the URL does not exist. Call 1-877-275-4782, press 2 for Support Services, 9 for an operator, and ask them to delete your account. They should pass your information to the Vuforia team to delete your account.",
         "domains": [
             "ptc.com",
             "vuforia.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10780,7 +10780,7 @@
         "name": "Vuforia Chalk",
         "url": "https://support.ptc.com/help/vuforia/chalk_app_center/#page/Vuforia_Chalk_Admin_Center%2Fcommon%2Fget_help.html%23",
         "difficulty": "hard",
-        "notes": "Business Account users must contact their company administrator. Peronal account users must contact PTC by phone to request account deletion. (The email address provided at the URL does not exist.) Call 1-877-275-4782, press 2 for Support Services, 9 for an operator, and ask them to delete your account. They should pass your information to the Vuforia team to delete your account. After about two weeks, your login credentials should no longer work in the Chalk app.",
+        "notes": "Business Account users must contact their company administrator. Peronal Account users must contact PTC by phone to request account deletion. (The email address provided at the URL does not accept mail.) Call 1-877-275-4782, press 2 for Support Services, 9 for an operator, and ask them to delete your account. They should pass your information to the Vuforia team to delete your account. After about two weeks, your login credentials should no longer work in the Chalk app.",
         "domains": [
             "ptc.com",
             "vuforia.com"


### PR DESCRIPTION
This one's a journey.

PTC appears to own Chalk, since the in-app links redirect there. [PTC's Privacy Policy](https://www.ptc.com/en/documents/policies/privacy) states that personal information may be deleted upon request. (The same policy [points users to Vuforia Chalk's privacy policy](https://www.ptc.com/en/documents/policies/privacy#2), but the provided URL redirects to PTC's own policy.) [The relevant Help article](https://support.ptc.com/help/vuforia/chalk_app_center/#page/Vuforia_Chalk_Admin_Center%2Fcommon%2Fget_help.html%23) offers an email address to contact Vuforia support: vuforia-support@ptc.com. That address bounces mail back, and apparently does not exist anymore.

EDIT: PTC provides a [means of contacting a sales representative](https://www.ptc.com/en/contact-us), which proved less than useful. The rep linked me to [a list of support phone numbers](https://www.ptc.com/en/support/csguide/Contact/Americas). One of those numbers, after a few menu options, showed some promise.

EDIT: A couple of attempts at that number lead to someone who would pass my information on to "the Vuforia team" to delete my account. There is a chance that the "Vuforia team," if it exists, will not follow through with PTC's privacy policy. If so, I'll mark this entry as "impossible."

EDIT: It worked! After over a week of waiting, I found this morning that my credentials were invalidated!