### PR TITLE
Add Hotspot Shield

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1002,7 +1002,7 @@
         "notes_tr": "İsteklerin tamamlanması 30 günü bulabilir ve devlet tarafından verilmiş resimli bir kimlik gönderilmesi gerekebilir.",
         "notes_de": "Anfragen können bis zu 30 Tage dauern und es kann erforderlich sein, zur Nutzerverifikation ein staatlich anerkanntes Ausweisdokument einzureichen.",
         "notes_fr": "Le traitement de votre demande peut nécessiter jusqu'à 30 jours pour être achevée. Il pourra vous être demandé une pièce d'identité officielle avec une photo d'identité.",
-        "notes_it": "Potrebbero volerci 30 giorni per elaborare la richiesta. Ti potrebbe essere richiesto di allegare anche un documento di identità rilasciato dal governo e provvisto di fotografia.",h
+        "notes_it": "Potrebbero volerci 30 giorni per elaborare la richiesta. Ti potrebbe essere richiesto di allegare anche un documento di identità rilasciato dal governo e provvisto di fotografia.",
         "notes_es": "La petición pueden tardar hasta 30 días en completarse. Se te podrá requerir una imagen de un documento de identidad emitido por el gobierno.",
         "domains": [
             "eu.battle.net",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4808,8 +4808,9 @@
 
     {
         "name": "Hotspot Shield",
-        "url": "?",
-        "difficulty": "impossible",
+        "url": "",
+        "difficulty": "hard",
+        "notes": "If you're a paid user, you can contact support. If you're a free user, it's only possible if you have regulations that require deletion."
         "domains": [
             "hotspotshield.com",
             "support.hotspotshield.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4808,7 +4808,7 @@
 
     {
         "name": "Hotspot Shield",
-        "url": "",
+        "url": "hotspotshield.com",
         "difficulty": "hard",
         "notes": "If you're a paid user, you can contact support. If you're a free user, it's only possible if you have regulations that require deletion.",
         "domains": [

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1002,7 +1002,7 @@
         "notes_tr": "İsteklerin tamamlanması 30 günü bulabilir ve devlet tarafından verilmiş resimli bir kimlik gönderilmesi gerekebilir.",
         "notes_de": "Anfragen können bis zu 30 Tage dauern und es kann erforderlich sein, zur Nutzerverifikation ein staatlich anerkanntes Ausweisdokument einzureichen.",
         "notes_fr": "Le traitement de votre demande peut nécessiter jusqu'à 30 jours pour être achevée. Il pourra vous être demandé une pièce d'identité officielle avec une photo d'identité.",
-        "notes_it": "Potrebbero volerci 30 giorni per elaborare la richiesta. Ti potrebbe essere richiesto di allegare anche un documento di identità rilasciato dal governo e provvisto di fotografia.",
+        "notes_it": "Potrebbero volerci 30 giorni per elaborare la richiesta. Ti potrebbe essere richiesto di allegare anche un documento di identità rilasciato dal governo e provvisto di fotografia.",h
         "notes_es": "La petición pueden tardar hasta 30 días en completarse. Se te podrá requerir una imagen de un documento de identidad emitido por el gobierno.",
         "domains": [
             "eu.battle.net",
@@ -4810,7 +4810,7 @@
         "name": "Hotspot Shield",
         "url": "",
         "difficulty": "hard",
-        "notes": "If you're a paid user, you can contact support. If you're a free user, it's only possible if you have regulations that require deletion."
+        "notes": "If you're a paid user, you can contact support. If you're a free user, it's only possible if you have regulations that require deletion.",
         "domains": [
             "hotspotshield.com",
             "support.hotspotshield.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4808,7 +4808,7 @@
 
     {
         "name": "Hotspot Shield",
-        "url": "hotspotshield.com",
+        "url": "https://www.hotspotshield.com",
         "difficulty": "hard",
         "notes": "If you're a paid user, you can contact support. If you're a free user, it's only possible if you have regulations that require deletion.",
         "domains": [

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4807,6 +4807,16 @@
     },
 
     {
+        "name": "Hotspot Shield",
+        "url": "?",
+        "difficulty": "impossible",
+        "domains": [
+            "hotspotshield.com",
+            "support.hotspotshield.com"
+        ]
+    },
+
+    {
         "name": "Houzz",
         "url": "https://help.houzz.com/s/article/How-do-I-delete-my-account",
         "difficulty": "hard",


### PR DESCRIPTION
Don't know what to put in `url` because there's nothing in the FAQ saying about account deletion but I'm 99.999% sure you can't delete it.

On the [account page](https://support.hotspotshield.com/hc/en-us/articles/204600084-What-can-I-see-from-my-Hotspot-Shield-account-page-) there's no delete account page)

I tried contacting support but that requires payment (you need to buy a subscription to get support, FAQ is for free users only)

![image](https://user-images.githubusercontent.com/66189242/127732915-3648853f-0019-4863-82ce-b59854618d89.png)


I tried searching things on the FAQ such as [`delete`](https://support.hotspotshield.com/hc/en-us/search?commit=Search&page=1&query=delete&utf8=%E2%9C%93#results) then `deletion` and got this: [What is a Premium Family plan-and how does it work](https://support.hotspotshield.com/hc/en-us/articles/360045835311-What-is-a-Premium-Family-plan-and-how-does-it-work-)

ooo, something about deleting my account!

![image](https://user-images.githubusercontent.com/66189242/127732969-2b4d753f-6845-4388-b9c6-e1fe62fabfe8.png)

I click the link but I get this (anyways this is for family subscriptions I guess):

![image](https://user-images.githubusercontent.com/66189242/127732880-7e98c1f5-6796-4b0d-accc-2cb619998aff.png)

Then I went to their [Privacy Policy](https://www.aura.com/legal/privacy-policy?utm_source=hss_privacy)

Apparently the service is owned by Aura and then I search `delete` which is only about something about age:

>  If we discover that we have collected personal data from a minor without appropriate consents, we may delete such data without notice. For  certain countries, parental consent may be required for processing  the  personal data of children under the age of 16.

I guess only way to delete your *free* account is using your GDPR or CCPA laws, and for paid users they can contact support I guess
