### PR TITLE
Add Office Depot

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7242,7 +7242,7 @@
         "name": "OfficeDepot",
         "url": "https://www.officedepot.com/ccpa/landing.do",
         "difficulty": "hard",
-        "notes": "Note that while their privacy policy states that California residents may have their information deleted permanently, it does not specify whether they delete other accounts also. Go to the URL and fill out the form with the information pertaining to your account. Open the 'Delete My Information' section and check the box next to 'Delete my consumer data'. Submit the form and wait for their confirmation email to arrive.",
+        "notes": "Note that while their privacy policy states that California residents may have their information deleted permanently, it does not specify whether they delete other accounts also. Go to the URL and fill out the form with the information pertaining to your account. Open the 'Delete My Information' section and check the box next to 'Delete my consumer data'. Submit the form and wait for an email to arrive. Click the link in the email. If after 24 hours your account is not deleted, you might have to reach out to their customer support and present their Privacy Policy to have them act.",
         "domains": [
             "officedepot.com"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7242,7 +7242,7 @@
         "name": "OfficeDepot",
         "url": "https://www.officedepot.com/ccpa/landing.do",
         "difficulty": "hard",
-        "notes": "Note that their privacy policy states that only California residents may have their information deleted permanently. They may actually delete all accounts that request it. Go to the URL and fill out the form with the information pertaining to your account. Open the 'Delete My Information' section and check the box next to 'Delete my consumer data'. Submit the form and wait for their confirmation email to arrive.",
+        "notes": "Note that while their privacy policy states that California residents may have their information deleted permanently, it does not specify whether they delete other accounts also. Go to the URL and fill out the form with the information pertaining to your account. Open the 'Delete My Information' section and check the box next to 'Delete my consumer data'. Submit the form and wait for their confirmation email to arrive.",
         "domains": [
             "officedepot.com"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7239,6 +7239,16 @@
     },
 
     {
+        "name": "OfficeDepot",
+        "url": "https://www.officedepot.com/ccpa/landing.do",
+        "difficulty": "hard",
+        "notes": "Note that their privacy policy states that only California residents may have their information deleted permanently. They may actually delete all accounts that request it. Go to the URL and fill out the form with the information pertaining to your account. Open the 'Delete My Information' section and check the box next to 'Delete my consumer data'. Submit the form and wait for their confirmation email to arrive.",
+        "domains": [
+            "officedepot.com"
+        ]
+    },
+
+    {
         "name": "OkCupid",
         "url": "https://www.okcupid.com/settings",
         "difficulty": "easy",


### PR DESCRIPTION
I'm unsure what to do here. Their [Privacy Policy](https://www.officedepot.com/cm/help/privacy-statement) lays out a process for deleting one's own account, but after trying that process twice, my account remained fully intact.

A support representative claimed at first that there is no account deletion process. When I quoted the Privacy Policy on the matter and requested clarification, they said that they could indeed delete the account information and close the account, but the user's name and account number would remain. They kindly closed my account then, at my request, and my login credentials _finally_ no longer work.

@tupaschoal Given that Office Depot's account deletion procedure, as laid out in their Privacy Policy, does not function but might in the future, should I describe that process in the notes for this entry, or describe the process that actually enacted the closure of my account? EDIT: Another option might be to describe both procedures, but that could be rather lengthy, considering that I literally needed to quote specific statements from the Privacy Policy to enact deletion.