### PR TITLE
Implement alternative CI on GitHub Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,47 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  jekyll:
+    name: Run Jekyll Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.2
+        bundler-cache: true
+    - run: script/run_jekyll.sh
+  validate-json:
+    name: Validate JSON
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.2
+        bundler-cache: true
+    - run: script/validate_json.rb
+  ping-websites:
+    name: Ping Websites
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.2
+        bundler-cache: true
+    - run: script/ping_websites.rb
+  check-files-formatting:
+    name: Check Files Formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.2
+        bundler-cache: true
+    - run: script/check_files_formatting.sh


### PR DESCRIPTION
I had tried changing the workflow to the GH Actions before, on #467. At the time, it was not able to match the performance of Travis, and thus I just worked on ironing out the Travis CI setup and improving it.

A lot has changed since then: 
- GH actions have matured and evolved tremendously
- Travis-CI became paid after you run out of their credits and 

We need to switch to GH actions to maintain our ability to always run the checks for free. Other than that, it has also become significantly faster than Travis, which is a great win, as shown on the table below.

Step|Travis|GH Workflow|
------------|---------- |--------
Run Jekyll Tests|47s|14s
Validate JSON|37s|11s
Ping Websites|173s|141s
Check Files Formatting|39s|11s

All things considered, I'm enabling GH Actions immediately and will phase out Travis CI soonish.