### PR TITLE
Update all Gawker Media websites links to internet archive

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2440,7 +2440,7 @@
 
     {
         "name": "Deadspin (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",
@@ -3908,7 +3908,7 @@
 
     {
         "name": "Gawker (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",
@@ -4080,7 +4080,7 @@
 
     {
         "name": "Gizmodo (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",
@@ -5216,7 +5216,7 @@
 
     {
         "name": "IO9 (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",
@@ -5311,7 +5311,7 @@
 
     {
         "name": "Jalopnik (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",
@@ -5338,7 +5338,7 @@
 
     {
         "name": "Jezebel (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",
@@ -5534,7 +5534,7 @@
 
     {
         "name": "Kinja (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",
@@ -5606,7 +5606,7 @@
 
     {
         "name": "Kotaku (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",
@@ -5777,7 +5777,7 @@
 
     {
         "name": "Lifehacker (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",
@@ -10842,7 +10842,7 @@
 
     {
         "name": "Valleywag (Gawker Media)",
-        "url": "https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
+        "url": "https://web.archive.org/web/20210310103730/https://kinja.zendesk.com/hc/en-us/articles/360004518113-Can-I-delete-my-Kinja-account-",
         "difficulty": "impossible",
         "notes": "You may discontinue your use of the Service at any time without informing us. We may, however, retain and continue to use any Content that you have submitted or uploaded through the Service.",
         "notes_tr": "Servisi bize haber vermeden kullanmayı istediğiniz zaman bırakabilirsiniz. Fakat, Hizmet aracılığıyla gönderdiğiniz veya yüklediğiniz herhangi bir İçeriği saklayabilir ve kullanmaya devam edebiliriz.",


### PR DESCRIPTION
Original Zendesk page has been shutdown, but seems like it still isn't possible to delete account, so linking to the archive.

https://opposite-lock.com/topic/627/so-is-there-a-way-to-delete-my-kinja-account/11