### PR TITLE
Remove PlexGuide

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -8211,17 +8211,6 @@
     },
 
     {
-        "name": "PlexGuide",
-        "url": "https://plexguide.com/account/thui-deactivate/",
-        "difficulty": "impossible",
-        "notes": "Account can only be disabled, with option of contacting support to re-enable account afterwards.",
-        "notes_tr": "Hesap, yalnızca daha sonra hesabı yeniden etkinleştirmek için destekle iletişime geçme imkanı ile devre dışı bırakılabilir.",
-        "domains": [
-            "plexguide.com"
-        ]
-    },
-
-    {
         "name": "Pluralsight",
         "url": "https://help.pluralsight.com/help/how-do-i-delete-my-account",
         "difficulty": "easy",


### PR DESCRIPTION
Site was shut down according to what seems to be the founder: 
https://forum.sudobox.io/t/plexguide-pgblitz-plex-one-redirect/96