### PR TITLE
Remove CryptFolio

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2311,15 +2311,6 @@
     },
 
     {
-        "name": "CryptFolio",
-        "url": "https://cryptfolio.com/user#user_delete",
-        "difficulty": "easy",
-        "domains": [
-            "cryptfolio.com"
-        ]
-    },
-
-    {
         "name": "Crypton.sh",
         "url": "https://crypton.sh/app/account",
         "difficulty": "easy",


### PR DESCRIPTION
Twitter inactive since 2019: https://twitter.com/cryptfolio
Facebook inactive since 2018: https://www.facebook.com/cryptfolio
Wayback machine stopped crawling it in Feb 2021: https://web.archive.org/web/20210115000000*/https://cryptfolio.com/