### PR TITLE
Add default notes for when a deletion procedure is clear

### DIFF
--- a/TRANSLATION_REFERENCE.md
+++ b/TRANSLATION_REFERENCE.md
@@ -28,6 +28,8 @@ This is a reference guide for translating, so that one can see where each key fi
 - `showinfo`: Text for button that shows notes of an entry
 - `hideinfo`: Text for button that hides notes of an entry
 - `noinfo`: Text shown when entry has no notes
+- `defaultnote_easy`: Text shown when entry has no notes and deletion is accomplished by going to the linked URL
+- `defaultnote_email`: Text shown when entry has no notes and deletion is accomplished by emailing a company representative
 
 ## Footer
 

--- a/_data/trans/ar.json
+++ b/_data/trans/ar.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "الصعوبة",
     "difficulty_easy": "سهل",
     "difficulty_hard": "صعب",

--- a/_data/trans/cat.json
+++ b/_data/trans/cat.json
@@ -1,6 +1,8 @@
 {
     "about": "Quant a",
     "contribute": "Contribuir a GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "dificultat",
     "difficulty_easy": "senzilla",
     "difficulty_hard": "difícil",

--- a/_data/trans/cz.json
+++ b/_data/trans/cz.json
@@ -1,6 +1,8 @@
 {
     "about": "O projektu",
     "contribute": "Zapojte se na GitHubu",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "obtížnost",
     "difficulty_easy": "jednoduché",
     "difficulty_hard": "těžké",

--- a/_data/trans/de.json
+++ b/_data/trans/de.json
@@ -1,6 +1,8 @@
 {
     "about": "Über",
     "contribute": "Auf GitHub beitragen",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "Schwierigkeit",
     "difficulty_easy": "leicht",
     "difficulty_hard": "schwer",

--- a/_data/trans/en.json
+++ b/_data/trans/en.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Contribute on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "difficulty",
     "difficulty_easy": "easy",
     "difficulty_hard": "hard",

--- a/_data/trans/es.json
+++ b/_data/trans/es.json
@@ -1,6 +1,8 @@
 {
     "about": "Acerca de",
     "contribute": "Contribuya en Github",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "dificultad",
     "difficulty_easy": "fácil",
     "difficulty_hard": "difícil",

--- a/_data/trans/fa.json
+++ b/_data/trans/fa.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "دشواری",
     "difficulty_easy": "آسان",
     "difficulty_hard": "سخت",

--- a/_data/trans/fr.json
+++ b/_data/trans/fr.json
@@ -1,6 +1,8 @@
 {
     "about": "À propos de",
     "contribute": "Forkez le projet sur GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "difficulté",
     "difficulty_easy": "facile",
     "difficulty_hard": "difficile",

--- a/_data/trans/gr.json
+++ b/_data/trans/gr.json
@@ -1,6 +1,8 @@
 {
     "about": "Σχετικά",
     "contribute": "Συμμετοχή στο GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "δυσκολία",
     "difficulty_easy": "εύκολο",
     "difficulty_hard": "δύσκολο",

--- a/_data/trans/id.json
+++ b/_data/trans/id.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "kesulitan",
     "difficulty_easy": "mudah",
     "difficulty_hard": "sulit",

--- a/_data/trans/it.json
+++ b/_data/trans/it.json
@@ -1,6 +1,8 @@
 {
     "about": "Info",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "difficoltà",
     "difficulty_easy": "facile",
     "difficulty_hard": "difficile",

--- a/_data/trans/kr.json
+++ b/_data/trans/kr.json
@@ -1,6 +1,8 @@
 {
     "about": "정보",
     "contribute": "GitHub에서 기여하기",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "난이도",
     "difficulty_easy": "쉬움",
     "difficulty_hard": "어려움",

--- a/_data/trans/nl.json
+++ b/_data/trans/nl.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "moeilijkheidsgraad",
     "difficulty_easy": "gemakkelijk",
     "difficulty_hard": "moeilijk",

--- a/_data/trans/pl.json
+++ b/_data/trans/pl.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "trudność",
     "difficulty_easy": "łatwe",
     "difficulty_hard": "trudne",

--- a/_data/trans/pt_br.json
+++ b/_data/trans/pt_br.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Contribua no GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "dificuldade",
     "difficulty_easy": "fácil",
     "difficulty_hard": "difícil",

--- a/_data/trans/pt_br.json
+++ b/_data/trans/pt_br.json
@@ -1,8 +1,8 @@
 {
     "about": "About",
     "contribute": "Contribua no GitHub",
-    "defaultnote_easy": "Visit the linked page and delete your account.",
-    "defaultnote_email": "Send an email to the provided address and request account deletion.",
+    "defaultnote_easy": "Visite a página do link e delete a sua conta.",
+    "defaultnote_email": "Envie um e-mail para o endereço fornecido e solicite a que a conta seja deletada.",
     "difficulty": "dificuldade",
     "difficulty_easy": "fácil",
     "difficulty_hard": "difícil",

--- a/_data/trans/ro.json
+++ b/_data/trans/ro.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "dificultate",
     "difficulty_easy": "ușor",
     "difficulty_hard": "greu",

--- a/_data/trans/ru.json
+++ b/_data/trans/ru.json
@@ -1,6 +1,8 @@
 {
     "about": "Авторы",
     "contribute": "Форкнуть на GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "Сложность",
     "difficulty_easy": "легко",
     "difficulty_hard": "трудно",

--- a/_data/trans/sk.json
+++ b/_data/trans/sk.json
@@ -1,6 +1,8 @@
 {
     "about": "O projekte",
     "contribute": "Zapoj sa na GitHub-e",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "náročnosť",
     "difficulty_easy": "ľahké",
     "difficulty_hard": "ťažké",

--- a/_data/trans/sr.json
+++ b/_data/trans/sr.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "тешкоћа",
     "difficulty_easy": "лако",
     "difficulty_hard": "тешко",

--- a/_data/trans/th.json
+++ b/_data/trans/th.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "ความยาก",
     "difficulty_easy": "ง่าย",
     "difficulty_hard": "ยาก",

--- a/_data/trans/tr.json
+++ b/_data/trans/tr.json
@@ -1,6 +1,8 @@
 {
     "about": "Hakkında",
     "contribute": "GitHub'da Katkıda Bulunun",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "zorluk",
     "difficulty_easy": "kolay",
     "difficulty_hard": "zor",

--- a/_data/trans/vi.json
+++ b/_data/trans/vi.json
@@ -1,6 +1,8 @@
 {
     "about": "Giới thiệu",
     "contribute": "Đóng góp trên GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "mức độ",
     "difficulty_easy": "dễ",
     "difficulty_hard": "khó",

--- a/_data/trans/zh-cn.json
+++ b/_data/trans/zh-cn.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "难度分级",
     "difficulty_easy": "简单",
     "difficulty_hard": "困难",

--- a/_data/trans/zh-tw.json
+++ b/_data/trans/zh-tw.json
@@ -1,6 +1,8 @@
 {
     "about": "About",
     "contribute": "Fork on GitHub",
+    "defaultnote_easy": "Visit the linked page and delete your account.",
+    "defaultnote_email": "Send an email to the provided address and request account deletion.",
     "difficulty": "難度",
     "difficulty_easy": "簡單",
     "difficulty_hard": "困難",

--- a/_includes/body.html
+++ b/_includes/body.html
@@ -37,12 +37,16 @@
                 </p>
 
                 {% capture lang_notes %}notes_{{ page.lang }}{% endcapture %}
-                {% if entry.notes or entry[lang_notes] or entry.email %}
+                {% if entry.notes or entry[lang_notes] or entry.email or entry.difficulty == 'easy' %}
                     <div class="tooltip-content">
                         {% if entry[lang_notes] %}
                             {{ entry[lang_notes] }}
                         {% elsif entry.notes %}
                             {{ entry.notes }}
+                        {% elsif entry.email %}
+                            {{ site.data.trans[page.lang].defaultnote_email }}
+                        {% elsif entry.difficulty == 'easy' %}
+                            {{ site.data.trans[page.lang].defaultnote_easy }}
                         {% endif %}
                         {% if entry.email %}
                             {% if entry.notes or entry[lang_notes] %}

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -22,7 +22,7 @@ end
 
 SupportedDifficulties = ["easy", "medium", "hard", "impossible"]
 SupportedEntryKeys = ["difficulty", "domains", "email", "email_body", "email_subject", "meta", "name", "notes", "url"]
-SupportedLanguageKeys = ["about", "contribute", "difficulty", "difficulty_easy", "difficulty_hard", "difficulty_impossible",
+SupportedLanguageKeys = ["about", "contribute", "defaultnote_easy", "defaultnote_email", "difficulty", "difficulty_easy", "difficulty_hard", "difficulty_impossible",
                         "difficulty_medium", "extension", "extensionguide", "extensionp1", "extensionp2",
                         "extensionp3", "extensionp4", "extensionp5", "extensionp6", "footercredits",
                         "guide", "guideeasy", "guideexplanations", "guidehard", "guideimpossible",

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -22,13 +22,13 @@ end
 
 SupportedDifficulties = ["easy", "medium", "hard", "impossible"]
 SupportedEntryKeys = ["difficulty", "domains", "email", "email_body", "email_subject", "meta", "name", "notes", "url"]
-SupportedLanguageKeys = ["about", "contribute", "defaultnote_easy", "defaultnote_email", "difficulty", "difficulty_easy", "difficulty_hard", "difficulty_impossible",
-                        "difficulty_medium", "extension", "extensionguide", "extensionp1", "extensionp2",
-                        "extensionp3", "extensionp4", "extensionp5", "extensionp6", "footercredits",
-                        "guide", "guideeasy", "guideexplanations", "guidehard", "guideimpossible",
+SupportedLanguageKeys = ["about", "contribute", "defaultnote_easy", "defaultnote_email", "difficulty", "difficulty_easy",
+                        "difficulty_hard", "difficulty_impossible", "difficulty_medium", "extension", "extensionguide",
+                        "extensionp1", "extensionp2", "extensionp3", "extensionp4", "extensionp5", "extensionp6",
+                        "footercredits", "guide", "guideeasy", "guideexplanations", "guidehard", "guideimpossible",
                         "guidemedium", "hideinfo", "jgmd", "mikerogers", "name", "noinfo", "noresults", "noresultshelp",
-                        "popular", "pullrequest", "reset", "search", "sendmail", "showinfo", "tagline", "title", "twitter",
-                        "whatisthis", "whatisthis1", "whatisthis2", "whatisthis3", "whatisthis4"]
+                        "popular", "pullrequest", "reset", "search", "sendmail", "showinfo", "tagline", "title",
+                        "twitter", "whatisthis", "whatisthis1", "whatisthis2", "whatisthis3", "whatisthis4"]
 
 def get_supported_languages()
     return translation_files = Dir.children('_data/trans/').map { |f| f.delete_suffix('.json') }


### PR DESCRIPTION
* When no note is provided and an email address is provided, display a default note.
* When no note is provided and the difficulty is "easy", display a (different) default note.

I'm not sure if the "url" field is required. If it is, I suspect that the vast majority of "easy" entries provide a direct URL to the account/information deletion place.

Closes #653 