### PR TITLE
Adding Firefox support to OpenSearch

### DIFF
--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,4 +1,5 @@
-<OpenSearchDescription>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+    xmlns:moz="http://www.mozilla.org/2006/browser/search/">
     <ShortName>JustDeleteMe</ShortName>
     <Description>
         A directory of direct links to delete your account from web services.
@@ -8,4 +9,5 @@
         https://justdeleteme.xyz/assets/icons/apple-touch-icon-72x72-precomposed.png
     </Image>
     <Url type="text/html" method="get" template="https://justdeleteme.xyz/#{searchTerms}"/>
+    <moz:SearchForm>https://justdeleteme.xyz</moz:SearchForm>
 </OpenSearchDescription>


### PR DESCRIPTION
Unlike Chromium, Firefox wasn't able to recognize the plugin but now it is. Maby there are more browsers requires the `xmlns` but I have only Firefox and Ungooled-Chromoium in my PC.

In addition i added the search page link.