### PR TITLE
Update Nexus Mods

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7390,9 +7390,8 @@
 
     {
         "name": "Nexus Mods",
-        "url": "https://help.nexusmods.com/article/25-how-do-i-delete-my-account",
+        "url": "https://users.nexusmods.com/account/security",
         "difficulty": "easy",
-        "notes": "Accounts can be deleted by following the instructions on the link",
         "domains": [
             "nexusmods.com"
         ]


### PR DESCRIPTION
This can be simplified further by linking directly to the page containing the button to delete the account, rather than the help article. Once clicked, it only asks to confirm your password. I've removed the custom note as the default note is fine here.