### PR TITLE
Add CVS Pharmacy, remove The Artist Union

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -720,18 +720,6 @@
     },
 
     {
-        "name": "The Artist Union",
-        "url": "https://theartistunion.com/dashboard/account",
-        "difficulty": "easy",
-        "notes": "Login to your account first. Click 'Delete Account' and confirm by clicking 'Ok'.",
-        "notes_ru": "Сначала войдите в свою учетную запись. Нажмите «Удалить учетную запись» и подтвердите, нажав «ОК».",
-        "notes_tr": "Önce hesabınıza giriş yapın. \"Hesabı Sil\" \"Tamam\" tuşuna tıklayarak onaylayın.",
-        "domains": [
-            "theartistunion.com"
-        ]
-    },
-
-    {
         "name": "Artsy",
         "url": "https://www.artsy.net/user/delete",
         "difficulty": "easy",
@@ -2484,7 +2472,7 @@
         "name": "CVS Pharmacy",
         "url": "https://www.cvs.com/account/account-management.jsp",
         "difficulty": "medium",
-        "notes": "They allow account deletions under the CCPA, but only for California residents. However, the way they check your location is simply a ZIP code of your choosing. You can imput any California ZIP (ex. 94102) and they will allow you to delete your account. Visit the linked page, and select 'CA residents: request or delete personal information.' Enter any California ZIP code, then click 'Delete my info and account', and finally 'Yes, delete my info and account'.",
+        "notes": "They allow account deletions under the CCPA, but only for California residents. However, the way they check your location is simply a ZIP code of your choosing. You can input any California ZIP (ex. 94102) and they will allow you to delete your account. Visit the linked page, and select 'CA residents: request or delete personal information.' Enter any California ZIP code, then click 'Delete my info and account', and finally 'Yes, delete my info and account'.",
         "domains": [
             "cvs.com"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2481,6 +2481,16 @@
     },
 
     {
+        "name": "CVS Pharmacy",
+        "url": "https://www.cvs.com/account/account-management.jsp",
+        "difficulty": "medium",
+        "notes": "They allow account deletions under the CCPA, but only for California residents. However, the way they check your location is simply a ZIP code of your choosing. You can imput any California ZIP (ex. 94102) and they will allow you to delete your account. Visit the linked page, and select 'CA residents: request or delete personal information.' Enter any California ZIP code, then click 'Delete my info and account', and finally 'Yes, delete my info and account'.",
+        "domains": [
+            "cvs.com"
+        ]
+    },
+
+    {
         "name": "Cybrary",
         "url": "https://app.cybrary.it/settings/account",
         "difficulty": "easy",


### PR DESCRIPTION
I thought of setting the difficulty to impossible considering CVS Pharmacy doesn't provide a legitimate way for non-California residents to delete their account, but since it is currently possible for anyone to just input a California ZIP code in the account deletion form,  I set it to medium difficulty.

The Artist Union shut down on August 1st, 2020 and it is no longer possible to log into accounts to delete them, so I've removed it's listing.