### PR TITLE
Fix language dropdown position drifting on page scroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _site/
 .sass-cache/
 .jekyll-metadata
+.jekyll-cache/
 .bundle/
 vendor/

--- a/_includes/body.html
+++ b/_includes/body.html
@@ -109,7 +109,7 @@
 </div>
 
 <!-- Language dropdown -->
-<div id="language-dropdown" class="dropdown dropdown-tip">
+<div id="language-dropdown" class="language-dropdown dropdown dropdown-tip dropdown-relative">
     <ul class="dropdown-menu">
         {% assign sorted_files = (site.data.trans | sort:0) %}
         {% for lang in sorted_files %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,8 +13,8 @@
     <link rel="apple-touch-icon-precomposed" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-144x144-precomposed.png">
 
     <link rel="shortcut icon" href="{{ site.baseurl }}/assets/icons/favicon.ico">
-    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/style.css" />
     <link type="text/css" rel="stylesheet" href="{{ site.baseurl }}/assets/css/libs/jquery.dropdown.css" />
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/style.css" />
     <link type="application/opensearchdescription+xml" rel="search" href="{{ site.baseurl }}/opensearch.xml" title="JustDeleteMe">
 
     <script src="{{ site.baseurl }}/assets/js/libs/jquery.js"></script>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -38,6 +38,16 @@ nav {
     padding: 12px 10px 8px 12px;
 }
 
+.language-dropdown {
+    height: 100%;
+    position: fixed;
+}
+
+.language-dropdown > .dropdown-menu {
+    max-height: calc(95% - 52px);
+    overflow-y: auto;
+}
+
 nav a {
     color: black;
     font-weight: normal;


### PR DESCRIPTION
By adding `position: fixed;` to the language dropdown and instructing the plugin to use absolute position coordinates, we can place it at the same location it would otherwise have been placed at before.

To account for the possibility that a user has a screen small enough that they cannot view the full list of items, I've added scrolling overflow to this dropdown.

Fixes #987 