### PR TITLE
Update Duolingo entry to medium

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3321,8 +3321,9 @@
 
     {
         "name": "Duolingo",
-        "url": "https://www.duolingo.com/settings/deactivate",
-        "difficulty": "easy",
+        "url": "https://drive-thru.duolingo.com/",
+        "difficulty": "medium",
+        "notes": "Scroll down and click \"ERASE PERSONAL DATA\". You will receive an e-mail in which you have to click the link after \"Delete my data link:\". This confirms the erasure of your personal data and account.",
         "domains": [
             "duolingo.com"
         ]


### PR DESCRIPTION
The duolingo entry linked to a page to disable your account, however, there is an option to permanently delete your account & personal data on duolingo. I linked this url instead, updated the difficulty since you have to go through an additional step, and added a new note accordingly.