### PR TITLE
Added Humble Bundle alternative

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5447,6 +5447,16 @@
             "humblebundle.com"
         ]
     },
+    
+    {
+        "name": "Humble Bundle",
+        "url": "https://support.humblebundle.com/hc/en-us/requests/new",
+        "difficulty": "hard",
+        "notes": "You will need to submit a request to support for account deletion. In the linked page under \"What can we help you with?\" select \"Humbe Bundle Account\" > \"Delete Account\", fill in your email, enter \"Account deletion\" as subject, add your honest reason for account deletion in the message, and submit. Someone from support should contact you and ask for some proof that you own the account. Once you have provided proof then your account should be deleted.",
+        "domains": [
+            "humblebundle.com"
+        ]
+    },
 
     {
         "name": "Ibotta",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5447,7 +5447,7 @@
             "humblebundle.com"
         ]
     },
-    
+
     {
         "name": "Humble Bundle",
         "url": "https://support.humblebundle.com/hc/en-us/requests/new",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5441,18 +5441,7 @@
         "name": "Humble Bundle",
         "url": "https://dsar.humblebundle.com",
         "difficulty": "medium",
-        "notes": "You must submit a Data Subject Request at their <a href=\"https://dsar.humblebundle.com/\">DSAR Privacy Portal</a> to request account deletion.",
-        "notes_tr": "You must submit a Data Subject Request at their DSAR Privacy Portal to request account deletion.",
-        "domains": [
-            "humblebundle.com"
-        ]
-    },
-
-    {
-        "name": "Humble Bundle",
-        "url": "https://support.humblebundle.com/hc/en-us/requests/new",
-        "difficulty": "hard",
-        "notes": "You will need to submit a request to support for account deletion. In the linked page under \"What can we help you with?\" select \"Humbe Bundle Account\" > \"Delete Account\", fill in your email, enter \"Account deletion\" as subject, add your honest reason for account deletion in the message, and submit. Someone from support should contact you and ask for some proof that you own the account. Once you have provided proof then your account should be deleted.",
+        "notes": "The easiest method is to submit a Data Subject Access Request at their <a href=\"https://dsar.humblebundle.com/\">DSAR Privacy Portal</a> to request account deletion. Alternatively, you can also <a href=\"https://support.humblebundle.com/hc/en-us/requests/new\">submit a support request</a> for account deletion. In the linked page under \"What can we help you with?\" select \"Humble Bundle Account\" > \"Delete Account\", fill in your email, enter \"Account deletion\" as subject, add your honest reason for account deletion in the message, and submit. Someone from support should contact you and guide you further.",
         "domains": [
             "humblebundle.com"
         ]


### PR DESCRIPTION
Added an additional method for deleting a Humble Bundle account. The existing DSAR method is the easier and more recommended approach, however this additional method is an alternative in case the DSAR approach is not possible.