### PR TITLE
Add wordpress.org as impossible

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12788,6 +12788,17 @@
     },
 
     {
+        "meta": "popular",
+        "name": "WordPress.org",
+        "url": "https://wordpress.org/about/privacy/data-erasure-request",
+        "difficulty": "impossible",
+        "notes": "You can't delete your \"wordpress.org\" account but you can anonymize your data <a href='https://wordpress.org/support/forum-user-guide/faq/#can-you-delete-my-account'>https://wordpress.org/support/forum-user-guide/faq/#can-you-delete-my-account</a>",
+        "domains": [
+            "wordpress.org"
+        ]
+    },
+
+    {
         "name": "workupload",
         "url": "https://workupload.com/contact",
         "difficulty": "hard",


### PR DESCRIPTION

Yes I know that "wordpress,com" is already there in sites.json but notice that "wordpress.org" is not.

https://wordpress.org/support/forum-user-guide/faq/#can-you-delete-my-account
