### PR TITLE
Renamed "Portuguese" to "Brazilian Portuguese"

### DIFF
--- a/_data/trans/pt_br.json
+++ b/_data/trans/pt_br.json
@@ -26,7 +26,7 @@
     "hideinfo": "esconder informações...",
     "jgmd": "Visite o Just Get My Data",
     "mikerogers": "Mike Rogers",
-    "name": "Português",
+    "name": "Português Brasileiro",
     "noinfo": "Nenhuma Informação Disponível",
     "noresults": "Não encontrou o que procurava?",
     "noresultshelp": "Ajude a tornar o JustDeleteMe melhor",


### PR DESCRIPTION
The ISO 693-1 code pt_BR used in this website corresponds to Brazilian Portuguese specifically, not just Portuguese in general. And, indeed, by observing the language used throughout the website, the variant of Portuguese used corresponds to, indeed, Brazilian Portuguese.

Thus, it would make more sense to name the language in the menu accordingly, mostly for 2 reasons:
1. In loads of software, when the language states just "Portuguese", it is actually referring to European Portuguese (pt_PT), this should eliminate that redundancy.
2. It opens the door for the support of European Portuguese (pt_PT) in the website.