### PR TITLE
Prevent stretching of language switch icon

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -40,6 +40,10 @@ nav {
     cursor: pointer;
 }
 
+.language-switch .icon {
+    align-self: center;
+}
+
 .language-dropdown {
     height: 100%;
     position: fixed;


### PR DESCRIPTION
The icon was previously being stretched to fit its flexbox parent. This PR changes its styling to center without stretching instead. The clickable area is not changed, so it is still very easy to click on as before.

| Before | After |
|:---:|:---:|
| ![Screenshot 2022-05-13 at 03-42-47 JustDeleteMe](https://user-images.githubusercontent.com/2199511/168207587-872d50c2-ae53-4ec1-ac9b-c9989cc0b967.png) | ![Screenshot 2022-05-13 at 03-42-54 JustDeleteMe](https://user-images.githubusercontent.com/2199511/168207589-b6ecf8c7-546d-4086-b453-54402a59856c.png) |