### PR TITLE
chore: removed club penguin rewritten

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2210,17 +2210,6 @@
     },
 
     {
-        "name": "Club Penguin Rewritten",
-        "url": "https://cprewritten.net/help/",
-        "email": "privacy@cprewritten.net",
-        "difficulty": "impossible",
-        "notes": "There is no option on the website to delete, you can try emailing their privacy or support email but they never reply to either after months.",
-        "domains": [
-            "cprewritten.net"
-        ]
-    },
-
-    {
         "name": "CNET Download",
         "url": "https://cbsi.secure.force.com/CBSi/submitcase?template=template_cnet&referer=cnet.com&cfs=SFS_1",
         "difficulty": "hard",


### PR DESCRIPTION
[Club penguin ](https://techcrunch.com/2022/04/13/club-penguin-rewritten-shut-down-disney/?guccounter=1&guce_referrer=aHR0cHM6Ly93d3cuZ29vZ2xlLmNvbS8&guce_referrer_sig=AQAAACUD14MBejZeMwSHZTdphnYfhgcr4y5DExSWT37twE9R2jsjfrvFx7vmH9QWzyYKtwHede8ZkZQ-rHmnS9zfR0-ha1JZb-OL7DebupcsMA49crGVNqZ3KZYNWSSxV50_IJrNTO63PnwynCQk-0jBBwI2uQXPn28jOqoKNutneMYx) has been shut down. Removed entry, please feel free to reject this PR if this is not the correct process :)