### PR TITLE
Update Reddit

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -9985,23 +9985,9 @@
     {
         "meta": "popular",
         "name": "Reddit",
-        "url": "https://ssl.reddit.com/prefs/delete/",
-        "difficulty": "hard",
-        "notes": "You cannot delete your Reddit account; you can only deactivate it. Content posted to Reddit (posts and comments) must be deleted individually beforehand. If you are an EU citizen, see the 'Reddit (GDPR) entry on JustDeleteMe.",
-        "notes_tr": "Reddit hesabınızı silemezsiniz; sadece devre dışı bırakabilirsiniz. Reddit'e gönderilen içerik (gönderiler ve yorumlar) tek tek silinmelidir. AB vatandaşı iseniz, kişisel verilerinizin e-posta yoluyla silinmesini talep edebilirsiniz.",
-        "notes_ru": "Вы не можете удалить свою учетную запись Reddit; Вы можете только деактивировать ее. Данные, размещенные на Reddit (посты и комментарии), должны быть удалены вами заранее. Если вы являетесь гражданином ЕС, см. Reddit (GDPR) на JustDeleteMe.",
-        "domains": [
-            "reddit.com"
-        ]
-    },
-
-    {
-        "meta": "popular",
-        "name": "Reddit (GDPR)",
-        "url": "https://www.reddit.com/message/compose?to=%2Fr%2Freddit.com&subject=GDPR / CCPA - u/[please enter your username here]&message=I am requesting deletion of my account and relate information under GDPR.",
-        "difficulty": "hard",
-        "notes": "Content posted to Reddit (posts and comments) must be deleted individually beforehand. As an EU citizen, do not use the normal deactivation process. Send a message with the provided link instead.",
-        "notes_ru": "Данные, размещенные на Reddit (посты и комментарии), должны быть удалены вами заранее. Как гражданин ЕС, не используйте стандартный процесс деактивации. Вместо этого отправьте сообщение с предоставленной ссылкой.",
+        "url": "https://www.reddit.com/prefs/delete/",
+        "difficulty": "easy",
+        "notes": "Your content will not be deleted (only disassociated).",
         "domains": [
             "reddit.com"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -9987,7 +9987,7 @@
         "name": "Reddit",
         "url": "https://www.reddit.com/prefs/delete/",
         "difficulty": "easy",
-        "notes": "Your content will not be deleted (only disassociated).",
+        "notes": "If you are opted in to the redesign, scroll to the bottom and click on the Delete Account button. Your content will not be deleted (only disassociated).",
         "domains": [
             "reddit.com"
         ]


### PR DESCRIPTION
- Change difficulty to easy (the text on the form implies that accounts are deleted rather than deactivated)
- Removed GDPR entry (it doesn't remove anything that the normal process doesn't - and usernames aren't freed up in either case)
- Updated link (ssl.reddit.com still exists, but doesn't respect the redesign setting, www will redirect if opted in)