### PR TITLE
Add toyota.de as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12078,6 +12078,17 @@
     },
 
     {
+        "name": "Toyota.de",
+        "url": "https://www.toyota.de/apps/customerportal#/publish/customer_portal_profile",
+        "difficulty": "easy",
+        "notes": "Login to your account, go to your Settings, choose Tab 'Meine Einstellungen' and click on 'Konto löschen'",
+        "notes_de": "Melde dich an, gehe zu deinen Einstellungen, wähle den Tab 'Meine Einstellungen' und klicke auf 'Konto löschen'",
+        "domains": [
+            "toyota.de"
+        ]
+    },
+
+    {
         "name": "The Tracktor",
         "url": "https://thetracktor.com/account/close",
         "difficulty": "easy",


### PR DESCRIPTION
Add deletion steps for toyota.de
As this is a german page and there is no english translation, the description of the tabs/buttons is in german.