### PR TITLE
Remove Dubsmash

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3620,18 +3620,6 @@
     },
 
     {
-        "name": "Dubsmash",
-        "url": "https://dubsmash.com/delete-account",
-        "difficulty": "easy",
-        "notes": "Click at \"Delete now\" to confirm the deletion of your account.<br><br>You can also request the deletion of your account via <a href=\"mailto:support@dubsmash.com\">email</a>.",
-        "notes_tr": "Hesabınızı silmeyi onaylamak için \"Şimdi Sil\" tuşuna tıklayın. Ayrıca hesabınızın silinmesini e-posta aracılığı ile de isteyebilirsiniz.",
-        "notes_pt_br": "Clique em \"Delete now\" para confirmar a exclusão da sua conta.<br><br>Você também pode requisitar a exclusão da sua conta via <a href=\"mailto:support@dubsmash.com\">e-mail</a>.",
-        "domains": [
-            "dubsmash.com"
-        ]
-    },
-
-    {
         "name": "Duo",
         "url": "https://help.duo.com/s/article/2162",
         "difficulty": "hard",


### PR DESCRIPTION
Shut down by Reddit on [February, 2022](https://www.bloomberg.com/news/articles/2022-02-22/dubsmash-no-match-for-tiktok-dies-quietly-after-its-acquisition-by-reddit#:~:text=This%20week%2C%20according%20to%20announcement,the%20post%20about%20Dubsmash's%20demise.)