### PR TITLE
Remove We the People

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -13360,22 +13360,6 @@
     },
 
     {
-        "name": "We the People",
-        "url": "https://petitions.whitehouse.gov",
-        "difficulty": "impossible",
-        "notes": "Site provides no user account management interface or account deletion options.",
-        "notes_tr": "Site, kullanıcı hesabı yönetimi arayüzü veya hesap silme seçenekleri sağlamıyor.",
-        "notes_fr": "Le site ne propose pas la suppression de compte.",
-        "notes_it": "Il sito non possiede nessuna interfaccia di gestione utente o possibilità di eliminare l'account",
-        "notes_pt_br": "O site não possui interface de gerenciamento da conta ou opções para remoção da conta.",
-        "notes_cat": "La web no té opcions d'usuari o per esborrar el compte.",
-        "notes_es": "El sitio no tiene opciones de configuración o para borrar la cuenta.",
-        "domains": [
-            "petitions.whitehouse.gov"
-        ]
-    },
-
-    {
         "name": "Weather.com",
         "url": "http://registration.weather.com/ursa/profile/unsubscribe",
         "difficulty": "easy",


### PR DESCRIPTION
Site now redirects to whitehouse.gov

Old petitions can be seen at https://petitions.trumpwhitehouse.archives.gov or https://petitions.obamawhitehouse.archives.gov depending on when the petition was created, but the sites are now frozen and cannot be logged in to, as such I would be surprised if they still kept the user accounts since the petitions only show names.