### PR TITLE
Add HBO Max as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5590,6 +5590,17 @@
     },
 
     {
+        "name": "HBO Max",
+        "url": "https://privacyportal.onetrust.com/webform/1b21e05d-c206-4e0b-970e-2d73a23e42e8/6555225c-a911-4af8-bdb5-20158994ece0",
+        "difficulty": "hard",
+        "notes": "It is also possible to file an account deletion request in the iOS app (account settings -> subscription)",
+        "domains": [
+            "hbo.com",
+            "hbomax.com"
+        ]
+    },
+
+    {
         "name": "hCaptcha",
         "url": "https://www.hcaptcha.com/privacy",
         "difficulty": "hard",


### PR DESCRIPTION
This one took a while. The warner media privacy page (where the privacy policy sends you to) only accepts requests from california residents, and they verify your id. It only appears in the iOS app and is not linked anywhere at all.