### PR TITLE
Change Wattpad to easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -13496,8 +13496,8 @@
     {
         "name": "Wattpad",
         "url": "https://www.wattpad.com/settings",
-        "difficulty": "impossible",
-        "notes": "You can close your account by going to Login > Close Account. Note that this doesn't delete it nor anything related to it and trying to log back in reactivates it instantly",
+        "difficulty": "easy",
+        "notes": "Closed accounts are deleted after six months.",
         "domains": [
             "wattpad.com"
         ]


### PR DESCRIPTION
[Closed accounts are wiped after six months](https://support.wattpad.com/hc/en-us/articles/205292130-I-can-t-reactivate-restore-my-account)