### PR TITLE
Remove old sites

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -13001,6 +13001,15 @@
     },
 
     {
+        "name": "Veduca",
+        "url": "https://veduca.org",
+        "difficulty": "impossible",
+        "domains": [
+            "veduca.org"
+        ]
+    },
+
+    {
         "name": "Vercel",
         "url": "https://vercel.com/account",
         "notes": "In the dashboard, click your profile picture on the top right, click \"Settings\", scroll down and then click \"Delete Personal Account\".",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4419,7 +4419,7 @@
         "name": "FogBugz",
         "url": "https://support.fogbugz.com/hc/en-us/articles/360011242754-Cancelling-a-FogBugz-or-Kiln-On-Demand-Subscription",
         "difficulty": "easy",
-        "notes": "The account retention period depends on the type of account you have."
+        "notes": "The account retention period depends on the type of account you have.",
         "domains": [
             "fogbugz.com"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12992,20 +12992,20 @@
     },
 
     {
-        "name": "Velo Hero",
-        "url": "https://app.velohero.com/settings/terminate",
-        "difficulty": "easy",
-        "domains": [
-            "velohero.com"
-        ]
-    },
-
-    {
         "name": "Veduca",
         "url": "https://veduca.org",
         "difficulty": "impossible",
         "domains": [
             "veduca.org"
+        ]
+    },
+
+    {
+        "name": "Velo Hero",
+        "url": "https://app.velohero.com/settings/terminate",
+        "difficulty": "easy",
+        "domains": [
+            "velohero.com"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4416,6 +4416,16 @@
     },
 
     {
+        "name": "FogBugz",
+        "url": "https://support.fogbugz.com/hc/en-us/articles/360011242754-Cancelling-a-FogBugz-or-Kiln-On-Demand-Subscription",
+        "difficulty": "easy",
+        "notes": "The account retention period depends on the type of account you have."
+        "domains": [
+            "fogbugz.com"
+        ]
+    },
+
+    {
         "name": "Follett",
         "url": "https://www.follett.com/policies/",
         "difficulty": "hard",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -572,19 +572,6 @@
     },
 
     {
-        "name": "AllCall Forum",
-        "url": "http://bbs.allcall.hk/",
-        "difficulty": "impossible",
-        "notes": "The website does not offer any options that allow the account to be deleted.",
-        "notes_ru": "Веб-сайт не предлагает никаких опций, позволяющих удалить учетную запись.",
-        "notes_tr": "Bu web sitesi hesabınızın silinmesi için herhangi bir seçenek sunmuyor.",
-        "notes_pt_br": "O website não disponibiliza nenhuma opção que possibilite a exclusão da conta.",
-        "domains": [
-            "allcall.hk"
-        ]
-    },
-
-    {
         "name": "Alvanista",
         "url": "http://alvanista.com/profile/edit",
         "difficulty": "easy",
@@ -1298,17 +1285,6 @@
         "notes_tr": "\"Profilimi Düzenle\" sayfasındaki yan menüde bulunan bir \"Profili Sil\" seçeneği var. Verilerinizin 24 saat içinde silinmesi için bir seçenek bile seçebilirsiniz.",
         "domains": [
             "bewelcome.org"
-        ]
-    },
-
-    {
-        "name": "Beamly",
-        "url": "http://au.beamly.com/account/delete",
-        "difficulty": "easy",
-        "notes": "To delete your account, login and then next to your name select the drop down and go to 'Settings' once there scroll to the bottom of the page and select 'delete your account'.",
-        "notes_tr": "Hesabınızı silmek için, giriş yapın ve isminizin yanındaki menüye tıklayıp \"Ayarlar\" kısmına girin. Girdiğinizde, sayfanın altına kaydırın ve \"Hesabınızı Silin\" seçeneğini seçin.",
-        "domains": [
-            "beamly.com"
         ]
     },
 
@@ -2293,19 +2269,6 @@
     },
 
     {
-        "name": "ClickAndBuy",
-        "url": "http://clickandbuy.com/faqs",
-        "difficulty": "easy",
-        "notes": "Login to your account, then click 'delete account' on the page.",
-        "notes_tr": "Hesabınıza giriş yapın, ve sayfadaki \"Hesabı Sil\" tuşuna tıklayın.",
-        "notes_fr": "Connectez-vous et cliquez sur « delete account ».",
-        "notes_de": "Logge dich in deinen Account ein und klicke auf der Seite auf 'Account löschen'.",
-        "domains": [
-            "clickandbuy.com"
-        ]
-    },
-
-    {
         "name": "ClickUp",
         "url": "https://feedback.clickup.com/feature-requests/p/delete-account-3",
         "difficulty": "hard",
@@ -2448,18 +2411,6 @@
         "notes_tr": "Hesabınızı henüz silemezsiniz. Bu özellik üstünde çalışılıyor ve yakında mevcut olabilir.",
         "domains": [
             "codeforces.com"
-        ]
-    },
-
-    {
-        "name": "Codenvy",
-        "url": "https://codenvy.io/dashboard/#/account",
-        "difficulty": "easy",
-        "notes": "Deletion option can be found in the \"Security\" tab",
-        "notes_tr": "\"Güvenlik\" sekmesinde hesabı silme seçeneğini bulabilirsiniz",
-        "domains": [
-            "codenvy.com",
-            "codenvy.io"
         ]
     },
 
@@ -4251,17 +4202,6 @@
     },
 
     {
-        "name": "Fast2Pay",
-        "url": "https://www.fast2pay.com.br",
-        "difficulty": "impossible",
-        "notes": "Nowhere on the website or the android app there is a 'My account' page or similar providing a way to delete the account.",
-        "notes_tr": "Web sitesinin veya Android uygulamasının hiçbir yerinde hesabı silmenin bir yolunu sağlayan bir \"Hesabım\" sayfası veya benzeri yoktur.",
-        "domains": [
-            "fast2pay.com.br"
-        ]
-    },
-
-    {
         "name": "FastTech",
         "url": "https://support.fasttech.com/general/ACCT",
         "difficulty": "hard",
@@ -4472,17 +4412,6 @@
         "notes_tr": "Hesabınızın silinmesi için müşteri hizmetleri ile iletişime geçmeniz gerekir.",
         "domains": [
             "foap.com"
-        ]
-    },
-
-    {
-        "name": "FogBugz",
-        "url": "https://www.fogcreek.com/fogbugz/",
-        "difficulty": "easy",
-        "notes": "On the top right corner, click 'Admin' then 'Your On Demand Account' and search for the close account button at the bottom right. It is not really deleted, just closed.",
-        "notes_tr": "Sağ üst köşede, \"Yönetici\" tuşuna tıklayın ve ardından \"Talep Hesabınız\" seçeneğine tıklayın. Sağ alt köşede hesabı kapatma tuşunu bulun. Hesap silinmeyecek, yalnızca kapatılacak.",
-        "domains": [
-            "fogbugz.com"
         ]
     },
 
@@ -5714,18 +5643,6 @@
     },
 
     {
-        "name": "Heroes of Newerth",
-        "url": "https://www.heroesofnewerth.com",
-        "difficulty": "hard",
-        "email": "support@heroesofnewerth.com",
-        "notes": "The only way of deleting your account is by sending an e-mail to 'support@heroesofnewerth.com'.",
-        "notes_tr": "Hesabı silmenizin tek yolu e-posta göndermektir.",
-        "domains": [
-            "heroesofnewerth.com"
-        ]
-    },
-
-    {
         "name": "Heroku",
         "url": "https://dashboard.heroku.com/account",
         "difficulty": "easy",
@@ -6074,18 +5991,6 @@
         "notes_fr": "Connectez-vous, allez dans vos parametres puis cliquez sur « Delete Account » en bas à gauche.",
         "domains": [
             "imo.im"
-        ]
-    },
-
-    {
-        "name": "Importa Brasil",
-        "url": "https://importabr.com.br/new-content/23",
-        "difficulty": "hard",
-        "notes": "Create a topic to request the deletion of your account.",
-        "notes_tr": "Hesabınızın silinmesini istemek için bir konu oluşturun.",
-        "notes_pt_br": "Crie um tópico para solicitar a exclusão da sua conta.",
-        "domains": [
-            "importabr.com.br"
         ]
     },
 
@@ -7933,17 +7838,6 @@
     },
 
     {
-        "name": "Metacafe",
-        "url": "https://www.metacafe.com/feedback/",
-        "difficulty": "hard",
-        "notes": "Request to delete account by contacting support.",
-        "notes_tr": "Müşteri desteğine iletişime geçerek hesabınızı silmenizi talep edin.",
-        "domains": [
-            "metacafe.com"
-        ]
-    },
-
-    {
         "name": "Mi Account",
         "url": "https://account.xiaomi.com/pass/del",
         "difficulty": "easy",
@@ -8287,19 +8181,6 @@
         "notes_pt_br": "Na página da sua conta, vá até o final e clique no botão vermelho 'Excluir'",
         "domains": [
             "muambator.com.br"
-        ]
-    },
-
-    {
-        "name": "Multiplay.co.uk",
-        "url": "https://multiplay.com/contactus/",
-        "difficulty": "hard",
-        "notes": "You have to contact Multiplay by their contact us page.",
-        "notes_tr": "Multiplay sitesinin \"İletişim\" sayfasından kendileri ile iletişime geçmelisiniz.",
-        "notes_fr": "Vous devez contactez Multiplay par le formulaire de contact.",
-        "notes_es": "Tienes que contactar a Multiplay a través de su página contactanos.",
-        "domains": [
-            "multiplay.com"
         ]
     },
 
@@ -9115,18 +8996,6 @@
     },
 
     {
-        "name": "OpenShift",
-        "url": "https://developers.openshift.com/en/account-overview.html#_how_do_i_delete_my_account",
-        "difficulty": "impossible",
-        "notes": "You can't delete your account including all data, only a ‘soft delete’ is possible where you can always re-enable your account.",
-        "notes_tr": "Tüm veriler dahil olmak üzere hesabınızı silemezsiniz, yalnızca hesabınızı her zaman yeniden etkinleştirebileceğiniz bir 'hafif silme' mümkündür.",
-        "notes_de": "Es ist nicht möglich das Konto mit allen Daten zu löschen, es ist nur ein 'weiches Löschen' möglich, bei dem es immer die Möglichkeit des Wieder-Aktivierens gibt.",
-        "domains": [
-            "openshift.com"
-        ]
-    },
-
-    {
         "name": "OpenStreetMap",
         "url": "https://www.openstreetmap.org/account/deletion",
         "difficulty": "easy",
@@ -9152,15 +9021,6 @@
         "notes": "On the linked page select 'Delete my account'.",
         "domains": [
             "opera.com"
-        ]
-    },
-
-    {
-        "name": "Orkut",
-        "url": "https://support.google.com/orkut/",
-        "difficulty": "easy",
-        "domains": [
-            "orkut.google.com"
         ]
     },
 
@@ -11520,23 +11380,6 @@
     },
 
     {
-        "name": "Sonico",
-        "url": "http://www.sonico.com/tyc.php",
-        "difficulty": "hard",
-        "notes": "Send a request to legal@sonico.com and request deletion.",
-        "notes_tr": "Silmeyi talep etmek için e-posta gönderin.",
-        "notes_fr": "Envoyez une demande de suppression à legal@sonico.com .",
-        "notes_it": "Invia la richiesta a legal@sonico.com",
-        "notes_pt_br": "Envie um pedido para legal@sonico.com e peça a remoção.",
-        "notes_cat": "Enviï una petició per esborrar el seu compte a legal@sonico.com.",
-        "notes_es": "Envía una petición para borrar tu cuenta a legal@sonico.com.",
-        "email": "legal@sonico.com",
-        "domains": [
-            "sonico.com"
-        ]
-    },
-
-    {
         "name": "Sonos",
         "url": "https://www.sonos.com/en-us/legal/privacy#legal-privacy-contact",
         "difficulty": "hard",
@@ -12204,18 +12047,6 @@
     },
 
     {
-        "name": "Technorati",
-        "url": "https://technorati.com",
-        "difficulty": "impossible",
-        "notes": "It's not possible to remove your account, but you can remove your blogs.",
-        "notes_tr": "Hesabınızı kaldırmanız mümkün değildir, ancak bloglarınızı kaldırabilirsiniz.",
-        "notes_pt_br": "Não é possível remover sua conta, mas você pode remover seus blogs.",
-        "domains": [
-            "technorati.com"
-        ]
-    },
-
-    {
         "name": "TED",
         "url": "https://support.ted.com/hc/en-us/articles/360005310614-TED-Ed-Accounts-and-managing-students",
         "difficulty": "hard",
@@ -12854,15 +12685,6 @@
     },
 
     {
-        "name": "Twoo",
-        "url": "https://www.twoo.com/settings/delete/",
-        "difficulty": "easy",
-        "domains": [
-            "www.twoo.com"
-        ]
-    },
-
-    {
         "name": "twoseven",
         "url": "https://twoseven.xyz/help/faq",
         "notes": "The instructions are the the bottom of their FAQs",
@@ -13185,15 +13007,6 @@
         "difficulty": "easy",
         "domains": [
             "vercel.com"
-        ]
-    },
-
-    {
-        "name": "Verduca",
-        "url": "http://www.veduca.com.br",
-        "difficulty": "impossible",
-        "domains": [
-            "veduca.com.br"
         ]
     },
 
@@ -14107,18 +13920,6 @@
         "notes_tr": "Hesabınızı sonlandırmak için, Müşteri Hizmetleri'ne web iletişim formu aracılığıyla kullanıcı adınızı ve hesabınızla ilişkili e-posta adresini içeren bir mesaj göndermeniz yeterlidir. Bunu yaptığınızda, Destek Ekibimizin bir üyesi hesabınızı devre dışı bırakacak, hem genel hem de özel tüm ürünleri kaldıracak ve (varsa) mağazanızı devre dışı bırakacaktır. Sistemimiz bir sonraki hesap kaldırma grubunu işlediğinde hesap tamamen silinecektir.",
         "domains": [
             "zazzle.com"
-        ]
-    },
-
-    {
-        "name": "Zeit",
-        "url": "https://zeit.co/account/plan",
-        "difficulty": "hard",
-        "notes": "You would need to email the team by clicking contact us to get your account closed.",
-        "notes_tr": "Hesabınızı kapatmak için iletişime geçerek destek ekibine e-posta göndermeniz gerekir.",
-        "email": "team@zeit.co",
-        "domains": [
-            "zeit.co"
         ]
     },
 


### PR DESCRIPTION
A large cleanup of old sites:

- AllCall Forum: Site hasn't worked for years and does not indicate it will ever work again
- Beamly: Subdomain linked doesn't work, root domain redirects to coty, which does not have an account system
- ClickAndBuy: [The site was most likely shut down, as the company is no longer in business](https://web.archive.org/web/20220128235816/clickandbuy.com/faqs)
- Codenvy: Now uses the Red Hat account system
- Fast2Pay: Does not have any A/AAAA records at root or www, last successful wayback machine archive was in August 2021
- FogBugz: Now known as Glitch (which is already listed on jdm)
- Heroes of Newerth: [Game and site shut down on June 20, 2022](https://en.wikipedia.org/wiki/Heroes_of_Newerth#Development)
- Importa Brasil: Redirects to AliExpress
- Metacafe: [Website supposedly stopped working in August 2021](https://en.wikipedia.org/wiki/Metacafe#Closure)
- Multiplay: Now tied to Unity ID
- OpenShift: Now uses the Red Hat account system
- Orkut: Archive link doesn't work at all anymore (site was archived in 2014)
- Sonico: Redirects to Twoo (which is now shut down and sends you to Plenty of Fish)
- Technorati: Site hasn't had any login functionality or blogs since about 2014
- Twoo: See Sonico
- Zeit: Now known as Vercel (also listed on jdm)

I will add the red hat id deletion form in another pr