### PR TITLE
Updated enjin note to actually delete account.

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3942,7 +3942,7 @@
         "name": "enjin",
         "url": "https://www.enjin.com/dashboard/account/privacy",
         "difficulty": "easy",
-        "notes": "Scroll down and click on 'Deactivate Account'.",
+        "notes": "Scroll down and click on 'Delete Account'.",
         "domains": [
             "enjin.com"
         ]


### PR DESCRIPTION
Previously the note told you to use the deactivate account process which doesn't fully delete your account. Recently the option to delete your account from the same page was added.