### PR TITLE
Remove Google+ and Picasa

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5335,15 +5335,6 @@
     },
 
     {
-        "name": "Google+",
-        "url": "https://plus.google.com/downgrade",
-        "difficulty": "easy",
-        "domains": [
-            "plus.google.com"
-        ]
-    },
-
-    {
         "name": "GoPetition",
         "url": "https://www.gopetition.com",
         "difficulty": "easy",
@@ -9735,24 +9726,6 @@
         "notes": "To delete your account, you must <a href=\"https://support.photobucket.com/hc/en-us/requests/new\">open a support ticket</a> and provide your username, email address, full name, dob, the postal code and country from where you registered for verification. According to Photobucket, account deletion takes up to 30 days, and your old pictures cannot be recovered from deleted accounts as they will be completely erased from their servers.",
         "domains": [
             "photobucket.com"
-        ]
-    },
-
-    {
-        "name": "Picasa",
-        "url": "http://picasaweb.google.com",
-        "difficulty": "impossible",
-        "notes": "You can't delete your Google Account for Picasa Web Albums without deleting your entire Google Account.",
-        "notes_tr": "Picasa Web Albümleri hesabınızı Google Hesabınızın tamamını silmeden silemezsiniz.",
-        "notes_fr": "Vous ne pouvez pas supprimer votre compte Picassa sans supprimer votre compte Google.",
-        "notes_it": "Non puoi eliminare il tuo account Picasa Web Albums senza eliminare l'intero Account Google.",
-        "notes_pt_br": "Você não pode deletar sua conta Picasa sem deletar toda sua Conta Google.",
-        "notes_cat": "No pot esborrar el seu compte a Picasa sense esborrar el seu compte de Google.",
-        "notes_es": "No puedes borrar tu cuenta de Picasa sin borrar toda la cuenta de Google.",
-        "notes_pl": "Nie ma możliwosći usunięcia konta w usłudze Picasa Web Albums bez usuwania całego konta Google.",
-        "domains": [
-            "picasaweb.google.com",
-            "picasa.google.com"
         ]
     },
 


### PR DESCRIPTION
Removing sites (Picasa and Google+) doesn't exist anymore.