### PR TITLE
Add The Atlantic as limited

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1106,6 +1106,17 @@
     },
 
     {
+        "name": "The Atlantic",
+        "url": "https://support.theatlantic.com/hc/en-us/requests/new",
+        "difficulty": "limited",
+        "notes": "Depending on where you live you either need to select \"Submit an EEA Data Request\" or \"Submit a CCPA Data Request\".",
+        "domains": [
+            "accounts.theatlantic.com",
+            "theatlantic.com",
+        ]
+    },
+
+    {
         "name": "Atlassian / Bitbucket",
         "url": "https://id.atlassian.com/manage/close-account",
         "difficulty": "medium",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1112,7 +1112,7 @@
         "notes": "Depending on where you live you either need to select \"Submit an EEA Data Request\" or \"Submit a CCPA Data Request\".",
         "domains": [
             "accounts.theatlantic.com",
-            "theatlantic.com",
+            "theatlantic.com"
         ]
     },
 


### PR DESCRIPTION
They point to a ticket form which says they will verify identity and residency.