### PR TITLE
Add subdomain for Standard Notes Web App

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12934,7 +12934,8 @@
         "url": "https://standardnotes.com/reset",
         "difficulty": "easy",
         "domains": [
-            "standardnotes.com"
+            "standardnotes.com",
+            "app.standardnotes.com"
         ]
     },
 


### PR DESCRIPTION
added `app.standardnotes.com` to `Standard Notes`