### PR TITLE
Update AWS difficulty to medium

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -750,10 +750,11 @@
     {
         "name": "Amazon AWS",
         "url": "https://console.aws.amazon.com/billing/home#/account",
-        "difficulty": "impossible",
-        "notes": "AWS accounts are never entirely deleted, only closed.",
+        "difficulty": "medium",
+        "notes": "You will not be able to reuse the email address on the account at the time of closure, but they appear to accept disposable email addresses. However, for accounts created prior to May 2017, there is also an Amazon Marketplace account with the same email. See the entry for Amazon to delete that account.",
         "domains": [
-            "amazon.com"
+            "aws.amazon.com",
+            "console.aws.amazon.com"
         ]
     },
 


### PR DESCRIPTION
They updated their privacy notice again, and it's less ambiguous than before. [Although there's more headaches for anyone that has a pre-2017 account and used the same email for their amazon.com account](https://confluence.cornell.edu/display/CLOUD/Interactions+of+AWS+Root+Accounts+and+Amazon.com+Accounts)

Now it's the same deal as everyone else ("we keep the stuff we need for tax purposes as long as we are required to keep it")