### PR TITLE
Remove honorific language in de.json

### DIFF
--- a/_data/trans/de.json
+++ b/_data/trans/de.json
@@ -1,7 +1,7 @@
 {
     "about": "Über",
     "contribute": "Auf GitHub beitragen",
-    "defaultnote_easy": "Besuche die verlinkte Seite und löschen Sie Ihren Account.",
+    "defaultnote_easy": "Besuche die verlinkte Seite und lösche deinen Account.",
     "defaultnote_email": "Sende eine E-Mail an die angegebene Adresse und fordere die Löschung deines Accounts.",
     "difficulty": "Schwierigkeit",
     "difficulty_easy": "leicht",


### PR DESCRIPTION
The language used for the German translation was a bit stiff and uncommon.