### PR TITLE
Update Nexon from "Impossible" to "hard"

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10569,9 +10569,9 @@
 
     {
         "name": "Nexon",
-        "url": "https://support.nexon.net/hc/en-us/articles/360001112943-How-can-I-delete-or-deactivate-my-account-",
-        "difficulty": "impossible",
-        "notes": "The support page tells you to open a ticket, but you can't open a ticket to delete your account",
+        "url": "https://support-maplestory.nexon.net/hc/fr/articles/360000698823-Comment-puis-je-supprimer-ou-d%C3%A9sactiver-mon-compte-",
+        "difficulty": "hard",
+        "notes": "Open a ticket to ask for account deletion",
         "domains": [
             "nexon.com",
             "one.nexon.com",


### PR DESCRIPTION
I recently added Nexon as impossible because I couldn't open a ticket.

I contacted them by email and they sent me a link that allows sending a ticket for account deletion.

What happened is that their website is a bit complicated and everything isn't coherent. I asked them to fix that

So I'm marking Nexon as Hard and I set the link to the one the support sent me.