### PR TITLE
Remove font-weight from button to improve accessibility

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -103,7 +103,6 @@ header h1 span {
     border-radius: 5px;
     color: white;
     display: inline-block;
-    font-weight: lighter;
     letter-spacing: 1px;
     margin-top: 10px;
     padding: 10px 20px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/94064167/224502741-9902ab58-193b-4e70-9263-f0401d1d8343.png)

After:
![image](https://user-images.githubusercontent.com/94064167/224502758-33a1ef94-0dab-472d-8c46-6a526ddf434e.png)

I use Firefox on Fedora 37.