### PR TITLE
Update IFTTT deletion link

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7538,7 +7538,7 @@
 
     {
         "name": "IFTTT",
-        "url": "https://ifttt.com/settings/deactivate",
+        "url": "https://ifttt.com/settings/confirm_deletion",
         "difficulty": "easy",
         "domains": [
             "ifttt.com"


### PR DESCRIPTION
The deletion link for IFTTT has been updated from https://ifttt.com/settings/deactivate to https://ifttt.com/settings/confirm_deletion