### PR TITLE
Update DJI to easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4082,9 +4082,8 @@
 
     {
         "name": "DJI",
-        "url": "https://dji.com",
-        "difficulty": "medium",
-        "notes": "You cannot delete your account from the website, you must use the app. Go to 'Account' then 'Settings' and finally 'Delete Account'.",
+        "url": "https://account.dji.com/account/userCancel",
+        "difficulty": "easy",
         "domains": [
             "dji.com"
         ]


### PR DESCRIPTION
Asked DJI support to delete my account since I didn't want to download the app and got the following reply:

> DJI now supports the self-deletion of your DJI account, which only takes you 1-2 minutes and is also the quickest and easiest way to get it deleted. Please enter the link below---log into your DJI account to submit account deletion, our team will handle it as soon as possible.
https://account.dji.com/account/userCancel