### PR TITLE
Add The Washington Post as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -16842,6 +16842,17 @@
     },
 
     {
+        "name": "The Washington Post",
+        "url": "https://helpcenter.washingtonpost.com/hc/en-us/requests/new",
+        "difficulty": "hard",
+        "notes": "You have to submit a request regarding account deletion, and support will get back to you by sending you a account deletion confirmation email. After confirming, your account is deleted. For residents of EEA, UK, Switzerland, California, or Virginia who verify your address, they will delete additional information.",
+        "domains": [
+            "helpcenter.washingtonpost.com",
+            "washingtonpost.com"
+        ]
+    },
+
+    {
         "name": "Watch2Gether",
         "url": "https://w2g.tv/users/current_user",
         "difficulty": "easy",


### PR DESCRIPTION
Quick question: I am a bit confused about marking this hard or limited, because the Washington Post claims in their account deletion confirmation email, that if you are a resident of EEA, UK, Switzerland, California, or Virginia, and you verified your address, they will delete additional information. It is not disclosed what this additional information is.