### PR TITLE
Remove space between extension text and period

### DIFF
--- a/TRANSLATION_REFERENCE.md
+++ b/TRANSLATION_REFERENCE.md
@@ -35,7 +35,8 @@ This is a reference guide for translating, so that one can see where each key fi
 ## Footer
 
 - `whatisthis`: Title of the section with the explanation about the website
-- `whatisthis[1-3]`: Phrase that describes the website, pieced together as "`whatisthis1` `whatisthis2` `whatisthis3`". `whatisthis2` is the "dark patterns" hyperlink text
+- `whatisthis[1-3]`: Phrase that describes the website, pieced together as "`whatisthis1` `whatisthis2` `whatisthis3`".
+  `whatisthis2` is the "dark patterns" hyperlink text
 - `whatisthis4`: Second paragraph explaining the website
 - `pullrequest`: Text for the hyperlink that takes to the JDM GitHub webpage
 - `guide`: Title for the section explaining how difficulties work
@@ -48,5 +49,8 @@ This is a reference guide for translating, so that one can see where each key fi
 - `extension_browser`: Title for the section explaining about the Chrome/Firefox browser extensions
 - `extensionguide`: Sentence introducing the extension section
 - `extensionp1`: Explains what the extensions do
-- `extensionp[2-5]`: Last paragraph showing how to install the extensions. It is written as "`extensionp2` + `extensionp3`/`extensionp4` + `extensionp5`" where `extensionp3` and `extensionp4` are the texts for the hyperlinks of the Chrome Web Store and Firefox Add-ons, respectively.
+- `extensionp[2-5]`: Last paragraph showing how to install the extensions. It is written as "`extensionp2` +
+  `extensionp3`/`extensionp4` + `extensionp5`" where `extensionp3` and `extensionp4` are the texts for the hyperlinks of
+  the Chrome Web Store and Firefox Add-ons, respectively. `extensionp5` is expected to either be an empty string, or
+  include leading space (as needed) between the prior link and a trailing period.
 - `footercredits`: Text to introduce creators

--- a/_data/trans/de.json
+++ b/_data/trans/de.json
@@ -15,7 +15,7 @@
     "extensionp2": "Um die Erweiterung zu installieren, öffne einfach den",
     "extensionp3": "Chrome Web Store",
     "extensionp4": "Firefox Add-ons",
-    "extensionp5": "auf",
+    "extensionp5": " auf.",
     "footercredits": "Erstellt von",
     "guide": "Anleitung",
     "guideeasy": "Einfacher Prozess",

--- a/_data/trans/kr.json
+++ b/_data/trans/kr.json
@@ -15,7 +15,7 @@
     "extensionp2": "설치하시려면 지금 바로",
     "extensionp3": "크롬 웹 스토어에",
     "extensionp4": "Firefox Add-ons",
-    "extensionp5": "방문하세요",
+    "extensionp5": " 방문하세요.",
     "footercredits": "만든 이들:",
     "guide": "가이드",
     "guideeasy": "간단한 절차",

--- a/_data/trans/nl.json
+++ b/_data/trans/nl.json
@@ -15,7 +15,7 @@
     "extensionp2": "Ga naar de",
     "extensionp3": "Chrome Web Store",
     "extensionp4": "Firefox Add-ons",
-    "extensionp5": "om te installeren",
+    "extensionp5": " om te installeren.",
     "footercredits": "Gemaakt door",
     "guide": "Gids",
     "guideeasy": "Eenvoudig proces",

--- a/_data/trans/tr.json
+++ b/_data/trans/tr.json
@@ -15,7 +15,7 @@
     "extensionp2": "İndirmek için, ",
     "extensionp3": "Chrome Web Mağaza",
     "extensionp4": "Firefox Add-ons",
-    "extensionp5": "'sına girin",
+    "extensionp5": "'sına girin.",
     "footercredits": "Yapımcı",
     "guide": "Kılavuz",
     "guideeasy": "Basit işlem",

--- a/_includes/body.html
+++ b/_includes/body.html
@@ -97,11 +97,14 @@
             <h2>{{ site.data.trans[page.lang].extension_browser|safe }}</h2>
             <p>{{ site.data.trans[page.lang].extensionp1|safe }}</p>
             <p>
+                {% assign post_extension_link_text = site.data.trans[page.lang].extensionp5 | safe %}
+                {% if post_extension_link_text == '' %}
+                    {% assign post_extension_link_text = '.' %}
+                {% endif %}
                 {{ site.data.trans[page.lang].extensionp2|safe }}
                 <a target='_blank' href='https://chrome.google.com/webstore/detail/justdeleteme/hfpofkfbabpbbmchmiekfnlcgaedbgcf'>{{ site.data.trans[page.lang].extensionp3|safe }}</a>
                 /
-                <a target='_blank' href='https://addons.mozilla.org/en-US/firefox/addon/justdeleteme/'>{{ site.data.trans[page.lang].extensionp4|safe }}</a>
-                {{ site.data.trans[page.lang].extensionp5|safe }}.
+                <a target='_blank' href='https://addons.mozilla.org/en-US/firefox/addon/justdeleteme/'>{{ site.data.trans[page.lang].extensionp4|safe }}</a>{{ post_extension_link_text }}
             </p>
         </div>
         <div class="banner-block-half">


### PR DESCRIPTION
This commit moves all post-extension-link text into translation files, preventing there from being a trailing space between the "Firefox Add-ons" link text and the period following it, incidentally preventing said period from wrapping to a new line on the English language page.

Fixes jdm-contrib/jdm#1583