### PR TITLE
Update website for Robb Lewis

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
     <div class="info-container">
         <footer>
             {{ site.data.trans[page.lang].footercredits }}
-                <a href='https://robblewis.me'>Robb Lewis</a>, <a href='https://github.com/edpoole'>Ed Poole</a>, & <a href='https://github.com/jdm-contrib'>JDM Contrib Team</a>
+                <a href='https://rknight.me/'>Robb Knight</a>, <a href='https://github.com/edpoole'>Ed Poole</a>, & <a href='https://github.com/jdm-contrib'>JDM Contrib Team</a>
                 | <a href='https://github.com/jdm-contrib/jdm'> {{ site.data.trans[page.lang].contribute }} </a>
         </footer>
     </div>


### PR DESCRIPTION
As said in #1722 Robb Lewis now seems to have a different name and a different website. This pull request updates the footer accordingly.

closes #1722 