### PR TITLE
Add SPC as impossible

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -15733,8 +15733,7 @@
         "email": "privacy@spccard.ca",
         "notes": "According to their privacy policy, emailing should be sufficient for data deletion, but they are unresponsive.",
         "domains": [
-            "spccard.ca",
-            "www.spccard.ca"
+            "spccard.ca"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -15727,6 +15727,18 @@
     },
 
     {
+        "name": "SPC",
+        "url": "https://www.spccard.ca/privacy-policy",
+        "difficulty": "impossible",
+        "email": "privacy@spccard.ca",
+        "notes": "According to their privacy policy, emailing <a href=\"mailto:privacy@spccard.ca\">privacy@spccard.ca</a> should be sufficient for data deletion, but this email is unresponsive.",
+        "domains": [
+            "spccard.ca",
+            "www.spccard.ca"
+        ]
+    },
+
+    {
         "name": "Speaker Deck",
         "url": "https://speakerdeck.com/account",
         "difficulty": "easy",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -15731,7 +15731,7 @@
         "url": "https://www.spccard.ca/privacy-policy",
         "difficulty": "impossible",
         "email": "privacy@spccard.ca",
-        "notes": "According to their privacy policy, emailing <a href=\"mailto:privacy@spccard.ca\">privacy@spccard.ca</a> should be sufficient for data deletion, but this email is unresponsive.",
+        "notes": "According to their privacy policy, emailing should be sufficient for data deletion, but they are unresponsive.",
         "domains": [
             "spccard.ca",
             "www.spccard.ca"


### PR DESCRIPTION
Although their privacy policy states that data deletion can be requested by emailing privacy@spccard.ca, they have been unresponsive for months leading to the impossible classification.