### PR TITLE
Update Gnome to easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7027,17 +7027,16 @@
 
     {
         "name": "GNOME",
-        "url": "https://www.gnome.org/privacy-policy/",
-        "difficulty": "hard",
-        "email": "info@gnome.org",
-        "notes": "Account deletion requires contacting Customer Support.",
-        "notes_tr": "Hesabınızın silinmesi için müşteri hizmetleri ile iletişime geçmeniz gerekir.",
-        "notes_fr": "Pour supprimer votre compte contactez le support.",
-        "notes_it": "La cancellazione account richiede di contattare il servizio clienti.",
-        "notes_de": "Account-Löschung erfordert es den Kundensupport zu kontaktieren",
-        "notes_pt_br": "Para deletar a sua conta contate a assistência ao cliente",
-        "notes_cat": "Per esborrar el seu compte contacti amb l'assistència al client",
-        "notes_es": "Para borrar tu cuenta contacta con asistencia al cliente",
+        "url": "https://extensions.gnome.org/accounts/settings",
+        "difficulty": "medium",
+        "notes": "In the section Account removal, you need to accept the option delete your account, and input your password.",
+        "notes_tr": "Hesap kaldırma bölümünde, hesabınızı silme seçeneğini kabul etmeniz ve şifrenizi girmeniz gerekiyor.",
+        "notes_fr": "Dans la section Suppression de compte, vous devez accepter l'option supprimer votre compte et saisir votre mot de passe.",
+        "notes_it": "Nella sezione Rimozione account, è necessario accettare l'opzione elimina il tuo account e inserire la tua password.",
+        "notes_de": "Im Abschnitt Konto entfernen müssen Sie die Option Ihr Konto löschen akzeptieren und Ihr Passwort eingeben.",
+        "notes_pt_br": "Na seção Remoção de conta, você precisa aceitar a opção de excluir sua conta e inserir sua senha.",
+        "notes_cat": "A la secció Eliminació de compte, cal que accepteu l'opció d'eliminar el vostre compte i introduir la vostra contrasenya.",
+        "notes_es": "En la sección Eliminación de cuenta, debes aceptar la opción de eliminar tu cuenta e ingresar tu contraseña.",
         "domains": [
             "gnome.org"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7028,15 +7028,8 @@
     {
         "name": "GNOME",
         "url": "https://extensions.gnome.org/accounts/settings",
-        "difficulty": "medium",
+        "difficulty": "easy",
         "notes": "In the section Account removal, you need to accept the option delete your account, and input your password.",
-        "notes_tr": "Hesap kaldırma bölümünde, hesabınızı silme seçeneğini kabul etmeniz ve şifrenizi girmeniz gerekiyor.",
-        "notes_fr": "Dans la section Suppression de compte, vous devez accepter l'option supprimer votre compte et saisir votre mot de passe.",
-        "notes_it": "Nella sezione Rimozione account, è necessario accettare l'opzione elimina il tuo account e inserire la tua password.",
-        "notes_de": "Im Abschnitt Konto entfernen müssen Sie die Option Ihr Konto löschen akzeptieren und Ihr Passwort eingeben.",
-        "notes_pt_br": "Na seção Remoção de conta, você precisa aceitar a opção de excluir sua conta e inserir sua senha.",
-        "notes_cat": "A la secció Eliminació de compte, cal que accepteu l'opció d'eliminar el vostre compte i introduir la vostra contrasenya.",
-        "notes_es": "En la sección Eliminación de cuenta, debes aceptar la opción de eliminar tu cuenta e ingresar tu contraseña.",
         "domains": [
             "gnome.org"
         ]
@@ -8798,7 +8791,7 @@
             "intelx.io"
         ]
     },
-    
+
     {
         "name": "Interactive Brokers",
         "url": "https://www.interactivebrokers.com/RegTemplates/PDF/closeAccount.pdf",


### PR DESCRIPTION
# Summary

This PR changed the removal "difficulty" from "hard" to "medium" as gnome.org allow easier account deletion.

## Screenshots

| Scope | Screenshot |
|---|---|
| Account removal section |<img width="1440" alt="image" src="https://github.com/jdm-contrib/jdm/assets/48123439/a6a515ca-c123-4fa7-91d0-198664d9530d"> |
| Confirmation email | <img width="690" alt="image" src="https://github.com/jdm-contrib/jdm/assets/48123439/97ed8e45-d386-4500-9915-0c88f65044a3"> |
