### PR TITLE
Remove app store language from limited guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The sites, urls and additional notes are stored in `_data/sites.json`. If you wa
   - `easy`: Sites with a simple process such as a 'delete account' button
   - `medium`: Sites that do allow account deletion but require you to perform additional steps
   - `hard`: Sites that require you to contact customer services or those that don't allow automatic or easy account deletion
-  - `limited`: Sites that only allow you to delete your account if you live in an area with privacy rights or where otherwise required to by a policy (e.g the iOS App Store). These are only used for websites that require proof that you are covered by local law or policy and verify it.
+  - `limited`: Sites that only allow you to delete your account if you live in an area with privacy rights. This is only used for websites that require proof that you are covered by local law and verify it.
   - `impossible`: For sites where it's basically impossible to totally delete your account, even if you contact them
 - `notes`: *(optional)* Notes will be shown when someone hovers on that service. Notes may include additional information you might need to delete your account (e.g. Skype) or consequences of deleting your account (e.g. iTunes). If you are drastically changing existing notes, do delete its translations, unless you have proficiency in one or more of them.
 - `notes_CODE`: *(optional)* Use the language `CODE` as suffix of the `notes` field to provide language-specific instructions, shown on the respective language page.

--- a/_data/trans/ar.json
+++ b/_data/trans/ar.json
@@ -22,7 +22,7 @@
     "guideexplanations": "الرصلات ملونة لتعلم المتصفح بمستوى صعوبة حذف حسابك في المواقع المدرجة",
     "guidehard": "لا يمكن مسحه بصفة نهائية حتى تتصل بدعم الموقع",
     "guideimpossible": "لا يمكن حذفه",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "تحتاج مراحل إضافية",
     "hideinfo": "حجب العلومات...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/cat.json
+++ b/_data/trans/cat.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Els enllaços de la part superior s'han classificat amb un codi de colors per indicar la dificultat per suprimir el compte:",
     "guidehard": "No es pot suprimir permanentment sense contactar amb atenció al client",
     "guideimpossible": "No es pot suprimir",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "S'han de realitzar alguns passos",
     "hideinfo": "amagar informació",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/cz.json
+++ b/_data/trans/cz.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Odkazy jsou barevně označeny tak, aby naznačovali obtížnost smazání účtu:",
     "guidehard": "Nemůžou být zcela smazány bez kontaktování podpory",
     "guideimpossible": "Nemůžou být smazány",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Potřeba provést několik kroky navíc",
     "hideinfo": "skrýt podrobnosti...",
     "jgmd": "Navštivte Just Get My Data",

--- a/_data/trans/en.json
+++ b/_data/trans/en.json
@@ -22,7 +22,7 @@
     "guideexplanations": "The links above are colour-coded to indicate the difficulty level of account deletion:",
     "guidehard": "Cannot be fully deleted without contacting customer services",
     "guideimpossible": "Cannot be deleted",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Some extra steps involved",
     "hideinfo": "hide info...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/es.json
+++ b/_data/trans/es.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Los enlaces de la parte superior se han clasificado con un código de colores para indicar la dificultad para suprimir la cuenta:",
     "guidehard": "No se puede suprimir permanentemente sin contactar con atención al cliente",
     "guideimpossible": "No puede ser eliminada",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Se tendrán que hacer algunos pasos extra",
     "hideinfo": "esconder información",
     "jgmd": "Visita Just Get My Data",

--- a/_data/trans/fa.json
+++ b/_data/trans/fa.json
@@ -22,7 +22,7 @@
     "guideexplanations": "پیوند‌های بالا برپایه‌ی دشواری حذف حساب، رنگ‌بندی شده‌اند:",
     "guidehard": "لازم به تماس با خدمات مشتری سایت برای حذف کامل",
     "guideimpossible": "غیر قابل حذف",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "شامل مراحل اضافی",
     "hideinfo": "مخفی کردن...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/fr.json
+++ b/_data/trans/fr.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Les liens ci-dessus utilisent un code-couleur pour indiquer le niveau de difficulté de la suppression de compte :",
     "guidehard": "Ne peut être totalement supprimé sans contacter le support",
     "guideimpossible": "Ne peut être supprimé",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Étapes supplémentaires requises",
     "hideinfo": "cacher les infos...",
     "jgmd": "Visitez Just Get My Data",

--- a/_data/trans/gr.json
+++ b/_data/trans/gr.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Οι παραπάνω σύνδεσμοι είναι προγραμματισμένοι με χρώμα για να προσδιορίσουν το επίπεδο δυσκολίας σχετικά με την διαγραφή του λογαριασμού:",
     "guidehard": "Δεν είναι δυνατή η πλήρης διαγραφή χωρίς να επικοινωνήσετε πρώτα με την υποστήριξη πελατών",
     "guideimpossible": "Δεν είναι δυνατή η διαγραφή",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Απαιτούνται κάποιες επιπλέον ενέργειες",
     "hideinfo": "Απόκρυψη Πληροφοριών...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/id.json
+++ b/_data/trans/id.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Warna tautan di atas menunjukkan level kesulitan akun yang akan dihapus:",
     "guidehard": "Tidak bisa dihapus sepenuhnya tanpa menghubungi customer service",
     "guideimpossible": "Tidak bisa dihapus",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Butuh langkah ekstra untuk dilakukan",
     "hideinfo": "sembunyikan info...",
     "jgmd": "Hampiri Just Get My Data",

--- a/_data/trans/nl.json
+++ b/_data/trans/nl.json
@@ -22,7 +22,7 @@
     "guideexplanations": "De links hierboven zijn kleur-gecodeerd om de moeilijkheidsgraad voor account verwijdering aan te geven:",
     "guidehard": "Kan niet volledig worden verwijderd zonder contact met de klanten service",
     "guideimpossible": "Kan niet worden verwijderd",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Extra stappen nodig",
     "hideinfo": "verberg informatie...",
     "jgmd": "Bezoek Just Get My Data",

--- a/_data/trans/pl.json
+++ b/_data/trans/pl.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Linki powyżej zawierają kolorowy kod aby pokazać poziom trudności usunięcia konta:",
     "guidehard": "Nie może być całkowicie usunięte bez skontaktowania z obsługą",
     "guideimpossible": "Nie może być usunięte",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Potrzeba kilka dodatkowych kroków",
     "hideinfo": "ukryj info...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/pt_pt.json
+++ b/_data/trans/pt_pt.json
@@ -22,7 +22,7 @@
     "guideexplanations": "As hiperligações acima estão coloridas conforme o nível de dificuldade da eliminação da conta:",
     "guidehard": "Não pode ser totalmente eliminada sem contactar a assistência ao cliente",
     "guideimpossible": "Não pode ser eliminada",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "São necessários alguns passos adicionais",
     "hideinfo": "esconder informações...",
     "jgmd": "Visite o Just Get My Data",

--- a/_data/trans/ro.json
+++ b/_data/trans/ro.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Linkurile sunt colorate pentru a arăta dificultatea cu care îți poți șterge contul pe respectivul site:",
     "guidehard": "Poate fi șters doar dacă prin contactarea serviciului clienți (support)",
     "guideimpossible": "Nu poate fi șters",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Unii pași, dar destul de simplu",
     "hideinfo": "ascunde informații...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/sk.json
+++ b/_data/trans/sk.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Linky hore sú farebne rozlíšené podľa obtiažnosti vymazania:",
     "guidehard": "Nemožné úplne vymazať bez kontaktovania zakazníckych služieb spoločnosti",
     "guideimpossible": "Nemožné vymazať",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Nutné kroky naviac",
     "hideinfo": "skryť informácie...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/sr.json
+++ b/_data/trans/sr.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Везе изнад су означене бојама да би приказале ниво тешкоће брисања налога:",
     "guidehard": "не може да се обрише у потпуности без контактирања корисничке подршке",
     "guideimpossible": "не може да се обрише",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "потребни су неки додатни кораци",
     "hideinfo": "сакриј податке...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/th.json
+++ b/_data/trans/th.json
@@ -22,7 +22,7 @@
     "guideexplanations": "ลิ้งข้างบนแสดงความยากง่ายในการลบบัญชีด้วยสีที่แตกต่างกัน:",
     "guidehard": "จำเป็นต้องติดต่อฝ่ายบริการลูกค้า",
     "guideimpossible": "ไม่สามารถลบได้",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "ต้องออกแรงนิดหน่อย",
     "hideinfo": "ซ่อนข้อมูล...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/vi.json
+++ b/_data/trans/vi.json
@@ -22,7 +22,7 @@
     "guideexplanations": "Những đường dẫn trên được đánh dấu bằng màu theo độ khó của việc xóa tài khoản:",
     "guidehard": "Không xóa được nếu không liên hệ bộ phận dịch vụ khách hàng",
     "guideimpossible": "Không thể xóa được",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "Cần có thêm một số thao tác bổ sung",
     "hideinfo": "ẩn thông tin...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/zh-cn.json
+++ b/_data/trans/zh-cn.json
@@ -22,7 +22,7 @@
     "guideexplanations": "上述链接的不同颜色表明帐号注销的难度分级:",
     "guidehard": "联系客服, 才能注销",
     "guideimpossible": "不能注销",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "一些必需步骤",
     "hideinfo": "收起信息...",
     "jgmd": "Visit Just Get My Data",

--- a/_data/trans/zh-tw.json
+++ b/_data/trans/zh-tw.json
@@ -22,7 +22,7 @@
     "guideexplanations": "上述連結不同的顏色用以表示刪除帳號的難易程度：",
     "guidehard": "需要聯絡客服才可刪除",
     "guideimpossible": "無法刪除",
-    "guidelimited": "Account can only be deleted if you live in a location with privacy rights or are covered by an applicable policy such as the iOS App Store guidelines",
+    "guidelimited": "Account can only be deleted if you live in a location with privacy rights",
     "guidemedium": "需要額外步驟",
     "hideinfo": "隱藏訊息...",
     "jgmd": "Visit Just Get My Data",


### PR DESCRIPTION
[Google Play has introduced their account deletion requirement](https://support.google.com/googleplay/android-developer/answer/13327111)

Given that you can run an android emulator and sideload the necessary apk on any computer that isn't a potato, it doesn't make sense to mark those entries as limited anymore.

