### PR TITLE
Add Withings as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19404,6 +19404,20 @@
     },
 
     {
+        "name": "Withings",
+        "url": "https://account.withings.com/account/account_delete",
+        "difficulty": "easy",
+        "notes": "You can delete your account after logging in, in one click from the user settings page. You can also choose to have your data sent to you first. The deletion process takes 7 days.",
+        "domains": [
+            "withings.com",
+            "account.withings.com",
+            "blog.withings.com",
+            "healthmate.withings.com",
+            "support.withings.com"
+        ]
+    },
+
+    {
         "name": "Wix",
         "url": "https://manage.wix.com/account/close-account",
         "difficulty": "medium",


### PR DESCRIPTION
This closes #1794.

I added these additional domains to the one suggested in the ticket:
* `account.withings.com`
* `blog.withings.com`
* `healthmate.withings.com`
* `support.withings.com`