### PR TITLE
Add Bikemap as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2007,7 +2007,7 @@
         "domains": [
             "bigstockphoto.com"
         ]
-    },   
+    },
 
     {
         "name": "Bikemap",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2007,6 +2007,18 @@
         "domains": [
             "bigstockphoto.com"
         ]
+    },   
+
+    {
+        "name": "Bikemap",
+        "url": "https://www.bikemap.net/",
+        "difficulty": "easy",
+        "notes": "Login, click settings, click 'Delete Account', confirm.",
+        "domains": [
+            "bikemap.net",
+            "blog.bikemap.net",
+            "help.bikemap.net"
+        ]
     },
 
     {


### PR DESCRIPTION
This closes #1795.

I added these additional domains to the one suggested in the ticket:

* `blog.bikemap.net`
* `help.bikemap.net`

Also, since `url` is a required field I set it to `https://www.bikemap.net/`. Sadly we can't be any more specific, since the actual link for deleting the account includes `u/<username>`.