### PR TITLE
Add The Epoch Times as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5464,6 +5464,40 @@
     },
 
     {
+        "name": "Epoch Times",
+        "url": "https://help.theepochtimes.com/hc/en-us/requests/new",
+        "difficulty": "hard",
+        "notes": "Send a request to customer support demanding for the deletion of your account.",
+        "domains": [
+            "reader.epoch.cloud",
+            "epochtimes.bg",
+            "epochtimes.com",
+            "epochtimes.com.au",
+            "epochtimes.com.br",
+            "epochtimes.cz",
+            "epochtimes.de",
+            "epochtimes.fr",
+            "epochtimes.it",
+            "epochtimes.jp",
+            "epochtimes.nl",
+            "epochtimes.pl",
+            "epochtimes.ru",
+            "epochtimes.se",
+            "epochtimes.sk",
+            "epochtimes-romania.com",
+            "epochtimestr.com",
+            "epochtimesviet.com",
+            "erabaru.net",
+            "help.theepochtimes.com",
+            "persianepochtimes.com",
+            "theepochtimes.com",
+            "es.theepochtimes.com",
+            "kr.theepochtimes.com",
+            "theepochtimes.gr"
+        ]
+    },
+
+    {
         "name": "eProject.me",
         "url": "https://eproject.me",
         "difficulty": "hard",
@@ -17075,40 +17109,6 @@
         "notes": "If you want to permanently delete your Textures.com account, go to the <a href='https://www.textures.com/my-account/delete'><b>Delete Account</b> tab on your account</a> fill out your password and press <b>Delete My Account</b>.",
         "domains": [
             "textures.com"
-        ]
-    },
-
-    {
-        "name": "The Epoch Times",
-        "url": "https://help.theepochtimes.com/hc/en-us/requests/new",
-        "difficulty": "hard",
-        "notes": "Send a request to customer support demanding for the deletion of your account.",
-        "domains": [
-            "reader.epoch.cloud",
-            "epochtimes.bg",
-            "epochtimes.com",
-            "epochtimes.com.au",
-            "epochtimes.com.br",
-            "epochtimes.cz",
-            "epochtimes.de",
-            "epochtimes.fr",
-            "epochtimes.it",
-            "epochtimes.jp",
-            "epochtimes.nl",
-            "epochtimes.pl",
-            "epochtimes.ru",
-            "epochtimes.se",
-            "epochtimes.sk",
-            "epochtimes-romania.com",
-            "epochtimestr.com",
-            "epochtimesviet.com",
-            "erabaru.net",
-            "help.theepochtimes.com",
-            "persianepochtimes.com",
-            "theepochtimes.com",
-            "es.theepochtimes.com",
-            "kr.theepochtimes.com",
-            "theepochtimes.gr"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -17079,6 +17079,40 @@
     },
 
     {
+        "name": "The Epoch Times",
+        "url": "https://help.theepochtimes.com/hc/en-us/requests/new",
+        "difficulty": "hard",
+        "notes": "Send a request to customer support demanding for the deletion of your account.",
+        "domains": [
+            "reader.epoch.cloud",
+            "epochtimes.bg",
+            "epochtimes.com",
+            "epochtimes.com.au",
+            "epochtimes.com.br",
+            "epochtimes.cz",
+            "epochtimes.de",
+            "epochtimes.fr",
+            "epochtimes.it",
+            "epochtimes.jp",
+            "epochtimes.nl",
+            "epochtimes.pl",
+            "epochtimes.ru",
+            "epochtimes.se",
+            "epochtimes.sk",
+            "epochtimes-romania.com",
+            "epochtimestr.com",
+            "epochtimesviet.com",
+            "erabaru.net",
+            "help.theepochtimes.com",
+            "persianepochtimes.com",
+            "theepochtimes.com",
+            "es.theepochtimes.com",
+            "kr.theepochtimes.com",
+            "theepochtimes.gr"
+        ]
+    },
+
+    {
         "name": "TheMovieDB",
         "url": "https://www.themoviedb.org/settings/delete-account",
         "difficulty": "easy",


### PR DESCRIPTION
This closes #1801.

I added these domains in addition to the one suggested in the ticket:
* `reader.epoch.cloud`
* `epochtimes.bg`
* `epochtimes.com`
* `epochtimes.com.au`
* `epochtimes.com.br`
* `epochtimes.cz`
* `epochtimes.de`
* `epochtimes.fr`
* `epochtimes.it`
* `epochtimes.jp`
* `epochtimes.nl`
* `epochtimes.pl`
* `epochtimes.ru`
* `epochtimes.se`
* `epochtimes.sk`
* `epochtimes-romania.com`
* `epochtimestr.com`
* `epochtimesviet.com`
* `erabaru.net`
* `help.theepochtimes.com`
* `persianepochtimes.com`
* `theepochtimes.com`
* `es.theepochtimes.com`
* `kr.theepochtimes.com`
* `theepochtimes.gr`