### PR TITLE
Update Holopin

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -8202,7 +8202,7 @@
 
     {
         "name": "Holopin",
-        "email": "team@holopin.io",
+        "email": "support@holopin.io",
         "url": "https://www.holopin.io/privacy.html",
         "difficulty": "hard",
         "notes": "Account deletion requires contacting Customer Support.",
@@ -8214,8 +8214,9 @@
         "notes_cat": "Per esborrar el seu compte contacti amb l'assistència al client",
         "notes_es": "Para borrar tu cuenta contacta con asistencia al cliente",
         "domains": [
-            "https://www.holopin.com",
-            "holopin.io"
+            "holopin.io",
+            "blog.holopin.io",
+            "docs.holopin.io"
         ]
     },
 


### PR DESCRIPTION
* Holopin now uses `support@holopin.io` instead of `team@holopin.io`.
* added `blog.holopin.io` and `docs.holopin.io` as domains