### PR TITLE
Check for duplicate entries

### DIFF
--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -18,6 +18,7 @@ module ExitCodes
     UNEXPECTED_LANGUAGE_KEY = 10   # Unexpected language key for translation
     UNSUPPORTED_FIELD = 11         # Unsupported field for site entry
     UNEXPECTED_NOTES = 12          # Unexpected notes key for translation
+    DUPLICATES = 13                # Duplicate entries
 end
 
 SupportedDifficulties = ["easy", "medium", "hard", "limited", "impossible"]
@@ -178,6 +179,13 @@ json_files.each do |file|
         json = JSON.parse(File.read(file))
         is_sites_json = File.basename(file) =~ /sites.json/
         keys_in_language_json = []
+
+        # check for duplicates
+        if json.uniq.length != json.length
+            STDERR.puts file + " contains duplicates"
+            exit ExitCodes::DUPLICATES
+        end
+
         # check for alphabetical ordering
         json.each_with_index do |(key, _), i|
             # sites.json is an array of objects; this would expand to:


### PR DESCRIPTION
The validate_json workflow now checks for duplicate entries. This closes #1810.