### PR TITLE
Update chrome web store link

### DIFF
--- a/_includes/body.html
+++ b/_includes/body.html
@@ -102,7 +102,7 @@
                     {% assign post_extension_link_text = '.' %}
                 {% endif %}
                 {{ site.data.trans[page.lang].extensionp2|safe }}
-                <a target='_blank' href='https://chrome.google.com/webstore/detail/justdeleteme/hfpofkfbabpbbmchmiekfnlcgaedbgcf'>{{ site.data.trans[page.lang].extensionp3|safe }}</a>
+                <a target='_blank' href='https://chrome.google.com/webstore/detail/just-delete-me/dlhckcablohllindinahbbpnfgblimoe'>{{ site.data.trans[page.lang].extensionp3|safe }}</a>
                 /
                 <a target='_blank' href='https://addons.mozilla.org/en-US/firefox/addon/justdeleteme/'>{{ site.data.trans[page.lang].extensionp4|safe }}</a>{{ post_extension_link_text }}
             </p>


### PR DESCRIPTION
The old link no longer works, not sure why. This new link seems to be the only extension available on the store.

The extension probably needs to be checked to make sure it's not malicious if the author is different from expected.

Old Link: https://chrome.google.com/webstore/detail/justdeleteme/hfpofkfbabpbbmchmiekfnlcgaedbgcf
New Link: https://chrome.google.com/webstore/detail/just-delete-me/dlhckcablohllindinahbbpnfgblimoe