### PR TITLE
Add webhosting.dk

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19578,7 +19578,7 @@
     {
         "name": "Webex - Free Account",
         "url": "https://help.webex.com/en-us/5m4i4y/Delete-Your-Free-Webex-Account#id_111643",
-        "difficulty": "easy",
+        "difficulty": "medium",
         "notes": "Just follow the settings to find the delete account button and click it",
         "notes_tr": "Hesabı sil düğmesini bulmak için ayarları takip edin ve tıklayın.",
         "domains": [

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19591,8 +19591,8 @@
     {
         "name": "Webhosting.dk",
         "url": "https://www.webhosting.dk/DKK/deleteaccount.php",
-        "difficulty": "easy",
-        "notes": "Due to a legal requirement to retain information for the last 5 financial years, user accounts cannot be deleted even if they are no longer in use. This retention is necessary because the accounts are linked to domain names, payment details with Nets, and invoices, as mandated by law.",
+        "difficulty": "hard",
+        "notes": "The service claims to be required by law to retain information for the last 5 financial years, and doesn't allow you to delete it. Your account must be inactive for 5 full years before you can delete it.",
         "domains": [
             "webhosting.dk"
         ]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19578,7 +19578,7 @@
     {
         "name": "Webex - Free Account",
         "url": "https://help.webex.com/en-us/5m4i4y/Delete-Your-Free-Webex-Account#id_111643",
-        "difficulty": "medium",
+        "difficulty": "easy",
         "notes": "Just follow the settings to find the delete account button and click it",
         "notes_tr": "Hesabı sil düğmesini bulmak için ayarları takip edin ve tıklayın.",
         "domains": [

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19589,6 +19589,16 @@
     },
 
     {
+        "name": "Webhosting.dk",
+        "url": "https://www.webhosting.dk/DKK/deleteaccount.php",
+        "difficulty": "easy",
+        "notes": "Due to a legal requirement to retain information for the last 5 financial years, user accounts cannot be deleted even if they are no longer in use. This retention is necessary because the accounts are linked to domain names, payment details with Nets, and invoices, as mandated by law.",
+        "domains": [
+            "webhosting.dk"
+        ]
+    },
+
+    {
         "name": "Weblate",
         "url": "https://hosted.weblate.org/accounts/remove/",
         "difficulty": "easy",


### PR DESCRIPTION
Adds [Webhosting.dk](https://www.webhosting.dk/?nl=ENG).

## About the difficulty

**TL;DR** I've set the difficulty to **hard**, as you'd have to wait 5 full years in order to be allowed to go trough with the deletion.

In theory, the deletion is simple, as you just need to visit the provided link and login to delete one's account. However, according to the company, due to a legal requirement to retain information for the last 5 financial years, user accounts cannot be deleted even if they are no longer in use. This retention is necessary because the accounts are linked to domain names, payment details with Nets, and invoices, as mandated by law.

In other words, one must wait 5 fulls years. 

The company are, in fact, _allowed_ (although not _permitted_, as they claim) to retain this info.
I'm extremely annoyed, that I cannot just issue a deletion, that'll take effect when my account meets their criteria. Instead, I'm supposed to remember to delete this in five years myself.