### PR TITLE
Update Crunchyroll

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4154,9 +4154,9 @@
 
     {
         "name": "Crunchyroll",
-        "url": "https://help.crunchyroll.com/hc/en-us/requests/new",
-        "difficulty": "hard",
-        "notes": "You can only have the account deleted through a support request.",
+        "url": "https://github.com/jdm-contrib/jdm/issues/1895",
+        "difficulty": "limited",
+        "notes": "If you live in California, use the [CCPA Request Form](https://privacyportal.onetrust.com/webform/d19e506f-1a64-463d-94e4-914dd635817d/fc46fc0c-407c-4735-9a43-14dfa283d17c). Otherwise, use the [All Other Requests Form](https://sites.sonypictures.com/corp/privacypolicies/b2c/contact-us.html).\n\nSelect \"Crunchyroll/Crunchyroll Games\" as your service.",
         "domains": [
             "crunchyroll.com",
             "help.crunchyroll.com"


### PR DESCRIPTION
Change url to a discussion that explains why Crunchyroll doesn't have a proper url. The Crunchyroll entry doesn't follow the url requirements due to the following reasons:

* Crunchyroll doesn't have an account deletion page.

* Crunchyroll auto closes account deletion support tickets.

* Crunchyroll has an account deletion help page with false information.

* Crunchyroll has multiple distinct forms to request account deletion depending on the jurisdiction.

Update difficulty from hard to limited. Crunchyroll only handles requests to exercise rights. If your jurisdiction doesn't have a right to data erasure, then you're out of luck.

Update notes to reflect new account deletion procedure.

Link: https://github.com/jdm-contrib/jdm/issues/1895