### PR TITLE
Add Kino.dk

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10173,6 +10173,19 @@
     },
 
     {
+        "name": "Kino.dk",
+        "url": "https://kino.dk/user",
+        "difficulty": "hard",
+        "notes": "",
+        "email": "kontakt@kino.dk",
+        "email_subject": "Sletning af profil",
+        "email_body": "Jeg ønsker at slette min konto hos jer. Tak.",
+        "domains": [
+            "kino.dk"
+        ]
+    },
+
+    {
         "name": "Kistania",
         "url": "https://www.kistania.com/pages/contact-us",
         "difficulty": "impossible",


### PR DESCRIPTION
Adds [Kino.dk](https://kino.dk/) as hard.

It's a Danish service for theaters, which is why the email stuff is in Danish.