### PR TITLE
Add TV 2

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -18771,6 +18771,18 @@
     },
 
     {
+        "name": "TV 2",
+        "url": "https://mit.tv2.dk/konto/luk",
+        "difficulty": "easy",
+        "notes": "Go to your account page and press 'Slet konto'.",
+        "domains": [
+            "tv2.dk",
+            "mit.tv2.dk",
+            "play.tv2.dk"
+        ]
+    },
+
+    {
         "name":"TV Tropes",
         "url":"https://tvtropes.org/pmwiki/profile.php",
         "difficulty": "easy",
@@ -19738,18 +19750,6 @@
         "domains": [
             "helpcenter.washingtonpost.com",
             "washingtonpost.com"
-        ]
-    },
-
-    {
-        "name": "TV 2",
-        "url": "https://mit.tv2.dk/konto/luk",
-        "difficulty": "easy",
-        "notes": "Go to your account page and press 'Slet konto'.",
-        "domains": [
-            "tv2.dk",
-            "mit.tv2.dk",
-            "play.tv2.dk"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19742,6 +19742,18 @@
     },
 
     {
+        "name": "TV 2",
+        "url": "https://mit.tv2.dk/konto/luk",
+        "difficulty": "easy",
+        "notes": "Go to your account page and press 'Slet konto'.",
+        "domains": [
+            "tv2.dk",
+            "mit.tv2.dk",
+            "play.tv2.dk"
+        ]
+    },
+
+    {
         "name": "Watch2Gether",
         "url": "https://w2g.tv/users/current_user",
         "difficulty": "easy",


### PR DESCRIPTION
Adds the Danish broadcast and subscription TV station "[TV 2](https://tv2.dk)" as easy to delete. 
This includes their streaming service "[TV 2 Play](https://play.tv2.dk)".