### PR TITLE
Update search

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -33,8 +33,29 @@ $(function(){
             var siteUrl = siteHeader.href.toLowerCase();
             var lowerTerm = term.toLowerCase();
 
-            // returns true if lowerTerm isn't found in site title or URL
-            return Math.max(siteTitle.indexOf(lowerTerm), siteUrl.indexOf(lowerTerm)) === -1;
+            // split words at spaces/dashes (' ' and '-')
+            const splitTerm = lowerTerm.trim().split(/ |-/g);
+            const splitTitle = siteTitle.trim().split(/ |-/g)
+           
+            // don't hide if part of term is included in title
+            for (let i = 0; i < splitTerm.length; i++) {
+               if (siteTitle.indexOf(splitTerm[i]) != -1) {
+                 return false;
+               }
+            }
+            // don't hide if substantial part (length > 2) of title is included in term
+            for (let i = 0; i < splitTitle.length; i++) {
+                if (lowerTerm.indexOf(splitTitle[i]) != -1 && splitTitle[i].length > 2) {
+                  return false;
+                }
+            }
+            // don't hide if term is included in url
+            if (siteUrl.indexOf(lowerTerm) != -1) {
+                return false;
+            }
+           
+            // else, hide
+            return true;
         });
 
         // Insert the term into the search field

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -35,22 +35,27 @@ $(function(){
 
             // split words at spaces/dashes (' ' and '-')
             const splitTerm = lowerTerm.trim().split(/ |-/g);
-            const splitTitle = siteTitle.trim().split(/ |-/g)
+            const splitTitle = siteTitle.trim().split(/ |-/g);
+            const siteDomain = siteUrl.match(/(?<=http(?:s?):\/\/)[^\/]+/)[0];
            
-            // don't hide if part of term is included in title
+            // don't hide if substantial part (length > 3) of term is included in title
             for (let i = 0; i < splitTerm.length; i++) {
-               if (siteTitle.indexOf(splitTerm[i]) != -1) {
+               if (siteTitle.indexOf(splitTerm[i]) != -1 && splitTerm[i].length > 3) {
                  return false;
                }
             }
-            // don't hide if substantial part (length > 2) of title is included in term
+            // don't hide if substantial part (length > 3) of title is included in term
             for (let i = 0; i < splitTitle.length; i++) {
-                if (lowerTerm.indexOf(splitTitle[i]) != -1 && splitTitle[i].length > 2) {
+                if (lowerTerm.indexOf(splitTitle[i]) != -1 && splitTitle[i].length > 3) {
                   return false;
                 }
             }
             // don't hide if term is included in url
-            if (siteUrl.indexOf(lowerTerm) != -1) {
+            if (siteDomain.indexOf(lowerTerm) != -1) {
+                return false;
+            }
+            // if other options fail, default to old search
+            if (Math.max(siteTitle.indexOf(lowerTerm), siteUrl.indexOf(lowerTerm)) != -1) {
                 return false;
             }
            


### PR DESCRIPTION
I tried to update the search functionality. My suggestion is by no means a perfect solution and still has various issues, but it has a few improvements, namely:

* split searches, e.g. searching for ["treenation"](https://justdeleteme.xyz/#treenation) or ["tree nation"](https://justdeleteme.xyz/#tree%20nation) would now also show the result ["tree-nation"](https://justdeleteme.xyz/#tree-nation), which is currently not the case
* part searches, e.g. searching for ["proton calendar"](https://justdeleteme.xyz/#proton%20calendar) will now show the appropriate result ["proton"](https://justdeleteme.xyz/#proton)

This comes with one major downside. Searching for something like ["Time and Date"](https://justdeleteme.xyz/#Time%20and%20Date), which is clearly supposed to be www.timeanddate.com will lead to various other results including the word "time" or "date", like the ["New York Times"](https://justdeleteme.xyz/#New%20York%20Times).
I still think this could become useful for users, I'd just like to hear your opinion and maybe get some help with fixing this issue.

EDIT: Maybe one solution for the issue of finding unrelated things could be by sorting entries based on similarity to the search term, instead of alphabetically. That way users would get the most relevant result first, while still being able to find similar things.

EDIT2: Just realized, should have made an issue to discuss this instead of a PR, but this was the easiest way to share my code, so please ignore that.