### PR TITLE
Add STEP as impossible

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -17550,21 +17550,21 @@
     },
 
     {
-        "name": "StepMap",
-        "url": "https://www.stepmap.de/profile.html#profile_delete",
-        "difficulty": "hard",
-        "domains": [
-            "stepmap.de"
-        ]
-    },
-
-    {
         "name": "STEP (Smart Traveler Enrollment Program)",
         "url": "https://step.state.gov",
         "difficulty": "impossible",
         "notes": "No self-serve options are available, and they will not delete accounts because \"Profile deletion requires an enormous amount of data about yourself, and your trips, which places users at risk for potential fraud issues\"",
         "domains": [
             "step.state.gov"
+        ]
+    },
+
+    {
+        "name": "StepMap",
+        "url": "https://www.stepmap.de/profile.html#profile_delete",
+        "difficulty": "hard",
+        "domains": [
+            "stepmap.de"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -17559,6 +17559,16 @@
     },
 
     {
+        "name": "STEP (Smart Traveler Enrollment Program)",
+        "url": "https://step.state.gov",
+        "difficulty": "impossible",
+        "notes": "No self-serve options are available, and they will not delete accounts because \"Profile deletion requires an enormous amount of data about yourself, and your trips, which places users at risk for potential fraud issues\"",
+        "domains": [
+            "step.state.gov"
+        ]
+    },
+
+    {
         "name": "StickK",
         "difficulty": "hard",
         "url": "https://stickk.zendesk.com/hc/en-us/requests/new",


### PR DESCRIPTION
I asked the Department of State about it and their reply was:

```
Hello,  
 
Thank you for contacting us with regards to your STEP Enrollment.  
 
Unfortunately at this time, we are currently unable to provide profile deletion services. Profile deletion requires an enormous amount of data about yourself, and your trips, which places users at risk for potential fraud issues. Please be assured that your information will never be distributed and will only be used by the U.S. Department of State for Smart Traveler Enrollment Program’s purposes. Please also note that having an inactive account does not affect your enrollment status nor pose any security risk to you.   
 
We sincerely apologize for the inconvenience. Please let us know if you have any additional questions regarding STEP. 
 
Regards, 
The STEP Team
```