### PR TITLE
Added Threads to sites list

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -18666,6 +18666,17 @@
     },
 
     {
+        "name": "Threads",
+        "url": "https://www.instagram.com/accounts/remove/request/permanent/",
+        "difficulty": "impossible",
+        "notes": "You must submit a request to close your INSTAGRAM account via form.",
+        "notes_es": "Deberás solicitar que borren tu cuenta de INSTAGRAM vía formulario.",
+        "domains": [
+            "threads.net"
+        ]
+    },
+
+    {
         "name": "Threema",
         "url": "https://myid.threema.ch/revoke",
         "difficulty": "easy",


### PR DESCRIPTION
Due to the absence of the "threads" site I decided to add it. Apparently, you cannot delete your thread account without first deleting your Instagram account, so I put the difficulty as "impossible" and the url is the same to delete your Instagram account.