### PR TITLE
Remove unnecessary ffi dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
 
-gem "ffi", ">= 1.15.0 "
 gem "jekyll", "= 4.3.0"
 gem "html-proofer", ">= 3.19.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  ffi (>= 1.15.0)
   html-proofer (>= 3.19.0)
   jekyll (= 4.3.0)
 


### PR DESCRIPTION
Not sure why we needed it and since when we stopped doing so, but it doesn't seem to affect anything.