### PR TITLE
Update html-proofer to 5.0.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "jekyll", "= 4.3.0"
-gem "html-proofer", ">= 3.19.0"
+gem "html-proofer", ">= 5.0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,48 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.1.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    afm (0.2.2)
+    async (2.8.1)
+      console (~> 1.10)
+      fiber-annotation
+      io-event (~> 1.1)
+      timers (~> 4.1)
     colorator (1.1.0)
     concurrent-ruby (1.1.10)
+    console (1.23.4)
+      fiber-annotation
+      fiber-local
+      json
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     ffi (1.15.5)
     ffi (1.15.5-x64-mingw-ucrt)
     ffi (1.15.5-x64-mingw32)
+    fiber-annotation (0.2.0)
+    fiber-local (1.0.0)
     forwardable-extended (2.6.0)
-    html-proofer (3.19.4)
+    hashery (2.1.2)
+    html-proofer (5.0.8)
       addressable (~> 2.3)
-      mercenary (~> 0.3)
+      async (~> 2.1)
       nokogiri (~> 1.13)
-      parallel (~> 1.10)
+      pdf-reader (~> 2.11)
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    io-event (1.4.4)
     jekyll (4.3.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -47,6 +63,7 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.7.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -60,9 +77,14 @@ GEM
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.12.0)
+      Ascii85 (~> 1.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     public_suffix (5.0.0)
     racc (1.7.3)
     rainbow (3.1.1)
@@ -71,6 +93,7 @@ GEM
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (4.0.0)
+    ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -78,11 +101,14 @@ GEM
       ffi (~> 1.9)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    typhoeus (1.4.0)
+    timers (4.3.5)
+    ttfunk (1.7.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     unicode-display_width (2.3.0)
     webrick (1.7.0)
     yell (2.2.2)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   ruby
@@ -91,7 +117,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  html-proofer (>= 3.19.0)
+  html-proofer (>= 5.0.8)
   jekyll (= 4.3.0)
 
 BUNDLED WITH

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,11 +10,11 @@
     <meta name="title" content="JustDeleteMe">
     <meta name="description" content="{{ site.data.trans.[page.lang].tagline }}">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ site.baseurl }}">
+    <meta property="og:url" content="https://justdeleteme.xyz/">
     <meta property="og:title" content="JustDeleteMe">
     <meta property="og:description" content="{{ site.data.trans.[page.lang].tagline }}">
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="{{ site.baseurl }}">
+    <meta property="twitter:url" content="https://justdeleteme.xyz/">
     <meta property="twitter:title" content="JustDeleteMe">
     <meta property="twitter:description" content="{{ site.data.trans.[page.lang].tagline }}">
 

--- a/script/run_jekyll.sh
+++ b/script/run_jekyll.sh
@@ -3,4 +3,4 @@ set -e # halt script on error
 
 # Build site, validate HTML
 bundle exec jekyll build
-bundle exec htmlproofer ./_site --checks-to-ignore 'LinkCheck'
+bundle exec htmlproofer ./_site --checks 'Images,Scripts,Favicon,OpenGraph'


### PR DESCRIPTION
- htmlproofer `--checks-to-ignore` was [deprecated in v4](https://github.com/gjtorikian/html-proofer/blob/main/UPGRADING.md), we now have to set the checks we want and leave out the ones we don't
- The OpenGraph check caught that we had empty `og:url` and `twitter:url`. I hardcoded them because I didn't want to fiddle with `_config.yml`, maybe that's not the best approach

PS: I tried enabling the links check, but it fails on links with direct to text reference, like [this](https://www.outdooractive.com/en/k/how-do-i-delete-my-community-account-/50323147/#:~:text=Go%20to%20your%20page%20by,then%20select%20%22Delete%20Profile%22.)