### PR TITLE
Changed URL for put.io

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -15636,7 +15636,7 @@
 
     {
         "name": "Put.io",
-        "url": "https://put.io/payment/billing",
+        "url": "https://app.put.io/account",
         "difficulty": "easy",
         "notes": "Click Destroy my account completely, then click Delete everything.",
         "notes_tr": "\"Hesabımı tamamen yok et\" öğesini ve ardından \"Her şeyi sil\" öğesini tıklayın.",


### PR DESCRIPTION
The URL where the "Destroy account" action is displayed has changed.