### PR TITLE
Add Inventory Shield as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -9874,7 +9874,7 @@
 
     {
         "name": "Inventory Shield",
-        "url": "https://inventoryshield.com/support_docs/account/",
+        "url": "https://inventoryshield.com/support_docs/user-account-details/",
         "difficulty": "easy",
         "notes": "Log in, open the menu, click \"Account Settings\", scroll to the \"Delete Your Account\" form, enter your password and click \"Confirm Deletion\".",
         "domains": [

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -9878,7 +9878,8 @@
         "difficulty": "easy",
         "notes": "Log in, open the menu, click \"Account Settings\", scroll to the \"Delete Your Account\" form, enter your password and click \"Confirm Deletion\".",
         "domains": [
-            "inventoryshield.com"
+            "inventoryshield.com",
+            "app.inventoryshield.com"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -9873,6 +9873,16 @@
     },
 
     {
+        "name": "Inventory Shield",
+        "url": "https://inventoryshield.com/support_docs/account/",
+        "difficulty": "easy",
+        "notes": "Log in, open the menu, click \"Account Settings\", scroll to the \"Delete Your Account\" form, enter your password and click \"Confirm Deletion\".",
+        "domains": [
+            "inventoryshield.com"
+        ]
+    },
+
+    {
         "name": "Investopedia",
         "url": "https://invcontent.zendesk.com/hc/en-us/articles/360017064553-Account-Deletion",
         "difficulty": "hard",


### PR DESCRIPTION
Added entry for [Inventory Shield](https://inventoryshield.com/support_docs/user-account-details/).

They don't have a direct link to the in-app account settings (yet), so this support article will have to do. I added notes that essentially mimic what the article says. Once logged in, the path to get to account deletion is very short.

Easy difficulty, since all users (with very few exceptions) are free to delete their account at will.