### PR TITLE
Update threads.net to easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19712,7 +19712,8 @@
         "difficulty": "easy",
         "notes": "In the app go to your profile, click on the right top corner and go to \"Account ⮕ Deactivate or delete profile ⮕ Delete profile\"",
         "domains": [
-            "threads.net"
+            "threads.net",
+            "www.threads.net"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19712,8 +19712,7 @@
         "difficulty": "easy",
         "notes": "In the app go to your profile, click on the right top corner and go to \"Account ⮕ Deactivate or delete profile ⮕ Delete profile\"",
         "domains": [
-            "threads.net",
-            "www.threads.net"
+            "threads.net"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19708,10 +19708,9 @@
 
     {
         "name": "Threads",
-        "url": "https://www.instagram.com/accounts/remove/request/permanent/",
-        "difficulty": "impossible",
-        "notes": "You must submit a request to close your INSTAGRAM account via form.",
-        "notes_es": "Deberás solicitar que borren tu cuenta de INSTAGRAM vía formulario.",
+        "url": "https://www.threads.net/settings/account",
+        "difficulty": "easy",
+        "notes": "In the app go to your profile, click on the right top corner and go to \"Account ⮕ Deactivate or delete profile ⮕ Delete profile\"",
         "domains": [
             "threads.net"
         ]


### PR DESCRIPTION
threads.net now allows you to delete your Threads account only without it affecting your Instagram account.