### PR TITLE
Update You to easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22649,8 +22649,8 @@
 
     {
         "name": "You.com",
-        "url": "https://about.you.com/hc/faq/how-do-i-delete-my-profile/",
-        "difficulty": "hard",
+        "url": "https://you.com/profile",
+        "difficulty": "easy",
         "email": "legal@you.com",
         "domains": [
             "you.com",


### PR DESCRIPTION
I modified the difficulty and URL because it's easy to delete a You.com account. You just need to be logged in on You.com, go to your profile, and there's a delete account button.