### PR TITLE
Update Telltale to easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -20018,11 +20018,14 @@
 
     {
         "name": "Telltale",
-        "url": "https://telltale.com",
-        "difficulty": "hard",
-        "notes": "Contact support using the blue \"Support\" button at the bottom right, filling out all applicable fields with \"Account Deletion\"",
+        "url": "https://account.telltale.com/account/settings",
+        "difficulty": "easy",
+        "notes": "After logging in, navigate to your account's settings, scroll down to the “Delete Account” section. After pressing the “DELETE” button, enter your E-Mail and click the button again to confirm.",
+        "notes_cz": "Po přihlášení přejděte do nastavení účtu a přejděte do části „Delete Account“. Po stisknutí tlačítka „DELETE“ zadejte svůj e-mail a opětovným kliknutím na tlačítko potvrďte.",
+        "notes_sk": "Po prihlásení prejdite do nastavení svojho účtu a prejdite do časti „Delete Account“. Po stlačení tlačidla „DELETE“ zadajte svoj e-mail a opätovným kliknutím na tlačidlo potvrďte.",
         "domains": [
-            "telltale.com"
+            "telltale.com",
+            "account.telltale.com"
         ]
     },
 


### PR DESCRIPTION
Hey there!

After reviewing their website, it is no longer necessary to contact their support, as it was before. At present, a button in the account settings provides the option to delete your account. Therefore, it simplifies the process.

I have also updated the URL and added a few translations.

A screenshot as evidence:
![Telltale Update Button](https://i.imgur.com/11sJQTG.png)