### PR TITLE
update note for garena

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7887,10 +7887,17 @@
         "name": "Garena",
         "url": "https://www.garena.sg/support/",
         "difficulty": "hard",
-        "notes": "Accounts are deleted with 6 months of inactivity or by opening a ticket to their support team.",
-        "notes_tr": "Hesaplar, 6 ay boyunca herhangi bir işlem yapılmadığında veya destek ekibine bir talep gönderilerek silinir.",
+        "notes": "Accounts can only be deleted by opening a ticket to their support team.",
+        "notes_tr": "Hesaplar, destek ekibine bir talep gönderilerek silinebilir.",
         "domains": [
-            "garena.sg"
+            "account.garena.com",
+            "garena.com",
+            "garena.my",
+            "garena.ph",
+            "garena.sg",
+            "garena.tw",
+            "garena.vn",
+            "hotro.garena.vn"
         ]
     },
 


### PR DESCRIPTION
### Accounts are _**NOT**_ being deleted after 6 months of inactivity.

I have 3 accounts, all of which were last active in 2022 or earlier, but I can still log in to all of them successfully today. All of the data still seems to persist.

ref: https://www.reddit.com/r/Garena/comments/1apglbo/account_accessed_after_years_of_inactivity/?rdt=53062

my log:
![adasdasdfs](https://github.com/jdm-contrib/jdm/assets/90754622/1e4b67dc-78c4-4956-a497-004db2f4b70d)

