### PR TITLE
Update Walmart Canada to easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22198,10 +22198,9 @@
 
     {
         "name": "Walmart Canada",
-        "url": "https://www.walmart.ca/en/help/contact-us",
-        "difficulty": "hard",
-        "notes": "Contact customer service to close your account.",
-        "notes_tr": "Hesabınızı kapatmak için müşteri hizmetleriyle iletişime geçin.",
+        "url": "https://www.walmart.ca/en/account/delete-account",
+        "difficulty": "easy",
+        "notes": "Follow the link or scroll to the bottom of the website and click \"Delete my account.\" You will be prompted to log in and confirm the deletion.",
         "domains": [
             "walmart.ca"
         ]


### PR DESCRIPTION
Walmart Canada's difficulty is now easy instead of hard because there is now a link in their footer to directly delete your account. Since this update involves a drastic change to the notes, it also removes the Turkish translation, as per the contributing guide.