### PR TITLE
Add marq as medium

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12665,6 +12665,16 @@
     },
 
     {
+        "name": "Marq",
+        "url": "https://help.marq.com/delete-your-account",
+        "difficulty": "medium",
+        "notes": "Account can be deleted from the account settings. If you have an active subscription, then this needs to be cancelled first.",
+        "domains": [
+            "marq.com"
+        ]
+    },
+
+    {
         "name": "Marvel",
         "url": "https://marvelapp.com/account/",
         "difficulty": "easy",
@@ -12672,16 +12682,6 @@
         "notes_tr": "Hesabınıza giriş yapın, ve sayfanın altındaki \"Hesabım\" \"Hesabı Sil\" tuşuna tıklayın.",
         "domains": [
             "marvelapp.com"
-        ]
-    },
-
-    {
-        "name": "Marq",
-        "url": "https://help.marq.com/delete-your-account",
-        "difficulty": "medium",
-        "notes": "Account can be deleted from the account settings. If you have an active subscription, then this needs to be cancelled first.",
-        "domains": [
-            "marq.com"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12301,15 +12301,14 @@
     },
 
     {
-        "name": "Lucidchart/Lucidpress",
+        "name": "Lucidchart",
         "url": "https://www.lucidchart.com/users/login",
         "difficulty": "easy",
         "notes": "Click in the top right corner on your Username, then \"Account settings\" and at the tab \"Close Account\"",
         "notes_tr": "Sağ üst köşedeki kullanıcı adınıza tıklayın, \"Hesap Ayarları\" kısmından \"Hesabı Kapat\" sekmesine girin",
         "domains": [
             "lucid.app",
-            "lucidchart.com",
-            "lucidpress.com"
+            "lucidchart.com"
         ]
     },
 
@@ -12673,6 +12672,16 @@
         "notes_tr": "Hesabınıza giriş yapın, ve sayfanın altındaki \"Hesabım\" \"Hesabı Sil\" tuşuna tıklayın.",
         "domains": [
             "marvelapp.com"
+        ]
+    },
+
+    {
+        "name": "Marq",
+        "url": "https://help.marq.com/delete-your-account",
+        "difficulty": "medium",
+        "notes": "Account can be deleted from the account settings. If you have an active subscription, then this needs to be cancelled first.",
+        "domains": [
+            "marq.com"
         ]
     },
 


### PR DESCRIPTION
Added Marq as medium.
The value of the note key is a link to an article about how to delete your account, as the direct URL to account deletion is individual per user.
Simultaneously removed association between Lucidchart and Lucidpress, as Lucidpress was sold and later rebranded as Marq in 2022.
 