### PR TITLE
Update Dashlane delete account URL

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5008,7 +5008,7 @@
 
     {
         "name": "Dashlane",
-        "url": "https://www.dashlane.com/deleteaccount",
+        "url": "https://app.dashlane.com/#/delete-account",
         "difficulty": "easy",
         "notes": "After entering the email address and selecting a reason for deletion, you will receive a security code by email. Enter the security code. After that, the account will be irretrievably deleted.",
         "notes_tr": "E-posta adresinizi girip \"Neden ayrılıyorsunuz\" sorusuna cevap seçmeniz gerekir. Bu adımı onaylamak için e-postanıza gelecek olan güvenlik kodunu forma girmeniz gerekir. Bittikten sonra hesabınız silinecektir.",


### PR DESCRIPTION
Hello !
First of all thanks for this amazing website. It's so helpful.

The url for account deletion on Dashlane gave a 404 like page.
After a quick search in their forum I have the new url.

Here is the original [help article]( https://support.dashlane.com/hc/en-us/articles/202907531-Delete-your-Dashlane-account-and-data) from Dashlane.

I’ve modified the Dashlane url accordingly.
