### PR TITLE
Delete Sharelatex, Update Overleaf

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -18679,17 +18679,6 @@
     },
 
     {
-        "name": "ShareLaTeX",
-        "url": "https://www.sharelatex.com/user/settings",
-        "difficulty": "easy",
-        "notes": "Click the \"Delete your account\" at the bottom of the settings page and type \"DELETE\" in the popup box.",
-        "notes_tr": "Ayarlar sayfasının altındaki \"Hesabınızı Silin\" öğesini tıklayın ve açılır kutuya 'DELETE' yazın.",
-        "domains": [
-            "sharelatex.com"
-        ]
-    },
-
-    {
         "name": "Sharesome",
         "url": "https://sharesome.com/settings/privacy/",
         "difficulty": "easy",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -15692,7 +15692,6 @@
         "difficulty": "easy",
         "notes": "Select 'Delete your account' at the bottom of the account settings page.",
         "notes_tr": "\"Hesap Ayarları\" sayfasının altındaki \"Hesabınızı Silin\" tuşuna tıklayın.",
-        "email": "privacy@overleaf.com",
         "domains": [
             "overleaf.com"
         ]


### PR DESCRIPTION
Deleted Sharelatex as it was rebranded to Overleaf which is already registered.
Removed email-address from Overleaf as it is categorized as easy.