### PR TITLE
Add Incogni as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10557,6 +10557,19 @@
     },
 
     {
+        "name": "Incogni",
+        "url": "https://incogni.com/",
+        "difficulty": "hard",
+        "notes": "Must email Customer Support to delete account. No official help documentation exists for account deletion.",
+        "email": "support@incogni.com",
+        "email_subject": "Account Deletion Request",
+        "email_body": "Hello,\n\nI am requesting the deletion of my Incogni account and information associated with this email. I would also like to withdraw the consent given in the Authorization Form.\n\nI understand that by terminating my account I will lose any remaining time on my current subscription and I wish to proceed anyway.\n\nThanks.",
+        "domains": [
+            "incogni.com"
+        ]
+    },
+
+    {
         "name": "Indeed",
         "url": "https://indeed.com",
         "difficulty": "easy",


### PR DESCRIPTION
Added entry for Incogni as hard.

No official documentation seems to exist for account deletion except for https://support.incogni.com/hc/en-us/articles/18889349861266-I-no-longer-want-to-be-part-of-the-Incogni-Family-Friends-plan-can-I-delete-my-account.