### PR TITLE
Add missing url to SNCF

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19553,7 +19553,8 @@
             "tgvinoui.sncf",
             "ouigo.com",
             "monidentifiant.sncf",
-            "abonnement-regional.sncf"
+            "abonnement-regional.sncf",
+            "maxjeune-tgvinoui.sncf"
         ]
     },
 


### PR DESCRIPTION
They have too much URLs I cannot find them all.

As they have their own TLD is it possible to use just the TLD ?