### PR TITLE
Add Broadcom Support as Hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3185,6 +3185,18 @@
     },
 
     {
+        "name": "Broadcom Support",
+        "url": "https://knowledge.broadcom.com/external/article/368293/deleting-or-removing-broadcom-support-ac.html",
+        "difficulty": "hard",
+        "notes": "You need to send a request to the support",
+        "notes_fr": "Vous devez envoyer une demande au support.",
+        "domains": [
+            "broadcom.com",
+            "vmware.com"
+        ]
+    },
+
+    {
         "name": "BrowserStack",
         "url": "https://www.browserstack.com/accounts/profile",
         "difficulty": "easy",


### PR DESCRIPTION
I added the vmware.com domain as everything that is done with VMware now has to do with Broadcom Support account