### PR TITLE
Remove Twenty20

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22239,15 +22239,6 @@
     },
 
     {
-        "name": "Twenty20",
-        "url": "https://www.twenty20.com/delete-account?t20p=settings.index",
-        "difficulty": "easy",
-        "domains": [
-            "twenty20.com"
-        ]
-    },
-
-    {
         "name": "Twilio",
         "url": "https://support.twilio.com/hc/en-us/requests/new",
         "difficulty": "hard",


### PR DESCRIPTION
The site shutted down on July 31st, 2022 - https://help.elements.envato.com/hc/en-us/articles/360034211392-About-Twenty20