### PR TITLE
Remove email associated with galaxy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -8258,7 +8258,6 @@
         "url": "https://galaxy.click/settings#danger",
         "difficulty": "medium",
         "notes": "Navigate to the \"delete your account\" section of the \"danger zone\" in your account settings and follow the instructions. If you have published any games, you must delete them before you can proceed with account deletion. Games can be deleted within their edit page.",
-        "email": "privacy@galaxy.click",
         "domains": [
             "galaxy.click"
         ]


### PR DESCRIPTION
(If the content in this PR doesn't make it clear, full disclosure: I am the owner of this website.)

The email address was originally included in the site's Just Delete Me listing before on-site account deletion was added. Although it's still possible to submit an account deletion request via email, no *valid* deletion requests have been made this way. I emphasize "valid" in the previous sentence because the only emails I've received claiming to be account deletion requests all follow the default `Please delete my account, my username is XXXXXX` email template associated with JDM, and there is no account data associated with the sender's email or that username. I would appreciate it if this teeny tiny burden was lifted from my shoulders :^)

![image](https://github.com/user-attachments/assets/953e3fd5-dc8f-40ae-a641-cf440a9ff7c0)