### PR TITLE
Remove STEP

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -20498,16 +20498,6 @@
     },
 
     {
-        "name": "STEP (Smart Traveler Enrollment Program)",
-        "url": "https://step.state.gov",
-        "difficulty": "impossible",
-        "notes": "No self-serve options are available, and they will not delete accounts because \"Profile deletion requires an enormous amount of data about yourself, and your trips, which places users at risk for potential fraud issues\"",
-        "domains": [
-            "step.state.gov"
-        ]
-    },
-
-    {
         "name": "StepMap",
         "url": "https://www.stepmap.de/profile.html#profile_delete",
         "difficulty": "hard",


### PR DESCRIPTION
STEP as it existed when it was first added is no more.

From the email I got, all accounts on the old STEP were wiped. New STEP relies on MyTravelGov, which itself uses login.gov as its account system (and we have an entry for that already).

I guess we could replace the entry instead but it makes little sense to do so.