### PR TITLE
Add WayFi Wireless to Site List  

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -23694,7 +23694,7 @@
             "wattpad.com"
         ]
     },
-    
+
     {
         "name": "WayFi Wireless",
         "url": "https://wayfiwireless.com/contact",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -23698,7 +23698,7 @@
     {
         "name": "WayFi Wireless",
         "url": "https://wayfiwireless.com/contact",
-        "difficulty": "easy",
+        "difficulty": "hard",
         "notes": "To opt out, send an email to privacy@wayfiwireless.com or fill out the contact form.",
         "notes_ca": "Per optar per la baixa, envieu un correu electrònic a privacy@wayfiwireless.com o empleneu el formulari de contacte.",
         "notes_de": "Um sich abzumelden, senden Sie eine E-Mail an privacy@wayfiwireless.com oder füllen Sie das Kontaktformular aus.",
@@ -23711,7 +23711,10 @@
         "email": "privacy@wayfiwireless.com",
         "email_body": "I want my account to be deleted. My full name is XXXXXX and my user name is XXXXXX. Please remove my profile from WayFi Wireless and delete all associated data.",
         "domains": [
-            "wayfiwireless.com"
+            "wayfiwireless.com",
+            "portal.wayfiwireless.com",
+            "dashboard.wayfiwireless.com",
+            "lookup.wayfiwireless.com"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -23694,6 +23694,26 @@
             "wattpad.com"
         ]
     },
+    
+    {
+        "name": "WayFi Wireless",
+        "url": "https://wayfiwireless.com/contact",
+        "difficulty": "easy",
+        "notes": "To opt out, send an email to privacy@wayfiwireless.com or fill out the contact form.",
+        "notes_ca": "Per optar per la baixa, envieu un correu electrònic a privacy@wayfiwireless.com o empleneu el formulari de contacte.",
+        "notes_de": "Um sich abzumelden, senden Sie eine E-Mail an privacy@wayfiwireless.com oder füllen Sie das Kontaktformular aus.",
+        "notes_es": "Para optar por la exclusión, envíe un correo electrónico a privacy@wayfiwireless.com o complete el formulario de contacto.",
+        "notes_fr": "Pour vous désinscrire, envoyez un e-mail à privacy@wayfiwireless.com ou remplissez le formulaire de contact.",
+        "notes_it": "Per annullare l'iscrizione, invia un'e-mail a privacy@wayfiwireless.com o compila il modulo di contatto.",
+        "notes_pt-BR": "Para optar pela exclusão, envie um e-mail para privacy@wayfiwireless.com ou preencha o formulário de contato.",
+        "notes_ru": "Чтобы отказаться, отправьте электронное письмо на privacy@wayfiwireless.com или заполните контактную форму.",
+        "notes_tr": "Vazgeçmek için privacy@wayfiwireless.com adresine e-posta gönderin veya iletişim formunu doldurun.",
+        "email": "privacy@wayfiwireless.com",
+        "email_body": "I want my account to be deleted. My full name is XXXXXX and my user name is XXXXXX. Please remove my profile from WayFi Wireless and delete all associated data.",
+        "domains": [
+            "wayfiwireless.com"
+        ]
+    },
 
     {
         "name": "WAYN",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -23699,22 +23699,23 @@
         "name": "WayFi Wireless",
         "url": "https://wayfiwireless.com/contact",
         "difficulty": "hard",
-        "notes": "To opt out, send an email to privacy@wayfiwireless.com or fill out the contact form.",
-        "notes_ca": "Per optar per la baixa, envieu un correu electrònic a privacy@wayfiwireless.com o empleneu el formulari de contacte.",
-        "notes_de": "Um sich abzumelden, senden Sie eine E-Mail an privacy@wayfiwireless.com oder füllen Sie das Kontaktformular aus.",
-        "notes_es": "Para optar por la exclusión, envíe un correo electrónico a privacy@wayfiwireless.com o complete el formulario de contacto.",
-        "notes_fr": "Pour vous désinscrire, envoyez un e-mail à privacy@wayfiwireless.com ou remplissez le formulaire de contact.",
-        "notes_it": "Per annullare l'iscrizione, invia un'e-mail a privacy@wayfiwireless.com o compila il modulo di contatto.",
-        "notes_pt-BR": "Para optar pela exclusão, envie um e-mail para privacy@wayfiwireless.com ou preencha o formulário de contato.",
-        "notes_ru": "Чтобы отказаться, отправьте электронное письмо на privacy@wayfiwireless.com или заполните контактную форму.",
-        "notes_tr": "Vazgeçmek için privacy@wayfiwireless.com adresine e-posta gönderin veya iletişim formunu doldurun.",
+        "notes": "To opt out, send an email or fill out the contact form.",
+        "notes_ca": "Per optar per la baixa, envieu un correu electrònic o empleneu el formulari de contacte.",
+        "notes_de": "Um sich abzumelden, senden Sie eine E-Mail oder füllen Sie das Kontaktformular aus.",
+        "notes_es": "Para optar por la exclusión, envíe un correo electrónico o complete el formulario de contacto.",
+        "notes_fr": "Pour vous désinscrire, envoyez un e-mail ou remplissez le formulaire de contact.",
+        "notes_it": "Per annullare l'iscrizione, invia un'e-mail o compila il modulo di contatto.",
+        "notes_pt-BR": "Para optar pela exclusão, envie um e-mail ou preencha o formulário de contato.",
+        "notes_ru": "Чтобы отказаться, отправьте письмо или заполните контактную форму.",
+        "notes_tr": "Vazgeçmek için e-posta gönderin veya iletişim formunu doldurun.",
         "email": "privacy@wayfiwireless.com",
         "email_body": "I want my account to be deleted. My full name is XXXXXX and my user name is XXXXXX. Please remove my profile from WayFi Wireless and delete all associated data.",
         "domains": [
             "wayfiwireless.com",
             "portal.wayfiwireless.com",
             "dashboard.wayfiwireless.com",
-            "lookup.wayfiwireless.com"
+            "lookup.wayfiwireless.com",
+            "metabase.wayfiwireless.com"
         ]
     },
 


### PR DESCRIPTION
As a representative of **WayFi Wireless**, we are committed to respecting user privacy and ensuring that no data is retained against a user's wishes. We only store the information necessary for users to access and use our services.  

By submitting this request, we are adding **WayFi Wireless** to the account deletion list with the following details:  

- **Opt-out process:** Users can request account deletion by sending an email to **[privacy@wayfiwireless.com](mailto:privacy@wayfiwireless.com)** or filling out our [[contact form](https://wayfiwireless.com/contact)](https://wayfiwireless.com/contact).  
- **Deletion policy:** Requesting data deletion will result in the removal of all associated accounts.  
- **Automation status:** While our deletion process is **not automated**, we will gladly comply with all deletion requests in a timely manner.  

This update ensures that users have clear instructions on how to remove their data from our system. Let us know if any additional details are required.  
