### PR TITLE
Apple ID is now Apple Account

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1535,14 +1535,14 @@
     },
 
     {
-        "name": "Apple ID / iTunes",
+        "name": "Apple Account / iTunes",
         "url": "https://support.apple.com/en-us/HT208504",
         "difficulty": "easy",
         "notes": "Follow the steps to request account deletion. It is possible to undo for a few days. If you have bought a developer license, it's impossible to delete your account. Once deleted, you will no longer be able to open a new one with the same email address.",
         "notes_it" : "Segui i passaggi per richiedere la cancellazione dell'account. È possibile annullarla per alcuni giorni. Se hai acquistato una licenza per sviluppatore, è impossibile eliminare il tuo account. Una volta eliminato, non potrai più aprirne uno nuovo con lo stesso indirizzo email.",
         "domains": [
             "apple.com",
-            "appleid.apple.com",
+            "account.apple.com",
             "developer.apple.com",
             "support.apple.com",
             "icloud.com"


### PR DESCRIPTION
As you can see also in the “How to delete your Apple Account” [page](https://support.apple.com/en-us/102559), they changed all the naming from Apple ID to Apple Account.