### PR TITLE
Add NA, Spanish translation, email, and notes to Yelp; change difficulty to "hard"

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -25475,10 +25475,16 @@
         "name": "Yelp",
         "meta": "popular",
         "url": "https://www.yelp.co.uk/contact?topic=support&subtopic=close",
-        "difficulty": "easy",
+        "notes": "Closing your account does not remove all data. To request deletion of data associated with your account, you must email [dataprotection@yelp.com](mailto:dataprotection@yelp.com). Additional information can be found here: [Yelp - Support Center - How do I close my account?](https://www.biz.yelp.com/support-center/article/How-do-I-close-my-account).",
+        "difficulty": "hard",
         "domains": [
-            "yelp.co.uk"
-        ]
+            "yelp.ca",
+            "yelp.co.uk",
+            "yelp.com"
+        ],
+        "email": "dataprotection@yelp.com",
+        "email_subject": "Account Data Deletion Request",
+        "email_body": "Please delete my account and all data associated with it. My username is XXXXXX"
     },
 
     {

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -25474,13 +25474,16 @@
     {
         "name": "Yelp",
         "meta": "popular",
-        "url": "https://www.yelp.co.uk/contact?topic=support&subtopic=close",
-        "notes": "Closing your account does not remove all data. To request deletion of data associated with your account, you must email [dataprotection@yelp.com](mailto:dataprotection@yelp.com). Additional information can be found here: [Yelp - Support Center - How do I close my account?](https://www.biz.yelp.com/support-center/article/How-do-I-close-my-account).",
+        "url": "https://www.yelp.com/support/contact/account_closure",
+        "url_es": "https://www.yelp.es/support/contact/account_closure",
+        "notes": "Closing your account does not remove all data. To delete the data associated with your account, you must email them. Additional information can be found here: [Yelp - Support Center - How do I close my account?](https://www.biz.yelp.com/support-center/article/How-do-I-close-my-account).",
+        "notes_es": "Cerrar su cuenta no elimina sus datos. Para eliminar los datos asociados con su cuenta, debe enviar un correo electrónico a ellos. Puede encontrar información addicional aquí, pero sólo en ínglés: [Yelp - Support Center - How do I close my account?](https://www.biz.yelp.com/support-center/article/How-do-I-close-my-account).",
         "difficulty": "hard",
         "domains": [
             "yelp.ca",
             "yelp.co.uk",
-            "yelp.com"
+            "yelp.com",
+            "yelp.es"
         ],
         "email": "dataprotection@yelp.com",
         "email_subject": "Account Data Deletion Request",


### PR DESCRIPTION
## Context
I put all context in the first commit, but to reiterate:

* I updated from "easy" to "hard" because a support ticket must be filed
  and an additional email sent to delete all data.
* I added an email for the separate data deletion step.
* I added notes to explain these changes.

Two things I'm unsure about:

1. Is using the email field for an additional step like this an okay usage of the field? Or should it be solely for account deletion?
2. I changed the URL to `.com`, but I want to make sure I'm supporting both `co.uk` and `.ca` for those respective regions. Would it make sense to add language support for both `en_gb` and `en_ca` for these cases respectively?

Lastly, I'm sending an email to the provided email to see if they'll both delete a test account and the data associated with it, so I'll report back here should anything change.

I welcome any other feedback; thank you for your help!