### PR TITLE
Add OpenSubtitles.com

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -16727,6 +16727,16 @@
     },
 
     {
+        "name": "OpenSubtitles.com",
+        "url": "https://www.opensubtitles.com/en/users/edit",
+        "difficulty": "easy",
+        "notes": "Click 'Delete Account' and enter your password.",
+        "domains": [
+            "opensubtitles.com"
+        ]
+    },
+
+    {
         "name": "OpenTable",
         "url": "https://help.opentable.com",
         "difficulty": "hard",


### PR DESCRIPTION
Specified as .com since there is also a .org. 
OpenSubtitles.com is the newer version but both still exist. They both use different accounts as far as I can tell.
See [here](https://opensubtitles.tawk.help/article/opensubtitlesorg-vs-opensubtitlescom) for the difference.