### PR TITLE
Add RemNote as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19237,6 +19237,17 @@
     },
 
     {
+        "name": "RemNote",
+        "url": "https://help.remnote.com/en/articles/8033036-deleting-your-account",
+        "difficulty": "easy",
+        "notes": "You can delete your account from Settings > Profile > Account Deletion > Delete Account",
+        "notes_es": "Para eliminar tu cuenta accede a Settings > Profile > Account Deletion > Delete Account",
+        "domains": [
+            "https://www.remnote.com/"
+        ]
+    },
+
+    {
         "name": "Render",
         "url": "https://render.com/",
         "difficulty": "easy",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19240,8 +19240,8 @@
         "name": "RemNote",
         "url": "https://help.remnote.com/en/articles/8033036-deleting-your-account",
         "difficulty": "easy",
-        "notes": "You can delete your account from Settings > Profile > Account Deletion > Delete Account",
-        "notes_es": "Para eliminar tu cuenta accede a Settings > Profile > Account Deletion > Delete Account",
+        "notes": "You can delete your account from Settings ⮕ Profile ⮕ Account Deletion ⮕ Delete Account",
+        "notes_es": "Para eliminar tu cuenta accede a Settings ⮕ Profile ⮕ Account Deletion ⮕ Delete Account",
         "domains": [
             "remnote.com",
             "feedback.remnote.com",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19243,7 +19243,9 @@
         "notes": "You can delete your account from Settings > Profile > Account Deletion > Delete Account",
         "notes_es": "Para eliminar tu cuenta accede a Settings > Profile > Account Deletion > Delete Account",
         "domains": [
-            "https://www.remnote.com/"
+            "remnote.com",
+            "feedback.remnote.com",
+            "help.remnote.com"
         ]
     },
 


### PR DESCRIPTION
I added a new entry for RemNote and translated the note field into Spanish. The note provides instructions for deleting your account, including the UI path (Settings > Profile > Account Deletion > Delete Account). I translated the note to Spanish but kept the UI path part in English due to RemNote's current lack of Spanish translation. Please let me know if it would be better to translate the entire field.