### PR TITLE
Update NordVPN to easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -16158,8 +16158,8 @@
     {
         "name": "NordVPN",
         "url": "https://support.nordvpn.com/FAQ/1521982312/How-can-I-delete-my-account.htm",
-        "difficulty": "hard",
-        "notes": "Fill the form on the site to request deletion. Alternatively, use the Live Chat service to request deletion, located at the bottom right of the form.",
+        "difficulty": "easy",
+        "notes": "Login, then go to your account settings page. There is a delete account button. It makes you verify your email with a 6 digit code, then allows deletion.",
         "domains": [
             "nordvpn.com",
             "support.nordvpn.com"


### PR DESCRIPTION
The deletion process has changed. The earlier support website  content has also changed, though the website stays the same.

> Previously, account deletions could only be initiated by contacting us via email; however, we have now implemented an automated account deletion system that is more efficient and convenient for our customers to use. 

You can now delete your NordVPN account by deleting your Nord Account. This deletion will apply to all Nord Security products and services, including NordLocker and NordPass. 