### PR TITLE
changed czc as medium

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5358,7 +5358,7 @@
     {
         "name": "CZC",
         "url": "https://www.czc.cz/soukromi/sprava-udaju",
-        "difficulty": "easy",
+        "difficulty": "medium",
         "notes": "You have to fill out a form. (BUT IT'S ONLY IN CZECH)",
         "notes_cs": "Musíte vyplnit formulář.",
         "notes_sk": "Musíte vyplniť formulár.",


### PR DESCRIPTION
This pull request includes a change to the `_data/sites.json` file, where the difficulty level for the CZC site has been updated.

* [`_data/sites.json`](diffhunk://#diff-d90c9f1aae25e585903f8ef98912cba11bdb5e45ac27fbb2a096d1e98d2828a1L5361-R5361): Changed the difficulty level for the CZC site from "easy" to "medium".