### PR TITLE
Add almost all Auvergne Rhone Alpes transport services and Ile de France Mobilités

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19767,6 +19767,18 @@
     },
 
     {
+        "name": "Rhonexpress",
+        "url": "https://www.rhonexpress.fr/en_GB/account/profile/edit",
+        "url_it": "https://www.rhonexpress.fr/fr_FR/account/profile/edit",
+        "difficulty": "easy",
+        "notes": "On your personal information page, scroll down to \"Delete my account\", and click on \"I delete my account\".",
+        "notes_fr": "Sur la page de vos informations personnelles, descendez jusqu'a \"Supprimer mon compte\", et cliquez sur \"Je supprime mon compte\"",
+        "domains": [
+            "rhonexpress.fr"
+        ]
+    },
+
+    {
         "name": "Rideindego",
         "url": "https://www.rideindego.com/faq/#how-do-i-cancel-my-pass",
         "difficulty": "impossible",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -24461,6 +24461,17 @@
     },
 
     {
+        "name": "Valence Romans Mobilités",
+        "url": "https://start.valenceromansmobilites.fr/fr/compte/informations",
+        "difficulty": "easy",
+        "notes": "On your account information page, click on \"Supprimer mon compte\", confirm your email address and your password, and click on \"Supprimer mon compte\".",
+        "notes_fr": "Sur la page d'informations sur votre compte, cliquez sur \"Supprimer mon compte\", confirmez votre adress email et votre mot de passe, et cliquez sur \"Supprimer mon compte\".",
+        "domains": [
+            "valenceromansmobilites.fr"
+        ]
+    },
+
+    {
         "name": "Valorant",
         "url": "https://support-valorant.riotgames.com/hc/en-us/articles/360050328414-Deleting-Your-Riot-Account-and-All-Your-Data",
         "difficulty": "easy",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1111,6 +1111,17 @@
     },
 
     {
+        "name": "Altibus",
+        "url": "https://www.altibus.com/contact/",
+        "difficulty": "hard",
+        "notes": "You need to contact the support through chat or phone to delete your account.",
+        "notes_fr": "Vous devez contacter le support par chat ou téléphone pour supprimer votre compte.",
+        "domains": [
+            "altibus.com"
+        ]
+    },
+
+    {
         "name": "Altium",
         "email": "data.compliance@altium.com",
         "url": "https://www.altium.com/privacy-policy",
@@ -22415,6 +22426,17 @@
         "notes": "In \"My Profile Page\", click on \"Delete Account\" link on the left side and then the \"Delete Account\" button.",
         "domains": [
             "syncfusion.com"
+        ]
+    },
+
+    {
+        "name": "Synchro Mobilités",
+        "url": "https://start.synchro.grandchambery.fr/fr/compte/informations",
+        "difficulty": "easy",
+        "notes": "On your account information page, click on \"Supprimer mon compte\", confirm your email address and your password, and click on \"Supprimer mon compte\".",
+        "notes_fr": "Sur la page d'informations sur votre compte, cliquez sur \"Supprimer mon compte\", confirmez votre adress email et votre mot de passe, et cliquez sur \"Supprimer mon compte\".",
+        "domains": [
+            "synchro.grandchambery.fr"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -15132,6 +15132,17 @@
     },
 
     {
+        "name": "Mon Espace STAS",
+        "url": "https://www.reseau-stas.fr/fr/mon-espace-stas/159/Member/editprofile",
+        "difficulty": "easy",
+        "notes": "On your profile settings, scroll down and click on \"Delete my account\", then confirm by clicking on \"Delete my subscription\".",
+        "notes_fr": "Sur vos paramètres de compte, descendez et cliquez sur \"Supprimer mon inscription\", puis confirmez en cliquant sur \"Supprimer mon inscription\".",
+        "domains": [
+            "reseau-stas.fr"
+        ]
+    },
+
+    {
         "name": "Monarch Money",
         "url": "https://help.monarchmoney.com/hc/en-us/articles/4412388754708-Delete-a-Monarch-Account",
         "difficulty": "easy",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3833,6 +3833,17 @@
     },
 
     {
+        "name": "Cars Région Isère",
+        "url": "https://carsisere.auvergnerhonealpes.fr/fr/mon-espace/159/Member/editprofile",
+        "difficulty": "easy",
+        "notes": "On your profile settings, scroll down and click on \"Delete my account\", then confirm by clicking on \"Delete my subscription\".",
+        "notes_fr": "Sur vos paramètres de compte, descendez et cliquez sur \"Supprimer mon inscription\", puis confirmez en cliquant sur \"Supprimer mon inscription\".",
+        "domains": [
+            "carsisere.auvergnerhonealpes.fr"
+        ]
+    },
+
+    {
         "name": "Cash'em All",
         "url": "https://cashemall.online/legal/v1/privacy/online.cashemall.app",
         "email": "contact@cashemall.online",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -26900,6 +26900,18 @@
     },
 
     {
+        "name": "Île-de-France Mobilités Connect",
+        "url": "https://www.iledefrance-mobilites.fr/en/aide-et-contacts/iledefrance-mobilites-connect/desactiver-mon-compte-idfm-connect",
+        "url_fr": "https://www.iledefrance-mobilites.fr/aide-et-contacts/iledefrance-mobilites-connect/desactiver-mon-compte-idfm-connect",
+        "difficulty": "medium",
+        "notes": "Log in to the account Île-de-France Mobilités Connect that you want to deactivate, in the \"My space\" section, select \"Manage my information\", click on the link \"Deactivate my Île-de-France Mobilités Connect account\", click the \"Confirm Deactivation\" button",
+        "notes_fr": "Connectez-vous sur le compte Île-de-France Mobilités Connect que vous souhaitez désactiver, dans la rubrique \"Mon espace\", sélectionnez \"Gérer mes informations\", cliquez sur le lien \"Désactiver mon compte Île-de-France Mobilités Connect\", cliquez sur le bouton \"Confirmer la désactivation\".",
+        "domains": [
+            "iledefrance-mobilites.fr"
+        ]
+    },
+
+    {
         "name": "ÖBB",
         "url": "https://www.oebb.at/en/fragen-und-antworten/tickets-kaufen/online-mobile-ticketing/registrierung",
         "url_de": "https://www.oebb.at/de/fragen-und-antworten/tickets-kaufen/online-mobile-ticketing/registrierung",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4082,8 +4082,11 @@
         "name": "Chamonix Mobilité",
         "url": "https://www.chamonix-mobilite.com/en/nous-contacter",
         "url_fr": "https://www.chamonix-mobilite.com/fr/nous-contacter",
-        "notes": "You need to contact support to delete your account.",
-        "notes_fr": "Vous devez contacter le support pour supprimer votre compte.",
+        "notes": "You need to contact support through email to delete your account.",
+        "notes_fr": "Vous devez contacter le support par email pour supprimer votre compte.",
+        "email": "assistance@secureticket.fr",
+        "email_subject": "Suppression de compte",
+        "email_body": " Je demande la suppression de mon compte Chamonix Mobilité",
         "difficulty": "hard",
         "domains": [
             "chamonix-mobilite.com"

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -21757,6 +21757,17 @@
     },
 
     {
+        "name": "Star't",
+        "url": "https://www.star-t.fr/account/profile",
+        "difficulty": "easy",
+        "notes": "On your profile page, scroll down, click on \"Supprimer mon compte\" then click on \"Oui, supprimer\".",
+        "notes_fr": "Sur votre page de profil, descendez, cliquez sur \"Supprimer mon compte\" puis cliquez sur \"Oui, supprimer\".",
+        "domains": [
+            "star-t.fr"
+        ]
+    },
+
+    {
         "name": "Starbucks",
         "url": "https://www.starbucks.com/terms/privacy-policy/#contact_us",
         "difficulty": "hard",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22465,6 +22465,17 @@
     },
 
     {
+        "name": "TAC Mobilités",
+        "url": "https://www.tac-mobilites.fr/account/profile",
+        "difficulty": "easy",
+        "notes": "On your profile page, scroll down, click on \"Supprimer mon compte\" then click on \"Supprimer\".",
+        "notes_fr": "Sur votre page de profil, descendez, cliquez sur \"Supprimer mon compte\" puis cliquez sur \"Supprimer\".",
+        "domains": [
+            "tac-mobilites.fr"
+        ]
+    },
+
+    {
         "name": "Tagged",
         "url": "https://tagged.com/account_cancel.html",
         "difficulty": "easy",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4067,6 +4067,18 @@
     },
 
     {
+        "name": "Chamonix Mobilité",
+        "url": "https://www.chamonix-mobilite.com/en/nous-contacter",
+        "url_fr": "https://www.chamonix-mobilite.com/fr/nous-contacter",
+        "notes": "You need to contact support to delete your account.",
+        "notes_fr": "Vous devez contacter le support pour supprimer votre compte.",
+        "difficulty": "hard",
+        "domains": [
+            "chamonix-mobilite.com"
+        ]
+    },
+
+    {
         "name": "Change.org",
         "url": "https://www.change.org/policies/privacy",
         "difficulty": "hard",
@@ -22458,6 +22470,17 @@
         "notes": "You will need to provide proof of identity such as a passport or drivers license and verify the phone number associated with your T-Mobile ID. This will not delete active service plans if you have any.",
         "domains": [
             "t-mobile.com"
+        ]
+    },
+
+    {
+        "name": "T2C Boutique",
+        "url": "https://eboutique.smtc-clermont.fr/en/account/informations",
+        "difficulty": "easy",
+        "notes": "On your account information page, click on \"Supprimer mon compte\", confirm your email address and your password, and click on \"Supprimer mon compte\".",
+        "notes_fr": "Sur la page d'informations sur votre compte, cliquez sur \"Supprimer mon compte\", confirmez votre adress email et votre mot de passe, et cliquez sur \"Supprimer mon compte\".",
+        "domains": [
+            "eboutique.smtc-clermont.fr"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -21804,6 +21804,17 @@
     },
 
     {
+        "name": "STAS - Agence en Ligne",
+        "url": "https://www.reseau-stas.fr/fr/nous-contacter/14/Contact",
+        "difficulty": "hard",
+        "notes": "You need to contact support to delete your account.",
+        "notes_fr": "Vous devez contacter le support pour supprimer votre compte.",
+        "domains": [
+            "boutique.reseau-stas.fr"
+        ]
+    },
+
+    {
         "name": "Stardock",
         "url": "https://stardock.atlassian.net/servicedesk/customer/portal/4/group/14/create/10143",
         "difficulty": "hard",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1111,18 +1111,6 @@
     },
 
     {
-        "name": "Cars Région Savoie / Altibus",
-        "url": "https://www.cars-region-savoie.fr/suggestions-reclamations/",
-        "difficulty": "hard",
-        "notes": "You need to contact the support to delete your account.",
-        "notes_fr": "Vous devez contacter le support pour supprimer votre compte.",
-        "domains": [
-            "cars-region-savoie.fr",
-            "altibus.com"
-        ]
-    },
-
-    {
         "name": "Altium",
         "email": "data.compliance@altium.com",
         "url": "https://www.altium.com/privacy-policy",
@@ -3841,6 +3829,18 @@
         "notes_fr": "Sur vos paramètres de compte, descendez et cliquez sur \"Supprimer mon inscription\", puis confirmez en cliquant sur \"Supprimer mon inscription\".",
         "domains": [
             "carsisere.auvergnerhonealpes.fr"
+        ]
+    },
+
+    {
+        "name": "Cars Région Savoie / Altibus",
+        "url": "https://www.cars-region-savoie.fr/suggestions-reclamations/",
+        "difficulty": "hard",
+        "notes": "You need to contact the support to delete your account.",
+        "notes_fr": "Vous devez contacter le support pour supprimer votre compte.",
+        "domains": [
+            "cars-region-savoie.fr",
+            "altibus.com"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19898,6 +19898,17 @@
     },
 
     {
+        "name": "RLV e-boutique",
+        "url": "https://eboutique-rlv.airwebpass.com/account/",
+        "difficulty": "easy",
+        "notes": "On your account page, click on your account name, scroll down, and click on \"Supprimer mon compte\". Confirm you want to delete your account, a login prompt will ask for your email and password, and click on \"Me Connecter\".",
+        "notes_fr": "Sur votre page de compte, cliquez sur le nom de votre compte, descendez et cliquez sur \"Supprimer mon compte\". Confirmez que vous souhaitez supprimer votre compte, un pop-up de connexion demandera votre email et mot de passe, et cliquez sur \"Me Connecter\".",
+        "domains": [
+            "eboutique-rlv.airwebpass.com"
+        ]
+    },
+
+    {
         "name": "Roadie",
         "url": "https://send.roadie.com/profile/settings",
         "difficulty": "medium",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12759,6 +12759,17 @@
     },
 
     {
+        "name": "L'VA",
+        "url": "https://www.lva-mobilite.fr/account/profile",
+        "difficulty": "easy",
+        "notes": "On your account information page, click on \"Supprimer mon compte\", confirm your email address and your password, and click on \"Supprimer mon compte\".",
+        "notes_fr": "Sur la page d'informations sur votre compte, cliquez sur \"Supprimer mon compte\", confirmez votre adress email et votre mot de passe, et cliquez sur \"Supprimer mon compte\".",
+        "domains": [
+            "lva-mobilite.fr"
+        ]
+    },
+
+    {
         "name": "La Poste",
         "url": "https://aide.laposte.fr/mesdonneespersonnelles/moncompte/suppression",
         "difficulty": "hard",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -21804,17 +21804,6 @@
     },
 
     {
-        "name": "STAS - Agence en Ligne",
-        "url": "https://www.reseau-stas.fr/fr/nous-contacter/14/Contact",
-        "difficulty": "hard",
-        "notes": "You need to contact support to delete your account.",
-        "notes_fr": "Vous devez contacter le support pour supprimer votre compte.",
-        "domains": [
-            "boutique.reseau-stas.fr"
-        ]
-    },
-
-    {
         "name": "Stardock",
         "url": "https://stardock.atlassian.net/servicedesk/customer/portal/4/group/14/create/10143",
         "difficulty": "hard",
@@ -21847,6 +21836,17 @@
         "notes_tr": "Profil ayarlarınıza gidin, aşağı kaydırın ve 'Profili sil' bağlantısını tıklayın. Bazı nedenlerden dolayı hesabınızın silinememesi mümkün olabilir, örneğin: başlangıç, finansman veya bitiş aşamasında bir projeniz var; aktif bir ortak sayfanız var; hala finansman aşamasında olan bir projeyi desteklediniz ve ödemenizi henüz almadık veya ödemeniz size iade edilmedi.",
         "domains": [
             "startnext.com"
+        ]
+    },
+
+    {
+        "name": "STAS - Agence en Ligne",
+        "url": "https://www.reseau-stas.fr/fr/nous-contacter/14/Contact",
+        "difficulty": "hard",
+        "notes": "You need to contact support to delete your account.",
+        "notes_fr": "Vous devez contacter le support pour supprimer votre compte.",
+        "domains": [
+            "boutique.reseau-stas.fr"
         ]
     },
 

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -16842,6 +16842,17 @@
     },
 
     {
+        "name": "Ondéa Grand Lac",
+        "url": "https://www.ondeagrandlac.fr/account/profile",
+        "difficulty": "easy",
+        "notes": "On your profile page, scroll down, click on \"Supprimer mon compte\" then click on \"Oui, supprimer\".",
+        "notes_fr": "Sur votre page de profil, descendez, cliquez sur \"Supprimer mon compte\" puis cliquez sur \"Oui, supprimer\".",
+        "domains": [
+            "ondeagrandlac.fr"
+        ]
+    },
+
+    {
         "name": "One Month",
         "url": "https://www.iubenda.com/privacy-policy/735465",
         "difficulty": "hard",


### PR DESCRIPTION
Ile de france Mobilités (Paris): medium
Note: not tested, linked the support page. Chose medium because the support page states that it's humanely processed and may take time
Rhonexpress (Lyon to Airport): easy
Ondéa Grand Lac (Aix-les-Bains): easy
Cars Région Savoie / Altibus (Savoie buses): hard (No deletion confirmation)
Sibra (Annecy): impossible (no response, considered impossible)
TAC Mobilités (Annemasse): easy
Synchro Mobilités (Chambéry): easy
Chamonix Mobilité (Chamonix): hard (after right request, waited 5min, so quick I missed it)
T2C Alertes (Clermont-Ferrand): hard (waited 2 weeks)
T2C Boutique (Clermont-Ferrand): easy
RLV e-boutique (Riom): easy
Mon espace STAS: easy
STAS Agence en ligne: hard (waited less than 24h)
Star't: easy
Valence Romans Mobilités: easy
L'VA: easy
Cars Région Isère: easy

Funny notes:
Ondéa, Sibra, TAC, Star't and even Oùra use the same login service provided by Instant system
Ondéa, TAC and Star't use a very similar frontend
Synchro Mobilités, T2C Boutique, Valence Romans Mobilités and L'VA use a very similar frontend
CoqueliGO, Le37, Mobilité en Velay, T'CAP, ARCHE Agglo and MOBIVIE use a very similar frontend and ask so much info it's a struggle to create an account (and it looks like it can be deleted from an agency)
Tout'enbus, Rubis, Ruban, Colibri, TICO 3CM, Star, Saônibus and L'va use directly Oùra for their tickets
Trans'Cab, Proxim iTi, Montelibus, Duobus, Star, use the NéMO app to do everything (I couldn't install it so I couldn't add it)
Trans'Cab, TCL, Maelis and Aléo are the only ones keeping their own transport card instead of using the Oùra card (IDFM does not could here as it's not the same region)
Star't e-boutique uses a different account than Star't and has a bug that prevented me from creating an account.
Cars Région Savoie and Altibus actually have the same account database despite having different websites
