### PR TITLE
Add MyCreds as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -15612,6 +15612,16 @@
     },
 
     {
+        "name": "MyCreds",
+        "url": "https://membertrustregistry.mycreds.ca",
+        "difficulty": "hard",
+        "notes": "Account deletion has to be done by the issuing institution. Use the linked page to find the approprite information for contacting the issuing institution.",
+        "domains": [
+            "mycreds.ca"
+        ]
+    },
+
+    {
         "name": "myESET",
         "url": "https://my.eset.com/account",
         "difficulty": "easy",


### PR DESCRIPTION
Seemingly the only information on their website about deleting your account is from a chatbot. After clicking through the buttons to delete your account it says this:

"Account deletion requests must be initiated by the issuing institution. Please contact the appropriate office using the information provided in our [Member Trust Registry](https://membertrustregistry.mycreds.ca/en)."