### PR TITLE
Update url for Gumtree

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10347,8 +10347,9 @@
 
     {
         "name": "Gumtree",
-        "url": "https://my.gumtree.com/manage/details/deactivate",
+        "url": "https://www.gumtree.com/manage-account",
         "difficulty": "easy",
+        "notes": "There is a link at the bottom of the page to deactivate your account.",
         "domains": [
             "gumtree.com",
             "my.gumtree.com"


### PR DESCRIPTION
The previous link raised 404 error, updated the information to match current sstate.