### PR TITLE
Add SteamHistory as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22686,6 +22686,18 @@
     },
 
     {
+        "name": "SteamHistory",
+        "url": "https://steamhistory.net/newbeta/terms-of-service",
+        "difficulty": "hard",
+        "notes": "Data deletion requires contacting Customer Support.",
+        "notes_ru": "Единственный способ удалить персональные даные — отправить электронное письмо службе поддержки.",
+        "email": "privacy@steamhistory.net",
+        "domains": [
+            "steamhistory.net"
+        ]
+    },
+
+    {
         "name": "SteelSeries",
         "url": "https://steelseries.com/dashboard/profile",
         "difficulty": "easy",


### PR DESCRIPTION
* Add SteamHistory (as hard)
* * Languages: en & ru

This is not exactly about deleting an account, but rather about removing scraped personal data. If this is out of scope, feel free to close this PR.