### PR TITLE
Add System76 as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19124,14 +19124,6 @@
         "domains": ["thetakeout.com"]
     },
     {
-        "name": "Tandoor",
-        "url": "https://tandoor.dev/privacy/",
-        "difficulty": "hard",
-        "notes": "You need to send the developer an email. Remember to use the email that you sign up with.",
-        "email": "info@tandoor.dev",
-        "domains": ["tandoor.dev"]
-    },
-    {
         "name": "Tanga",
         "url": "https://www.tanga.com/support",
         "difficulty": "hard",


### PR DESCRIPTION
System76 has a privacy policy which includes: 
```
The right to erasure – You have the right to request that we erase your personal data, under certain conditions.
```
But as the website don't have an automatic way to delete accounts, I have listed both the privacy policy page and email address. 

First time contributing, so let me know if there's anything I need to change. 