### PR TITLE
Add Gleam.io as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7901,6 +7901,14 @@
         ]
     },
     {
+        "name": "Gleam.io",
+        "url": "https://gleam.io",
+        "difficulty": "easy",
+        "notes": "In your account settings, fill the 'Delete Account' confirmation box then click the 'Delete My Account' button.",
+        "notes_fr": "Dans les paramètres de votre compte, remplissez la boite de confirmation 'Delete Account' puis appuyez sur le bouton 'Delete My Account'.",
+        "domains": ["gleam.io"]
+    },
+    {
         "name": "Glide (UK)",
         "url": "https://prearrival.glidestudent.co.uk/privacy-policy",
         "difficulty": "hard",


### PR DESCRIPTION
Add [Gleam.io](https://gleam.io) as easy.

Marked as draft because I'm not sure what url to add.
The current one links to the FAQ page that misleadingly states we need to send an email to `privacy@gleam.io` while we can access an easy "Delete My Account" button on the profile settings page.
I also can't add the profiles settings page url because it seems to use a unique id (`https://gleam.io/user/<some id>/profile`).

Should I just leave it like this ?