### PR TITLE
Dieg0 kongregate

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10772,7 +10772,7 @@
         "name": "Kongregate",
         "url": "www.kongregate.com/en/accounts",
         "difficulty": "easy",
-        "notes": "From your account page, click the gear icon and select 'Delete Account'. Confirm the delettion in the E-Mail sent to you.",
+        "notes": "From your account page, click the gear icon and select “Delete Account.” Confirm the deletion in the email sent to you.",
         "domains": ["kongregate.com"]
     },
     {


### PR DESCRIPTION
The current link gives a page not found:
<img width="896" height="668" alt="image" src="https://github.com/user-attachments/assets/4bf79cce-adf9-4e01-872f-8ebf8cb34c2b" />

Updated for instructions on how to delete the account from the profile page. The deletion URL contains the username therefore I linked the account page. 
<img width="620" height="280" alt="image" src="https://github.com/user-attachments/assets/d67c0d48-fc69-4770-969a-39b7f42d7d03" />
