### PR TITLE
Dieg0 kongregate https:// 

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10770,7 +10770,7 @@
     },
     {
         "name": "Kongregate",
-        "url": "www.kongregate.com/en/accounts",
+        "url": "https://www.kongregate.com/en/accounts",
         "difficulty": "easy",
         "notes": "From your account page, click the gear icon and select “Delete Account.” Confirm the deletion in the email sent to you.",
         "domains": ["kongregate.com"]


### PR DESCRIPTION
The URL from my last pull request was missing the https:// which results in:
<img width="1146" height="593" alt="image" src="https://github.com/user-attachments/assets/06027a31-0033-45b6-a446-780b8e7868e9" />

Adding https:// fixes the issue if i manually edit the href by inspect element. 

Sorry!