### PR TITLE
Added MouseCTRL (hard)

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -13352,7 +13352,7 @@
     },
     {
         "name": "MouseCTRL",
-        "url": "https://mousectrl.com/profile",
+        "url": "https://mousectrl.com/",
         "difficulty": "hard",
         "notes": "Email the support team from the email address of the account you wish to delete.",
         "email": "hello@mousectrl.com",


### PR DESCRIPTION
A email is required to the support email address to trigger a manual deletion process