### PR TITLE
Add Presearch as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -16263,6 +16263,17 @@
         "domains": ["premiumize.me"]
     },
     {
+        "name": "Presearch",
+        "url": "https://account.presearch.com/privacy-policy",
+        "email": "privacy@presearch.io",
+        "difficulty": "hard",
+        "notes": "Email Presearch's privacy team to request account deletion.",
+        "domains": [
+            "presearch.com",
+            "account.presearch.com"
+        ]
+    },
+    {
         "name": "PrestaShop",
         "url": "https://accounts.distribution.prestashop.net/settings/delete-account",
         "difficulty": "easy",


### PR DESCRIPTION
Add Presearch as hard, as it's required to email the privacy team of Presearch to request account deletion