### PR TITLE
Update Crunchyroll URL and difficulty level

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4633,8 +4633,8 @@
     },
     {
         "name": "Crunchyroll",
-        "url": "https://www.crunchyroll.com/nuke",
-        "difficulty": "easy",
+        "url": "https://privacyportal.onetrust.com/webform/d19e506f-1a64-463d-94e4-914dd635817d/35fb5149-8905-48f3-9cbf-8b651c427d0e",
+        "difficulty": "medium",
         "domains": [
             "crunchyroll.com",
             "help.crunchyroll.com"


### PR DESCRIPTION
old link didnt work, got the new one from [datarequests.org ](https://www.datarequests.org/generator/)