### PR TITLE
Fix MatGoat URL and notes

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12461,9 +12461,9 @@
     },
     {
         "name": "MatGoat",
-        "url": "https://app.matgoat.com/user",
+        "url": "https://matgoat.com",
         "difficulty": "easy",
-        "notes": "Go to your Account ⮕ \"Delete My Account\". You'll receive an email once it's completed.",
+        "notes": "Sign in ⮕ Go to your Account ⮕ \"Delete My Account\". You'll receive an email once it's completed.",
         "domains": ["matgoat.com"]
     },
     {


### PR DESCRIPTION
Since I don't have a stateful way if the user is not logged in, I've realized it's clearer for non-logged in users (which might be the most common case if they want to delete their account since it's probably a while since they used it), to have a "route" from the main domain and then Sign in -> Go to your account, etc.

I hope this makes sense, so sorry for the extra work here 🙏 