### PR TITLE
Add Cornelsen.de account deletion instructions

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4471,9 +4471,7 @@
         "notes_de": "Account-Löschung erfordert es, den Kundensupport zu kontaktieren.",
         "notes_en": "Account deletion requires contacting Customer Support.",
         "email": "service@cornelsen.de",
-        "domains": [
-            "cornelsen.de"
-        ]
+        "domains": ["cornelsen.de"]
     },
     {
         "name": "Correl.app",


### PR DESCRIPTION
This PR adds Cornelsen.de to the JustDeleteMe database.

Cornelsen does not provide an automatic account deletion button. According to their website, users must request account deletion by sending an email to service@cornelsen.de.

Deletion method:
- Requires contacting customer support by email
- No self-service deletion available

I classified the difficulty as "hard" and added:
- Service page URL
- Email address
- German and English notes
- Domain for browser extensions

Source:
https://www.cornelsen.de

German wording on site:
"Wenn Sie nicht mehr zum Online-Kundenkreis auf cornelsen.de gehören möchten, schreiben Sie uns bitte eine E-Mail an service@cornelsen.de"