### PR TITLE
SoundCloud secretly prevents composers from deleting their own accounts

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -19301,7 +19301,8 @@
     {
         "name": "SoundCloud",
         "url": "https://soundcloud.com/settings/account#delete-user",
-        "difficulty": "easy",
+        "difficulty": "medium",
+        "notes": "Delete your songs manually first before attempting to delete your account, in case it gets 'frozen', which means that you would have to message a nonexistent chatbot to 'unfreeze' your own account.",
         "domains": ["soundcloud.com"]
     },
     {


### PR DESCRIPTION
Updated difficulty level and added notes for SoundCloud account deletion.
https://help.soundcloud.com/hc/en-us/articles/115003563468-My-Account-Is-Frozen-and-I-Can-t-Sign-In