### PR TITLE
Update URL, difficulty, and notes for Méliuz

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -14280,8 +14280,9 @@
     },
     {
         "name": "Méliuz",
-        "url": "https://www.meliuz.com.br/minha-conta/meus-dados/excluir-conta",
-        "difficulty": "easy",
+        "url": "https://ajuda.meliuz.com.br/hc/pt-br/articles/4417549110292",
+        "difficulty": "hard",
+        "notes": "No self-service deletion is available. Call 0800 301 0101 and select the cancellation option. The previous direct deletion URL returns 404.",
         "domains": ["meliuz.com.br"]
     },
     {

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -14282,7 +14282,7 @@
         "name": "Méliuz",
         "url": "https://ajuda.meliuz.com.br/hc/pt-br/articles/4417549110292",
         "difficulty": "hard",
-        "notes": "No self-service deletion is available. Call 0800 301 0101 and select the cancellation option. The previous direct deletion URL returns 404.",
+        "notes": "No self-service deletion is available. Call 0800 301 0101 and select the cancellation option.",
         "domains": ["meliuz.com.br"]
     },
     {


### PR DESCRIPTION
Méliuz no longer offers self-service account deletion.

- The previous URL (`https://www.meliuz.com.br/minha-conta/meus-dados/excluir-conta`) returns HTTP 404.
- Per Méliuz's own help center, cancellation now requires calling 0800 301 0101 and selecting the cancellation option.
- Updated `difficulty` from `easy` → `hard` because phone-only cancellation falls under the project's definition: "Sites that require you to contact customer services."
- Updated `url` to the canonical help article on this process.
- Added `notes` so users understand the phone-call requirement before clicking through.

Source: https://ajuda.meliuz.com.br/hc/pt-br/articles/4417549110292-Quero-cancelar-minha-conta-no-M%C3%A9liuz