### PR TITLE
Use <details> for card info accordions

### DIFF
--- a/_includes/body.html
+++ b/_includes/body.html
@@ -43,7 +43,7 @@
 
                 {% capture lang_notes %}notes_{{ page.lang }}{% endcapture %}
                 {% if entry.notes or entry[lang_notes] or entry.email or entry.difficulty == 'easy' %}
-                    <div class="tooltip-content">
+                    <details class="tooltip-content">
                         {% if entry[lang_notes] %}
                             {{ entry[lang_notes] | markdownify }}
                         {% elsif entry.notes %}
@@ -54,16 +54,13 @@
                             {{ site.data.trans[page.lang].defaultnote_easy }}
                         {% endif %}
                         {% if entry.email %}
-                            {% if entry.notes or entry[lang_notes] %}
-                                <br>
-                            {% endif %}
-                            <a href="mailto:{{ entry.email }}?Subject={% if entry.email_subject %}{{ entry.email_subject | replace: ' ', '%20' }}{% else %}Account%20Deletion%20Request{% endif %}&body={% if entry.email_body %}{{ entry.email_body | replace: ' ', '%20' }}{% else %}Please%20delete%20my%20account,%20my%20username%20is%20 XXXXXX{% endif %}">{{ site.data.trans[page.lang].sendmail }} &raquo;</a>
+                            <a class="email-info" href="mailto:{{ entry.email }}?Subject={% if entry.email_subject %}{{ entry.email_subject | replace: ' ', '%20' }}{% else %}Account%20Deletion%20Request{% endif %}&body={% if entry.email_body %}{{ entry.email_body | replace: ' ', '%20' }}{% else %}Please%20delete%20my%20account,%20my%20username%20is%20 XXXXXX{% endif %}">{{ site.data.trans[page.lang].sendmail }} &raquo;</a>
                         {% endif %}
-                    </div>
-                    <a href="#" class="tooltip-toggle contains-info">
-                        <span class="show-info">{{ site.data.trans[page.lang].showinfo }}</span>
-                        <span class="hide-info">{{ site.data.trans[page.lang].hideinfo }}</span>
-                    </a>
+                        <summary class="tooltip-toggle contains-info">
+                            <span class="show-info">{{ site.data.trans[page.lang].showinfo }}</span>
+                            <span class="hide-info">{{ site.data.trans[page.lang].hideinfo }}</span>
+                        </summary>
+                    </details>
                 {% else %}
                     <p class="tooltip-toggle">{{ site.data.trans[page.lang].noinfo }}</p>
                 {% endif %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -308,25 +308,54 @@ main {
     border: 1px solid #BFC6CC;
     border-top: 0;
     color: #293840;
-    display: none;
+    display: flex;
+    flex-direction: column;
     font-size: 12px;
     line-height: 1.5;
     margin: 0;
-    padding: 10px;
+    overflow: hidden;
+}
+
+.site-block .tooltip-content::details-content {
+    border-bottom: 0 solid #BFC6CC;
+    height: 0;
+    min-height: 0;
+    padding: 0 10px;
+}
+
+@supports (interpolate-size: allow-keywords) {
+    .site-block {
+        interpolate-size: allow-keywords;
+    }
+
+    .site-block .tooltip-content::details-content {
+        transition: height 0.4s, min-height 0.4s, content-visibility 0.4s, border-bottom-width 0.4s;
+        transition-behavior: allow-discrete;
+    }
 }
 
 .site-block .tooltip-toggle {
     background-color: #EAEBED;
-    border: 1px solid #BFC6CC;
-    border-top: 0;
     color: #878787;
+    cursor: pointer;
     display: block;
     font-size: 10px;
     font-weight: bold;
     line-height: 0;
-    margin: 0;
+    list-style: none;
+    order: 1;
     padding: 15px 10px;
     text-transform: uppercase;
+    user-select: none;
+}
+
+.site-block .tooltip-toggle::-webkit-details-marker {
+    display: none;
+}
+
+.site-block .email-info {
+    display: inline-block;
+    margin-bottom: 10px;
 }
 
 .site-block .tooltip-toggle.contains-info {
@@ -343,10 +372,15 @@ main {
     display: none;
 }
 
-.toggled + .tooltip-toggle > .show-info {
+.tooltip-content[open]::details-content {
+    border-bottom-width: 1px;
+    height: auto;
+}
+
+.tooltip-content[open] .show-info {
     display: none;
 }
-.toggled + .tooltip-toggle > .hide-info {
+.tooltip-content[open] .hide-info {
     display: inline;
 }
 

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -87,17 +87,6 @@ $(function(){
         }
     });
 
-    // Toggle visibility of site info boxes
-    $(".contains-info").click(function(e) {
-        e.preventDefault();
-        if ($(this).prev().hasClass("toggled")) {
-            $(this).prev().slideToggle().removeClass("toggled");
-        } else {
-            $(".toggled").slideToggle().removeClass("toggled");
-            $(this).prev().slideToggle().addClass("toggled");
-        }
-    });
-
     // When the search field changes, update the hash
     var hashUpdateTimer;
     $("input").on("input", function(){


### PR DESCRIPTION
This removes the need for the jQuery slideToggle previously used for showing and hiding card content, allowing it to be usable without JS. On browsers supporting the necessary CSS properties (Chrome and Edge at time of writing), the sliding animation is retained; for browsers without this support, the cards will open and close instantly instead.

This incorporates several other minor changes:
* Padding of card info contents is reduced; the text already had vertical margin around paragraphs, so the extra padding felt like too much
* For the same reason, a `<br>` is no longer inserted before the email link, when present
* Multiple cards can now be open at once. I don't think we ever had a reason to only ever have one open at once, so I didn't replicate that behavior here. (it would be easy to do so if there is a reason--setting a shared `name` attribute on each `<details>` element would ensure only one is open at a time)

Closes #2905