### PR TITLE
Add Beyond All Reason as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2498,6 +2498,14 @@
         "domains": ["betterment.com"]
     },
     {
+        "name": "Beyond All Reason",
+        "url": "https://www.beyondallreason.info/privacy",
+        "difficulty": "hard",
+        "notes": "Account deletion requires sending an email to the team, who will process the request.",
+        "email": "delete@beyondallreason.info",
+        "domains": ["beyondallreason.info"]
+    },
+    {
         "name": "BeyondMenu",
         "url": "https://www.beyondmenu.com/manageaccount.aspx",
         "difficulty": "easy",


### PR DESCRIPTION
## Summary

Adds **Beyond All Reason** (free, open-source RTS) to the list.

## Data

- `name`: Beyond All Reason
- `url`: https://www.beyondallreason.info/privacy
- `difficulty`: hard
- `notes`: Account deletion requires sending an email to the team, who will process the request.
- `email`: delete@beyondallreason.info
- `domains`: beyondallreason.info

## Context

Beyond All Reason has no self-service account deletion. Per their [privacy policy](https://www.beyondallreason.info/privacy), deletion is requested by emailing `delete@beyondallreason.info`. Because it requires contacting the team, it's classified as `hard`; the `email` field auto-generates the mailto link.

## Checklist

- [x] Placed alphabetically (between Betterment and BeyondMenu)
- [x] Indented 4 spaces per level
- [x] Valid JSON (validated against `script/validate_json.rb` rules)
- [x] Commit named "Add Beyond All Reason as hard"