### PR TITLE
Add Nebula as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -14561,6 +14561,13 @@
         "domains": ["nearpod.com"]
     },
     {
+        "name": "Nebula",
+        "url": "https://nebula.tv/settings/account/delete",
+        "difficulty": "easy",
+        "notes": "If you have an active subscription, cancel it first, then confirm the deletion on the account deletion page.",
+        "domains": ["nebula.tv"]
+    },
+    {
         "name": "Neocities.org",
         "url": "https://neocities.org/settings#delete",
         "difficulty": "easy",


### PR DESCRIPTION
## Summary

Adds **Nebula** (creator-owned streaming service) to the list.

## Data

- `name`: Nebula
- `url`: https://nebula.tv/settings/account/delete
- `difficulty`: easy
- `notes`: If you have an active subscription, cancel it first, then confirm the deletion on the account deletion page.
- `domains`: nebula.tv

## Context

Nebula provides a self-service account deletion page at `https://nebula.tv/settings/account/delete`. As with other subscription streaming services in the list (e.g. Netflix), an active subscription should be cancelled before deletion. Classified `easy` for consistency with comparable self-serve deletion flows.

## Checklist

- [x] Placed alphabetically (between Nearpod and Neocities.org)
- [x] Indented 4 spaces per level
- [x] Valid JSON (validated against `script/validate_json.rb` rules)
- [x] Commit named "Add Nebula as easy"