### PR TITLE
Add Domino's Pizza as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5778,6 +5778,13 @@
         "domains": ["dollskill.com"]
     },
     {
+        "name": "Domino's Pizza",
+        "url": "https://www.dominos.ca/en/pages/content/customer-service/faq",
+        "difficulty": "hard",
+        "notes": "Self-service account deletion is no longer available. Contact customer service to request deletion of your account and personal data.",
+        "domains": ["dominos.ca"]
+    },
+    {
         "name": "DonationAlerts",
         "url": "https://www.donationalerts.com/dashboard/general-settings/account",
         "notes": "Press \"Delete account\" under the \"Account removal\". Your account will be deleted within a month.",


### PR DESCRIPTION
## Summary

Adds **Domino's Pizza** (Canada) to the list.

## Data

- `name`: Domino's Pizza
- `url`: https://www.dominos.ca/en/pages/content/customer-service/faq
- `difficulty`: hard
- `notes`: Self-service account deletion is no longer available. Contact customer service to request deletion of your account and personal data.
- `domains`: dominos.ca

## Context

As of 2024, Domino's Canada no longer offers self-service account deletion through the website (Pizza Profile). Deleting an account / personal data now requires contacting customer service, so this is classified `hard`.

## Checklist

- [x] Placed alphabetically (between Dollskill and DonationAlerts)
- [x] Indented 4 spaces per level
- [x] Valid JSON (validated against `script/validate_json.rb` rules)
- [x] Commit named "Add Domino's Pizza as hard"