### PR TITLE
Add Pikkado as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -16487,6 +16487,14 @@
         ]
     },
     {
+        "name": "Pikkado",
+        "url": "https://www.pikkado.com/contact/en",
+        "difficulty": "hard",
+        "notes": "There is no self-service account deletion. Contact support to request deletion of your account and personal data.",
+        "email": "webmaster@en.pikkado.com",
+        "domains": ["pikkado.com"]
+    },
+    {
         "name": "Pillpack",
         "url": "https://help.pillpack.com/hc/en-us/requests/new",
         "difficulty": "hard",


### PR DESCRIPTION
## Summary

Adds **Pikkado** (free Secret Santa / gift-exchange organizer) to the list.

## Data

- `name`: Pikkado
- `url`: https://www.pikkado.com/contact/en
- `difficulty`: hard
- `notes`: There is no self-service account deletion. Contact support to request deletion of your account and personal data.
- `email`: webmaster@en.pikkado.com
- `domains`: pikkado.com

## Context

Pikkado offers no self-service account deletion: the FAQ does not cover it, and the privacy policy directs data-related requests to `webmaster@en.pikkado.com`. Deleting an account / personal data therefore requires contacting support, so this is classified `hard`.

## Checklist

- [x] Placed alphabetically (between PicPay and Pillpack)
- [x] Indented 4 spaces per level
- [x] Valid JSON (validated against `script/validate_json.rb` rules)
- [x] Commit named "Add Pikkado as hard"