### PR TITLE
Add Carrefour as medium

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3535,19 +3535,19 @@
         "domains": ["cariboutests.com"]
     },
     {
+        "name": "Carrd.co",
+        "url": "https://carrd.co/dashboard/account/delete",
+        "difficulty": "easy",
+        "notes": "Just enter password and confirm deletion!",
+        "domains": ["carrd.co"]
+    },
+    {
         "name": "Carrefour",
         "url": "https://www.carrefour.fr/nous-contacter/rgpd/formulaire",
         "difficulty": "medium",
         "notes": "Fill out the GDPR form. Select 'Droit à l'effacement de vos données' and choose the service(s) concerned (Carrefour.fr, Carte Club Carrefour, or specify others).",
         "notes_fr": "Remplissez le formulaire RGPD. Sélectionnez 'Droit à l'effacement de vos données' et choisissez le(s) service(s) concerné(s) (Carrefour.fr, Carte Club Carrefour ou précisez d'autres services).",
         "domains": ["carrefour.fr"]
-    },
-    {
-        "name": "Carrd.co",
-        "url": "https://carrd.co/dashboard/account/delete",
-        "difficulty": "easy",
-        "notes": "Just enter password and confirm deletion!",
-        "domains": ["carrd.co"]
     },
     {
         "name": "Cars Région Isère",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3535,6 +3535,14 @@
         "domains": ["cariboutests.com"]
     },
     {
+        "name": "Carrefour",
+        "url": "https://www.carrefour.fr/nous-contacter/rgpd/formulaire",
+        "difficulty": "medium",
+        "notes": "Fill out the GDPR form. Select 'Droit à l'effacement de vos données' and choose the service(s) concerned (Carrefour.fr, Carte Club Carrefour, or specify others).",
+        "notes_fr": "Remplissez le formulaire RGPD. Sélectionnez 'Droit à l'effacement de vos données' et choisissez le(s) service(s) concerné(s) (Carrefour.fr, Carte Club Carrefour ou précisez d'autres services).",
+        "domains": ["carrefour.fr"]
+    },
+    {
         "name": "Carrd.co",
         "url": "https://carrd.co/dashboard/account/delete",
         "difficulty": "easy",


### PR DESCRIPTION
This PR adds Carrefour to the Just Delete Me directory with the procedure for requesting account/data deletion via their GDPR form.

The entry includes:
- Direct link to the Carrefour GDPR form
- Marked as 'medium' difficulty since users fill out a form themselves but need to perform additional steps
- Notes in both English and French explaining the process
- Proper domain entry for the service

Users can use this form to exercise their right to erasure under GDPR by selecting 'Droit à l'effacement de vos données' and choosing the relevant service(s).