### PR TITLE
Add YouTube Kids domain

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -24526,7 +24526,8 @@
         "domains": [
             "youtube.com",
             "music.youtube.com",
-            "studio.youtube.com"
+            "studio.youtube.com",
+            "kids.youtube.com"
         ]
     },
     {


### PR DESCRIPTION
Added the domain for YouTube Kids ([YouTube Kids](https://kids.youtube.com)) in the YouTube field.