### PR TITLE
Accept domains when filtering

### DIFF
--- a/_includes/body.html
+++ b/_includes/body.html
@@ -20,7 +20,7 @@
         <p class="no-results">{{ site.data.trans[page.lang].noresults }} <a href='https://github.com/jdm-contrib/jdm'>{{ site.data.trans[page.lang].noresultshelp }}</a>.</p>
 
         {% for entry in site.data.sites %}
-            <section class="site-block {{ entry.difficulty }}"{% if entry.meta == 'popular' %} data-popular{% endif %}>
+            <section class="site-block {{ entry.difficulty }}"{% if entry.meta == 'popular' %} data-popular{% endif %}{% if entry.domains %} data-domains='{{ entry.domains | jsonify }}'{% endif %}>
                 {% capture lang_url %}url_{{ page.lang }}{% endcapture %}
                 <a class="site-header" href="{% if entry[lang_url] %}{{ entry[lang_url] }}{% else %}{{entry.url}}{% endif %}">
                     <span class="name">{{ entry.name }}</span>

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -31,10 +31,26 @@ $(function(){
             var siteHeader = $(this).find(".site-header")[0];
             var siteTitle = siteHeader.innerText.trim().toLowerCase();
             var siteUrl = siteHeader.href.toLowerCase();
+            var siteDomains = $(this).data("domains") || [];
             var lowerTerm = term.toLowerCase();
+            var normalizedDomains = siteDomains.map(function(domain) {
+                return domain.toLowerCase();
+            });
 
-            // returns true if lowerTerm isn't found in site title or URL
-            return Math.max(siteTitle.indexOf(lowerTerm), siteUrl.indexOf(lowerTerm)) === -1;
+            var startsWithDomain = normalizedDomains.some(function(domain) {
+                return domain.indexOf(lowerTerm) === 0;
+            });
+
+            if (startsWithDomain) {
+                return false;
+            }
+
+            var domainMatch = normalizedDomains.some(function(domain) {
+                return domain.indexOf(lowerTerm) !== -1;
+            });
+
+            // returns true if lowerTerm isn't found in site title or URL or domains
+            return siteTitle.indexOf(lowerTerm) === -1 && siteUrl.indexOf(lowerTerm) === -1 && !domainMatch;
         });
 
         // Insert the term into the search field


### PR DESCRIPTION
Fixes #1783 to accept searching for a domain (such as `youtube.com`). Tested locally using Jekyll in the described way in README.md.