### PR TITLE
Fix Hebrew typo

### DIFF
--- a/_data/trans/he.json
+++ b/_data/trans/he.json
@@ -8,7 +8,7 @@
     "difficulty_easy": "קל",
     "difficulty_hard": "קשה",
     "difficulty_impossible": "בלתי אפשרי",
-    "difficulty_limited": "אפשריות מוגבלת",
+    "difficulty_limited": "אפשרות מוגבלת",
     "difficulty_medium": "בינוני",
     "extension_browser": "הרחבה ל־ Chrome או ל־Firefox",
     "extensionguide": "מדריך נקודות הרחבה",


### PR DESCRIPTION
This PR fixes a Hebrew typo in the "limited availability" field in the Hebrew translation file.