### PR TITLE
Update search placeholder color contrast

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -158,12 +158,6 @@ header h1 span {
 #search::placeholder {
     color: lightgray;
 }
-#search::-webkit-input-placeholder {
-    color: lightgray;
-}
-#search::-moz-placeholder {
-    color: lightgray;
-}
 
 .search .search-container label {
     background: url('../img/spyglass.png');

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -155,6 +155,16 @@ header h1 span {
     direction: ltr;
 }
 
+#search::placeholder {
+    color: lightgray;
+}
+#search::-webkit-input-placeholder {
+    color: lightgray;
+}
+#search::-moz-placeholder {
+    color: lightgray;
+}
+
 .search .search-container label {
     background: url('../img/spyglass.png');
     background-size: 20px 20px;


### PR DESCRIPTION
This PR fixes issue #2986. Now the placeholder is light gray, which creates a good color contrast with the red background.

Tested locally using Jekyll as described in README.md.

<img width="533" height="94" alt="image" src="https://github.com/user-attachments/assets/3807de47-aeba-4635-83aa-a1bb17b9ee22" />
