### PR TITLE
Mark GitHub as popular

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -8435,6 +8435,7 @@
         "name": "GitHub",
         "url": "https://github.com/settings/admin#:~:text=Delete%20account",
         "difficulty": "easy",
+        "meta": "popular",
         "notes": "Click on 'Delete account' near the bottom of the page and follow the instructions. Some user content will continue to exist anonymously on the website.",
         "notes_tr": "Sayfanın altındaki \"Hesabı Sil\" tuşuna tıklayın ve yönergeleri takip edin. Bazı kullanıcı içerikleri web sitesinde anonim olarak bulunmaya devam edecek.",
         "domains": [


### PR DESCRIPTION
I've marked GitHub as popular using `meta: "popular"`.

This was tested locally using Jekyll as described in README.md.