### PR TITLE
Show popular badges on popular sites

### DIFF
--- a/_includes/body.html
+++ b/_includes/body.html
@@ -24,6 +24,9 @@
                 {% capture lang_url %}url_{{ page.lang }}{% endcapture %}
                 <a class="site-header" href="{% if entry[lang_url] %}{{ entry[lang_url] }}{% else %}{{entry.url}}{% endif %}">
                     <span class="name">{{ entry.name }}</span>
+                    {% if entry.meta == 'popular' %}
+                        <span class="popular-badge">Popular</span>
+                    {% endif %}
                     <img class="icon" src="{{ site.baseurl }}/assets/icons/link.svg" alt="URL" />
                 </a>
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -303,6 +303,30 @@ main {
     text-transform: uppercase;
 }
 
+.popular-badge {
+    font-size: 11px;
+    border-radius: 9999px;
+    padding: 2px;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+.easy .popular-badge {
+    background-color: color-mix(#7BAC7B 60%, white 40%);
+}
+.medium .popular-badge {
+    background-color: color-mix(#E8C674 70%, white 30%);
+}
+.hard .popular-badge {
+    background-color: color-mix(#D04343 70%, white 30%);
+}
+.limited .popular-badge {
+    background-color: color-mix(#B521CC 60%, white 40%);
+}
+.impossible .popular-badge {
+    background-color: color-mix(#000000 60%, white 40%);
+}
+
 .site-block .tooltip-content {
     background-color: #EAEBED;
     border: 1px solid #BFC6CC;


### PR DESCRIPTION
This fixes issue #2990 to show "popular" badges on popular sites.

<img width="246" height="108" alt="image" src="https://github.com/user-attachments/assets/98e6733e-3473-4852-beb5-6f225500b7dc" />
<img width="247" height="108" alt="image" src="https://github.com/user-attachments/assets/87692dbd-18fd-4e06-809d-a0b0ce21b4a2" />
<img width="248" height="110" alt="image" src="https://github.com/user-attachments/assets/68e42104-b721-41c7-b544-33c09da5fceb" />
<img width="247" height="105" alt="image" src="https://github.com/user-attachments/assets/71eb2c59-455e-4536-9edd-76c513d748f7" />

There is also a tested badge for limited availability but there are no popular limited availablity sites.

This was tested locally using Jekyll as described in README.md.

Note: the color percentages in `color-mix` are different between difficulties to make sure color contrast passes.