### PR TITLE
Add browser compatibility to search box placeholder contrast

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -158,6 +158,12 @@ header h1 span {
 #search::placeholder {
     color: lightgray;
 }
+#search::-moz-placeholder {
+    color: lightgray;
+}
+#search::-webkit-input-placeholder {
+    color: lightgray;
+}
 
 .search .search-container label {
     background: url('../img/spyglass.png');


### PR DESCRIPTION
# Background
PR #2988 did the exact thing, but then it had a wrong commit that removed the compatibility for Chrome and Firefox. I couldn't revert that commit because the PR was already merged. So I created this PR.

# Tests
This was tested locally using Jekyll as described in README.md.