### PR TITLE
Add Blaise Transit as medium

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2700,6 +2700,13 @@
         "domains": ["blackwing602.com"]
     },
     {
+        "name": "Blaise Transit",
+        "url": "https://www.blaisetransit.com/contact-us",
+        "difficulty": "medium",
+        "notes": "Fill out the form to contact support and have your account deleted.",
+        "domains": ["blaisetransit.com"]
+    },
+    {
         "name": "Bleep",
         "url": "https://bleep.com/account/show",
         "difficulty": "hard",


### PR DESCRIPTION
Blaise Transit
medium because filling out a form is required, but it's fairly simple I provided the first 5 characters of my password(s) but otherwise they didn't verify that the account(s) were actually mine...perhaps concerning