### PR TITLE
Add WDM Gem if in Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ gem "jekyll", ">= 4.4.1"
 gem "logger", ">= 1.7.0"
 gem "html-proofer", ">= 5.2.1"
 
+gem "wdm", ">= 0.1.0" if Gem.win_platform?
+
 eval_gemfile "script/Gemfile"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     unicode-display_width (2.6.0)
+    wdm (0.2.0)
     webrick (1.9.1)
     yell (2.2.2)
     zeitwerk (2.7.1)
@@ -131,6 +132,7 @@ DEPENDENCIES
   jekyll (>= 4.4.1)
   logger (>= 1.7.0)
   nokogiri (>= 1.19.1)
+  wdm (>= 0.1.0)
 
 BUNDLED WITH
   4.0.11


### PR DESCRIPTION
I use a Windows computer. When I run `jekyll serve` to start the site locally, it works but I get this in the output:
```text
Please add the following declaration to your Gemfile to avoid polling for changes:
  gem 'wdm', '>= 0.1.0' if Gem.win_platform?
```

So I added it in this PR.
