### PR TITLE
feat: add viagogo as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22755,6 +22755,22 @@
         "domains": ["viadeo.com"]
     },
     {
+        "name": "viagogo",
+        "url": "https://my.viagogo.com/settings/?activeTab=PERSONALDETAILS",
+        "difficulty": "easy",
+        "notes": "Before deleting, close any active listing, sale, purchase, or pending payment; deletion is only possible 7 days after your last event. Then open the 'Personal details' tab in Settings and click 'Delete my account'.",
+        "domains": [
+            "viagogo.ca",
+            "viagogo.co.uk",
+            "viagogo.com",
+            "viagogo.de",
+            "viagogo.es",
+            "viagogo.fr",
+            "viagogo.it",
+            "viagogo.nl"
+        ]
+    },
+    {
         "name": "viainvest",
         "url": "https://viainvest.com/en/faq",
         "difficulty": "hard",


### PR DESCRIPTION
Adds viagogo, the concert, sport and theatre ticket marketplace, as an easy deletion. Account removal is self-serve from the Personal details tab in account settings using the Delete my account button, provided you have closed any active listings, sales, purchases or pending payments and it has been at least 7 days since your last event. The listed domains were each checked to confirm they serve viagogo before submission. Sources: https://my.viagogo.com/settings/?activeTab=PERSONALDETAILS and https://support.viagogo.com/articles/61000276675-delete-account