### PR TITLE
Fix typo in YouTube entry

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -24164,7 +24164,7 @@
         "meta": "popular",
         "url": "https://myaccount.google.com/deleteservices",
         "difficulty": "medium",
-        "notes": "Click the trash can next to YouTube and confirm the verification email. You can request a copy of your data, before you delete it.\nIf you want to delete your entire google account, use the instructions for [Google](https://justdeleteme.xyz/#google).",
+        "notes": "Click the trash can next to YouTube and confirm the verification email. You can request a copy of your data, before you delete it.\nIf you want to delete your entire Google account, use the instructions for [Google](https://justdeleteme.xyz/#google).",
         "notes_tr": "YouTube hesabınızı silmeden önce verilerinizin bir kopyasını talep edebilirsiniz.",
         "notes_ru": "Вы можете запросить копию данных перед удалением учетной записи YouTube.",
         "domains": [


### PR DESCRIPTION
In the YouTube entry, the word "Google" should be capitalized.
