### PR TITLE
Add TutorialSearch as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -21793,6 +21793,13 @@
         ]
     },
     {
+        "name": "TutorialSearch",
+        "url": "https://tutorialsearch.io/account",
+        "difficulty": "easy",
+        "notes": "Sign in, open the Account page, click \"Delete my account\", type \"DELETE\" and confirm. This permanently deletes your account and all saved tutorials, collections, and progress.",
+        "domains": ["tutorialsearch.io"]
+    },
+    {
         "name": "TV 2",
         "url": "https://mit.tv2.dk/konto/luk",
         "difficulty": "easy",


### PR DESCRIPTION
Adds [TutorialSearch](https://tutorialsearch.io) — a tutorial/course search platform — to the directory.

- **Difficulty:** `easy`
- **URL:** https://tutorialsearch.io/account — direct link to the account page containing the delete control.
- **Process:** Sign in, open the Account page, click "Delete my account", type "DELETE" and confirm. This permanently deletes the account together with all saved tutorials, collections, and progress.

### Checklist
- [x] Placed alphabetically (between `Tutamail` and `TV 2`)
- [x] 4-space indentation per level
- [x] `sites.json` validated as well-formed JSON
- [x] Uses a supported difficulty value and only supported entry fields