### PR TITLE
Add ClearMyInbox

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3905,9 +3905,7 @@
         "url": "https://www.clearmyinbox.ai/account",
         "difficulty": "easy",
         "notes": "Log in, open the Account page, click Delete Account and confirm with your email address. Deletion is immediate, permanent and also revokes the Gmail connection.",
-        "domains": [
-            "clearmyinbox.ai"
-        ]
+        "domains": ["clearmyinbox.ai"]
     },
     {
         "name": "CleverReach",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -3901,6 +3901,15 @@
         "domains": ["claude.ai"]
     },
     {
+        "name": "ClearMyInbox",
+        "url": "https://www.clearmyinbox.ai/account",
+        "difficulty": "easy",
+        "notes": "Log in, open the Account page, click Delete Account and confirm with your email address. Deletion is immediate, permanent and also revokes the Gmail connection.",
+        "domains": [
+            "clearmyinbox.ai"
+        ]
+    },
+    {
         "name": "CleverReach",
         "url": "https://www.cleverreach.com",
         "difficulty": "hard",


### PR DESCRIPTION
Adds ClearMyInbox (clearmyinbox.ai), a Gmail unsubscribe/inbox-cleanup service.

- URL points to the logged-in Account page, which has a Delete Account button with an email-confirmation dialog.
- Difficulty: easy — deletion is self-serve, immediate and permanent, and also revokes the service's Gmail OAuth grant.
- Entry placed alphabetically (between Claude and CleverReach) in `_data/sites.json`, 4-space indented, file validates as JSON.

Originally submitted to justdeleteme/justdelete.me#907; resubmitted here at @tupaschoal's suggestion since that repository is unmaintained.

Disclosure: I'm the developer of ClearMyInbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)