### PR TITLE
Add SalahClock as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -18260,6 +18260,13 @@
         ]
     },
     {
+        "name": "SalahClock",
+        "url": "https://salahclock.app/dashboard/account",
+        "difficulty": "easy",
+        "notes": "Open Account from the menu, then click \"Delete my account\" and type DELETE to confirm. If you are on a paid plan, cancel your subscription from the Billing page first.",
+        "domains": ["salahclock.app"]
+    },
+    {
         "name": "SamMobile",
         "url": "https://www.sammobile.com/remove-account/",
         "difficulty": "medium",


### PR DESCRIPTION
Adds SalahClock (salahclock.app), a prayer-times display service for mosques and homes.

- **name:** SalahClock
- **url:** https://salahclock.app/dashboard/account
- **difficulty:** easy — a self-serve "Delete my account" button on the Account page permanently deletes the account after a typed "DELETE" confirmation.
- **notes:** cover the confirmation step and the "cancel your subscription first" requirement for paid plans.
- **domains:** salahclock.app

Placed alphabetically (between Salad and SamMobile), 4-space indented, and JSON validated.