### PR TITLE
Add Vivideo as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22676,6 +22676,16 @@
         "domains": ["vive-lamode.com"]
     },
     {
+        "name": "Vivideo",
+        "url": "https://app.vivideo.ai/account",
+        "difficulty": "easy",
+        "notes": "Sign in, open the Account settings page and select 'Delete Account' at the bottom. Deletion is immediate and permanent, and your personal data is removed within 30 days. Deleting your account does not cancel an active subscription, so cancel any subscription on the Settings page first.",
+        "domains": [
+            "vivideo.ai",
+            "app.vivideo.ai"
+        ]
+    },
+    {
         "name": "ViVo",
         "url": "https://passport.vivo.com/in/#/personalCenter",
         "difficulty": "easy",


### PR DESCRIPTION
Adds [Vivideo](https://vivideo.ai) (AI video generation platform) to the directory.

- **name**: Vivideo
- **url**: https://app.vivideo.ai/account (in-app Account settings)
- **difficulty**: `easy` — there is a self-serve "Delete Account" button in the account settings of both the web app and mobile app.
- **notes**: Deletion is immediate and permanent (personal data removed within 30 days). Deleting the account does not cancel an active subscription, so the note reminds users to cancel any subscription first.

Entry placed alphabetically between "Vive La Mode" and "ViVo". `sites.json` validated as valid JSON.

Made with [Cursor](https://cursor.com)