### PR TITLE
Update notes for Vivideo

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22679,7 +22679,7 @@
         "name": "Vivideo",
         "url": "https://app.vivideo.ai/account",
         "difficulty": "easy",
-        "notes": "Sign in, open the Account settings page and select 'Delete Account' at the bottom. Deletion is immediate and permanent, and your personal data is removed within 30 days. Deleting your account does not cancel an active subscription, so cancel any subscription on the Settings page first.",
+        "notes": "Sign in to your [Vivideo](https://vivideo.ai) account, open the Account settings page and select 'Delete Account' at the bottom. Deletion is immediate and permanent, and your personal data is removed within 30 days. Deleting your account does not cancel an active subscription, so cancel any subscription on the Settings page first.",
         "domains": [
             "vivideo.ai",
             "app.vivideo.ai"


### PR DESCRIPTION
Minor notes tweak for the existing Vivideo entry: link the service name to the main site so the instructions point users to the correct place to sign in.

- Adds a markdown link to https://vivideo.ai in the `notes` (per the contributing guidelines, which support markdown links in notes).
- No change to `url`, `difficulty`, or `domains`.

`sites.json` validated as valid JSON.

Made with [Cursor](https://cursor.com)