### PR TITLE
Update url for Vivideo

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22677,9 +22677,9 @@
     },
     {
         "name": "Vivideo",
-        "url": "https://app.vivideo.ai/account",
+        "url": "https://vivideo.ai",
         "difficulty": "easy",
-        "notes": "Sign in, open the Account settings page and select 'Delete Account' at the bottom. Deletion is immediate and permanent, and your personal data is removed within 30 days. Deleting your account does not cancel an active subscription, so cancel any subscription on the Settings page first.",
+        "notes": "Sign in and open the Account page, then select 'Delete Account' at the bottom. Deletion is immediate and permanent, and your personal data is removed within 30 days. Deleting your account does not cancel an active subscription, so cancel any subscription on the Settings page first.",
         "domains": [
             "vivideo.ai",
             "app.vivideo.ai"


### PR DESCRIPTION
Updates the `url` for the Vivideo entry to the main site, `https://vivideo.ai`, and adjusts the note to direct users to the in-app Account page for deletion.

- **url**: `https://app.vivideo.ai/account` → `https://vivideo.ai`
- **notes**: now says to sign in and open the Account page, then select "Delete Account" (deletion is immediate/permanent, data removed within 30 days, and it does not cancel an active subscription).

Difficulty remains `easy` (self-serve delete button in account settings). `sites.json` validated as valid JSON.

Made with [Cursor](https://cursor.com)