### PR TITLE
Add PixMind as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -16523,6 +16523,14 @@
         "domains": ["pixlr.com"]
     },
     {
+        "name": "PixMind",
+        "url": "https://www.pixmind.io/privacy-policy",
+        "difficulty": "hard",
+        "notes": "Contact support via email and request your account and personal information to be deleted.",
+        "email": "support@pixmind.io",
+        "domains": ["pixmind.io"]
+    },
+    {
         "name": "Pixum",
         "url": "https://int.pixum.com/service/delete-account",
         "difficulty": "hard",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -16526,7 +16526,6 @@
         "name": "PixMind",
         "url": "https://www.pixmind.io/privacy-policy",
         "difficulty": "hard",
-        "notes": "Contact support via email and request your account and personal information to be deleted.",
         "email": "support@pixmind.io",
         "domains": ["pixmind.io"]
     },


### PR DESCRIPTION
Adds PixMind to the account-deletion directory.

PixMind’s privacy policy documents the right to request deletion of personal information, and its public contact page identifies support@pixmind.io for support requests. Because deletion requires contacting support rather than using a self-service button, this entry is marked as hard.

Validation:
- Parsed `_data/sites.json` successfully
- Confirmed alphabetical placement between Pixlr and Pixum
- `git diff --check` passed