### PR TITLE
Validate `url` Field in Entries

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5454,10 +5454,14 @@
     },
     {
         "name": "distill.io",
-        "url": "distill.io",
+        "url": "https://accounts.distill.io/account/#/account/",
         "difficulty": "easy",
-        "notes": "Click the button to delete the account.",
-        "domains": ["distill.io"]
+        "notes": "Click the 'Close Account' button to delete your account.",
+        "domains": [
+            "distill.io",
+            "accounts.distill.io",
+            "monitor.distill.io"
+        ]
     },
     {
         "name": "Divize",
@@ -21011,7 +21015,7 @@
     },
     {
         "name": "Texas Instruments (TI)",
-        "url": "www.ti.com/feedbackform/home",
+        "url": "https://www.ti.com/feedbackform/home",
         "difficulty": "hard",
         "domains": ["ti.com"]
     },
@@ -23404,7 +23408,7 @@
     },
     {
         "name": "wikiHow",
-        "url": "wikihow.com/Special:Preferences#mw-prefsection-personal",
+        "url": "https://www.wikihow.com/Special:Preferences#mw-prefsection-personal",
         "difficulty": "hard",
         "notes": "Requires emailing them to request for deletion.",
         "domains": ["wikihow.com"]

--- a/script/validate_json.rb
+++ b/script/validate_json.rb
@@ -22,6 +22,7 @@ module ExitCodes
     DUPLICATES = 13                # Duplicate entries
     MALFORMED_NOTES = 14           # Malformed notes
     INVALID_DOMAINS = 15           # Domain starts with forbidden prefix
+    INVALID_URL_SCHEME = 16        # URL isn't prefixed with http:// or https://
 end
 
 SupportedDifficulties = ["easy", "medium", "hard", "limited", "impossible"]
@@ -118,6 +119,18 @@ def validate_difficulty(key)
                     "Use one of the supported difficulty values:\n"\
                     "\t#{SupportedDifficulties}"
         exit ExitCodes::UNEXPECTED_DIFFICULTY
+    end
+end
+
+def validate_url_schemes(key)
+    key.each do |entry_key, value|
+        next unless entry_key.to_s.match?(/\Aurl(_.*)?\z/)
+        unless value.to_s.match?(%r{\Ahttps?://})
+            STDERR.puts "Entry '#{entry['name']}' key '#{entry_key}' has an invalid URL value: "\
+                        "'#{value}'.\n"\
+                        "Value must start with 'http://' or 'https://'."
+            exit ExitCodes::INVALID_URL_SCHEME
+        end
     end
 end
 


### PR DESCRIPTION
- Add validation for URL schemes to ensure they start with 'http://' or 'https://'.
- Updated URL values for various sites to add 'https://' schemes.

NOTE: Typo in second commit message (7d456a3) - should be 'Added missing schemas' instead of 'Removed'.