### PR TITLE
Add Lovable as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12272,7 +12272,7 @@
         "name": "Lovable",
         "url": "https://lovable.dev/settings/account",
         "difficulty": "easy",
-        "notes": "Scroll down and click on the \"Delete Account\" button, then decide whether to transform ownership of your workspaces, then enter your E-mail into the dialog and confirm.",
+        "notes": "Scroll down and click on the \"Delete Account\" button, decide whether to transfer ownership of your workspaces, then enter your e-mail into the dialog and confirm.",
         "domains": ["lovable.dev"]
     },
     {

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12269,6 +12269,13 @@
         "domains": ["loseit.com"]
     },
     {
+        "name": "Lovable",
+        "url": "https://lovable.dev/settings/account",
+        "difficulty": "easy",
+        "notes": "Scroll down and click on the \"Delete Account\" button, then decide wether to transform ownership of your workspaces, then enter your E-mail into the dialog and confirm.",
+        "domains": ["lovable.dev"]
+    },
+    {
         "name": "Love My Credit Union Rewards",
         "url": "https://rewards.lovemycreditunion.org/contact-us/",
         "difficulty": "hard",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -12272,7 +12272,7 @@
         "name": "Lovable",
         "url": "https://lovable.dev/settings/account",
         "difficulty": "easy",
-        "notes": "Scroll down and click on the \"Delete Account\" button, then decide wether to transform ownership of your workspaces, then enter your E-mail into the dialog and confirm.",
+        "notes": "Scroll down and click on the \"Delete Account\" button, then decide whether to transform ownership of your workspaces, then enter your E-mail into the dialog and confirm.",
         "domains": ["lovable.dev"]
     },
     {


### PR DESCRIPTION
# Add Lovable as easy

Steps for deletion (notes): Scroll down and click on the \"Delete Account\" button, decide whether to transfer ownership of your workspaces, then enter your e-mail into the dialog and confirm.

## Screenshots from Lovable UI

### Account page
<img width="1600" height="793" alt="lovable account page screenshot" src="https://github.com/user-attachments/assets/7bad7c90-4f55-4f29-8db4-c350a9b1d512" />

### Transfer workspace ownership
<img width="540" height="332" alt="lovable transfer workspace ownership screenshot" src="https://github.com/user-attachments/assets/f98b96ae-92d7-49cc-810f-b1df0efe7be2" />

### Confirm account deletion
<img width="567" height="237" alt="lovable confirm account deletion screenshot" src="https://github.com/user-attachments/assets/7d5c4009-613a-4049-b439-2ce72c9a03ac" />
