### PR TITLE
Add Imagga as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -10148,6 +10148,14 @@
         "domains": ["imageshack.com"]
     },
     {
+        "name": "Imagga",
+        "url": "https://imagga.com/company#contacts",
+        "difficulty": "hard",
+        "email": "support@imagga.com",
+        "email_body": "Please delete my account, my e-mail is XXXXXX",
+        "domains": ["imagga.com"]
+    },
+    {
         "name": "IMDb",
         "url": "https://www.imdb.com/registration/delete",
         "difficulty": "easy",


### PR DESCRIPTION
There's no resources on their website on account deletion, other than the page I linked and the TOS page, AFAIK. The closest thing I can link which seems relevant is their contacts page which contains their support e-mail link, shown in the following screenshot.

No note added since I included an e-mail.

In addition, their TOS states (at Art. 3 (1) 3.) that the user can delete their account from the account page, however I do not recall seeing any account deletion button and have unfortunately not photographed that page. Regardless, I deleted my account via e-mail.

<img width="1920" height="1080" alt="imagga company contacts page" src="https://github.com/user-attachments/assets/c3d73e86-220a-4e4b-b6ab-fb454fae789f" />
