### PR TITLE
Update notes for Reddit

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -17813,7 +17813,7 @@
         "meta": "popular",
         "url": "https://www.reddit.com/prefs/delete/",
         "difficulty": "easy",
-        "notes": "If you are opted in to the redesign, scroll to the bottom and click on the Delete Account button. Your content will not be deleted (only disassociated).",
+        "notes": "If you are opted in to the redesign, scroll to the bottom and click on the Delete Account button. Your content will not be deleted (only disassociated). Content deletion can be automated using several third party tools, such as [PowerDeleteSuite](https://github.com/j0be/PowerDeleteSuite) and [Ereddicator](https://github.com/Jelly-Pudding/ereddicator).",
         "domains": [
             "reddit.com",
             "accounts.reddit.com",


### PR DESCRIPTION
Add info on Reddit content deletion tools
----

Add info on how to delete your Reddit content using the following third-party Reddit content deletion tools:
- [PowerDeleteSuite](https://github.com/j0be/PowerDeleteSuite)
- [Ereddicator](https://github.com/Jelly-Pudding/ereddicator/)

I am not affiliated with either PowerDeleteSuite or Ereddicator. 

I have seen comments redacted by PDS in the wild in the past, and discussions recommending both tools. I personally have used neither.

I figured, since Discord has information on how to delete your messages using Discorch, that this change is appropriate. 