### PR TITLE
Update e-mail subject and body for Dollskill

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5586,7 +5586,7 @@
         "url": "https://www.dollskill.com/pages/contact-us",
         "difficulty": "hard",
         "email": "dataprotection@dollskill.com",
-        "email_subject": "Hello\n, please delete the account associated to this email. My phone number is XXXXXXXX and I would like all data associated to my account to be removed.",
+        "email_body": "Hello\n, please delete the account associated to this email. My phone number is XXXXXXXX and I would like all data associated to my account to be removed.",
         "domains": ["dollskill.com"]
     },
     {


### PR DESCRIPTION
Swap between e-mail subject and body fields, because this is what the e-mail looks like currently (shown in screenshot), with what I assume was supposed to originally be the e-mail body in the subject, and the body being the default text. This PR will change the subject to the default text.

<img width="1080" height="864" alt="email screenshot" src="https://github.com/user-attachments/assets/05463263-844b-4e91-9380-a82f38ea15e5" />
