### PR TITLE
Add Authier as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1725,7 +1725,10 @@
         "url": "https://vault.authier.pm/settings/account",
         "difficulty": "easy",
         "notes": "In the Danger zone, click \"Delete your account\" and confirm.",
-        "domains": ["authier.pm", "vault.authier.pm"]
+        "domains": [
+            "authier.pm",
+            "vault.authier.pm"
+        ]
     },
     {
         "name": "Author.today",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -1721,6 +1721,13 @@
         "domains": ["auth0.com"]
     },
     {
+        "name": "Authier",
+        "url": "https://vault.authier.pm/settings/account",
+        "difficulty": "easy",
+        "notes": "In the Danger zone, click \"Delete your account\" and confirm.",
+        "domains": ["authier.pm", "vault.authier.pm"]
+    },
+    {
         "name": "Author.today",
         "url": "https://help.author.today/knowledge_base/item/268554?sid=58980",
         "difficulty": "impossible",


### PR DESCRIPTION
## Summary

- Add Authier with `easy` deletion difficulty.
- Link directly to the signed-in account settings page.
- Describe the two visible actions: use the Danger zone's **Delete your account** button and confirm.

## Verification

- `https://vault.authier.pm/settings/account` returns HTTP 200.
- I created a disposable normal account against production, confirmed it was authenticated, used the same `deleteAccount` GraphQL path as the UI, and confirmed the deleted account's access token was then rejected as `not authenticated`. No credential or token is included here.
- A local resolver test against an in-memory PGlite database also confirmed deletion of the user and its dependent device, encrypted-secret, and API-token rows.

## Checks

- `script/validate_json.rb`
- `script/check_files_formatting.sh`
- `script/run_jekyll.sh` (Jekyll build and HTML-Proofer)
- `script/ping_websites.rb` (completed successfully; it reported existing unrelated unreachable/404 entries, but not Authier)

## Disclosures

I maintain Authier. AI assisted with the research, test preparation, entry edit, and PR draft; I reviewed and verified the result. Authier is early-stage software and has not undergone an independent security audit.
