### PR TITLE
Add eco99music as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -6089,6 +6089,12 @@
         "domains": ["ebonus.gg"]
     },
     {
+        "name": "eco99music",
+        "url": "https://eco99fm.maariv.co.il/settings",
+        "difficulty": "easy",
+        "domains": ["eco99fm.maariv.co.il"]
+    },
+    {
         "name": "Economist",
         "url": "https://myaccount.economist.com/s/contact-us",
         "difficulty": "hard",


### PR DESCRIPTION
No notes added since it's very straightforward, it's the upper red link (says "account deletion" in Hebrew) in the linked page (shown in screenshot) and then confirm the dialog
<img width="1920" height="1080" alt="eco99music account deletion page" src="https://github.com/user-attachments/assets/81530881-b8a6-4d1e-b726-864672842301" />
