### PR TITLE
Add Nudie Jeans as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -15129,6 +15129,15 @@
         "domains": ["nube.com.br"]
     },
     {
+        "name": "Nudie Jeans",
+        "url": "https://www.nudiejeans.com/co",
+        "difficulty": "hard",
+        "email": "shop@nudiejeans.com",
+        "email_subject": "Terminate my membership",
+        "email_body": "",
+        "domains": ["nudiejeans.com"]
+    },
+    {
         "name": "Nulled",
         "url": "https://www.nulled.to/topic/1418075-delete-account/",
         "difficulty": "impossible",


### PR DESCRIPTION
Resolves #3091

- Changed the difficulty written in the issue from **easy** to **hard**, since the issue states the process requires sending an e-mail
- Set the URL to `https://www.nudiejeans.com/co`, which was included in the issue. ~~Should be changed if a better resource exists~~ It includes info on account deletion as detailed in [this comment](https://github.com/jdm-contrib/jdm/issues/3091#issuecomment-5549839993)
   - Info on account deletion is present in [their privacy policy PDF](https://a.storyblok.com/f/329889/x/015901134c/privacy-policy-nudie-jeans-marketing-january-2026.pdf)
   - No info on account deletion is present in [their help center](https://www.nudiejeans.com/en-US/help-center)
- E-mail body left empty as stated in the issue