### PR TITLE
Add Croma as hard/impossible

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -4664,6 +4664,12 @@
         "domains": ["crevado.com"]
     },
     {
+        "name": "Croma",
+        "url": "https://www.croma.com/helpAndSupport",
+        "difficulty": "hard",
+        "domains": ["croma.com"]
+    },
+    {
         "name": "Cronometer",
         "url": "https://support.cronometer.com/hc/en-us/articles/360018760151-Account-Settings#h_440005960211545174984655",
         "difficulty": "easy",


### PR DESCRIPTION
Resolves #3080

Awaiting customer support response confirming account deletion (max. 30 days). In any case in which the account is not deleted, the difficulty should be changed to **impossible**. Until then, this PR is set to draft.