### PR TITLE
Add Nextbike Germany as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -14802,6 +14802,16 @@
         ]
     },
     {
+        "name": "Nextbike Germany",
+        "url": "https://www.nextbike.de/en/faq",
+        "url_de": "https://www.nextbike.de/de/faq",
+        "difficulty": "hard",
+        "notes": "Send an e-mail via the link below. After sending your account deletion request, you might never receive an answer, just check back a few days later if you still have access to the account.",
+        "email": "kundenservice@nextbike.de",
+        "email_body": "Please delete my account and all related personal data, my phone number is XXXXXX",
+        "domains": ["nextbike.de"]
+    },
+    {
         "name": "NextDNS",
         "url": "https://my.nextdns.io/account",
         "difficulty": "easy",


### PR DESCRIPTION
Resolves #3105

There is no link to an account deletion page/contact form/support article on account deletion. Closest thing I put in the URLs is their FAQ pages but they do not have info on account deletion at all

There are generic "right to erasure" sections in their privacy policies, but since they're very long PDFs and not a simple web page, I think putting them in the URL would confuse the users