### PR TITLE
Remove redundant email body from Ableton

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -263,7 +263,6 @@
         "url": "https://www.ableton.com/en/contact-us/",
         "difficulty": "hard",
         "email": "contact@support.ableton.com",
-        "email_body": "Please delete my account, my username is XXXXXX",
         "domains": ["ableton.com"]
     },
     {


### PR DESCRIPTION
E-mail body is identical to default value, and therefore redundant