### PR TITLE
Markdownify default notes

### DIFF
--- a/_includes/body.html
+++ b/_includes/body.html
@@ -49,11 +49,11 @@
                         {% elsif entry.notes %}
                             {{ entry.notes | markdownify }}
                         {% elsif entry.email %}
-                            {{ site.data.trans[page.lang].defaultnote_email }}
+                            {{ site.data.trans[page.lang].defaultnote_email | markdownify }}
                         {% elsif entry.difficulty == 'hard' %}
-                            {{ site.data.trans[page.lang].defaultnote_hard }}
+                            {{ site.data.trans[page.lang].defaultnote_hard | markdownify }}
                         {% elsif entry.difficulty == 'easy' %}
-                            {{ site.data.trans[page.lang].defaultnote_easy }}
+                            {{ site.data.trans[page.lang].defaultnote_easy | markdownify }}
                         {% endif %}
                         {% if entry.email %}
                             <a class="email-info" href="mailto:{{ entry.email }}?Subject={% if entry.email_subject %}{{ entry.email_subject | replace: ' ', '%20' }}{% else %}Account%20Deletion%20Request{% endif %}&body={% if entry.email_body %}{{ entry.email_body | replace: ' ', '%20' }}{% else %}Please%20delete%20my%20account,%20my%20username%20is%20XXXXXX{% endif %}">{{ site.data.trans[page.lang].sendmail }} &raquo;</a>


### PR DESCRIPTION
This standardizes the default notes and puts them inside a paragraph element. On entries with an email, an entry with default notes will now have a line break before the Send email link, just like those with notes.

Note that this is my first time ever touching Ruby and Jekyll. I have experience in web development, but not in this tech stack. Nonetheless the process seemed pretty straightforward.

I made sure to build and run locally with `bundle exec jekyll serve`, and I included the difference of the generated HTML documents and screenshots of how it appears in a Chromium browser. I also made sure to run the `check_files_formatting.sh` script. Feel free to tell me if I missed something or correct any mistakes.

## Diff of the before and after generated `_site/en.html`
```diff
                    <details class="tooltip-content">
                        
-                            Send an email to the provided address and request account deletion.
+                            <p>Send an email to the provided address and request account deletion.</p>
+
                        
                        
                            <a class="email-info" href="mailto:support@adfoc.us?Subject=Account%20Deletion%20Request&body=Please%20delete%20my%20AdFoc.us%20account%20registered%20under%20this%20email%20address.">Send email &raquo;</a>
                        
                        <summary class="tooltip-toggle contains-info">
                            <span class="show-info">show info...</span>
                            <span class="hide-info">hide info...</span>
                        </summary>
                    </details>
```

## Entry with visible difference -- Adfoc.us

### Before
<img width="1920" height="1080" alt="adfoc.us before markdownify (visible difference)" src="https://github.com/user-attachments/assets/fd6db5b4-2f56-4068-b5a1-6f8f3734be44" />

### After
<img width="1920" height="1080" alt="adfoc.us after markdownify (visible difference)" src="https://github.com/user-attachments/assets/b873b798-5b17-4a05-8127-a2d4d6a5e962" />

## Entry without visible difference -- Activision (has its own notes so it always markdownifies)

### Before
<img width="1920" height="1080" alt="activision entry before markdownify (no difference)" src="https://github.com/user-attachments/assets/ec7b3625-ecd9-41c0-92d7-3840256b2eda" />

### After
<img width="1920" height="1080" alt="activision entry after markdownify (no difference)" src="https://github.com/user-attachments/assets/f36a382b-237f-4a75-b4ea-14f9704cad8d" />
