### PR TITLE
Add Nitro Type as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -14924,6 +14924,14 @@
         ]
     },
     {
+        "name": "Nitro Type",
+        "url": "https://www.nitrotype.com/support",
+        "difficulty": "hard",
+        "email": "support@nitrotype.com",
+        "email_body": "Please delete my account, my username is XXXXXX and my e-mail is XXXXXX",
+        "domains": ["nitrotype.com"]
+    },
+    {
         "name": "Nitrous Networks",
         "url": "https://nitrous-networks.com/support/article/44/how-to-cancel-your-server",
         "difficulty": "hard",


### PR DESCRIPTION
Resolves #3110

The form in the linked URL states that the submission will be ignored if it is not related to account recovery. Therefore I only included the e-mail fields. I kept it as the URL since it shows their support e-mail address.