### PR TITLE
Add TETR.IO as medium

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -21197,7 +21197,7 @@
         "name": "TETR.IO",
         "url": "https://tetr.io",
         "difficulty": "medium",
-        "notes": "From the home page, go to Config ⮕ Account ⮕ Scroll to bottom ⮕ Delete my Account ⮕ Confirm the next **two** dialogs, type your username in the third and your password in the fourth to receive a confirmation e-mail. Open the link in the e-mail message. In the newly opened tab, confirm the next three dialogs, and wait 10 seconds. Note: accounts without a registered e-mail address cannot be deleted.",
+        "notes": "From the home page, go to Config ⮕ Account ⮕ Scroll to bottom ⮕ Delete my Account ⮕ Confirm the next **two** dialogs, type your username in the third and your password in the fourth to receive a confirmation e-mail. Open the link in the e-mail message. In the newly opened tab, confirm the next **three** dialogs, and wait 10 seconds. Note: accounts without a registered e-mail address cannot be deleted.",
         "domains": [
             "tetr.io",
             "ch.tetr.io",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -21194,6 +21194,17 @@
         ]
     },
     {
+        "name": "TETR.IO",
+        "url": "https://tetr.io",
+        "difficulty": "medium",
+        "notes": "From the home page, go to Config ⮕ Account ⮕ Scroll to bottom ⮕ Delete my Account ⮕ Confirm the next **two** dialogs, type your username in the third and your password in the fourth to receive a confirmation e-mail. Open the link in the e-mail message. In the newly opened tab, confirm the next three dialogs, and wait 10 seconds. Note: accounts without a registered e-mail address cannot be deleted.",
+        "domains": [
+            "tetr.io",
+            "ch.tetr.io",
+            "merch.tetr.io"
+        ]
+    },
+    {
         "name": "Teuxdeux",
         "url": "https://teuxdeux.com/account/request-delete",
         "difficulty": "easy",


### PR DESCRIPTION
Add as medium due to the account requiring being registered with e-mail address, and due to the obviously lengthy yet straightforward process. This PR includes a demo video using a dummy account.

## Account deletion demo video
<img width="800" height="450" alt="TETRIO account deletion demo" src="https://github.com/user-attachments/assets/d5deac41-38f4-4d62-a56f-7f5122d49acd" />

## Aftermath not shown in video clip
<img width="1920" height="1040" alt="TETRIO account deletion aftermath" src="https://github.com/user-attachments/assets/3045da2f-2fff-435d-afd3-3681ef02ebcb" />
