### PR TITLE
Add Devographics (State of JS) as impossible

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -5218,6 +5218,22 @@
         "domains": ["devitjobs.com"]
     },
     {
+        "name": "Devographics (State of JS)",
+        "url": "https://survey.devographics.com/en-US/account/profile",
+        "difficulty": "hard",
+        "email": "hello@stateofjs.com",
+        "domains": [
+            "survey.devographics.com",
+            "devographics.com",
+            "stateofjs.com",
+            "stateofcss.com",
+            "stateofhtml.com",
+            "stateofreact.com",
+            "stateofai.com",
+            "stateofdevs.com"
+        ]
+    },
+    {
         "name": "Devpost",
         "url": "https://devpost.com/settings/delete_account",
         "difficulty": "easy",


### PR DESCRIPTION
Instructions for deletion are in the linked URL and simply tell you to e-mail them if you'd like to delete your data. However, I have yet to receive a response from them, so I updated the difficulty to impossible.