### PR TITLE
Add Veii as easy

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -22687,6 +22687,15 @@
         "domains": ["veduca.org"]
     },
     {
+        "name": "Veii",
+        "url": "https://veii.ai/data-deletion",
+        "difficulty": "easy",
+        "notes": "Sign in, open Settings and choose to delete your account. People who never signed up but appear in a workspace's prospecting data can use the removal form on the same page, without an account.",
+        "notes_es": "Inicia sesión, abre Configuración y elige eliminar tu cuenta. Quien nunca se registró pero aparece en los datos de prospección de un espacio de trabajo puede usar el formulario de eliminación de la misma página, sin cuenta.",
+        "notes_it": "Accedi, apri Impostazioni e scegli di eliminare l'account. Chi non si è mai registrato ma compare nei dati di prospecting di un workspace può usare il modulo di rimozione sulla stessa pagina, senza account.",
+        "domains": ["veii.ai"]
+    },
+    {
         "name": "Velo Hero",
         "url": "https://app.velohero.com/settings/terminate",
         "difficulty": "easy",


### PR DESCRIPTION
Adds [Veii](https://veii.ai), a workspace platform with an AI-agent prospecting tool.

- `url`: https://veii.ai/data-deletion — the public deletion page. Users delete their account from Settings; the same page carries a removal form for people who never signed up but appear in a workspace's prospecting data, and it works without an account or JavaScript.
- `difficulty`: easy
- `notes` in English, with `notes_es` and `notes_it`.
- `domains`: veii.ai

Placed alphabetically between Veduca and Velo Hero. `sites.json` parses as valid JSON; I could not run `validate_json.rb` locally (the system Ruby 2.6 nokogiri crashes on upstream master as well), so relying on CI for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)